### PR TITLE
ASN.1 addresses simplified

### DIFF
--- a/metautils/lib/description.asn
+++ b/metautils/lib/description.asn
@@ -31,7 +31,7 @@ BEGIN
 			ipv4 OCTET STRING(SIZE(4)),
 			ipv6 OCTET STRING(SIZE(16))
 		},
-		port INTEGER OPTIONAL
+		port INTEGER
 	}
 
 	AddrInfoSequence ::= SEQUENCE OF AddrInfo

--- a/metautils/lib/metatypes.h
+++ b/metautils/lib/metatypes.h
@@ -148,10 +148,9 @@ union ip_addr_u
  */
 typedef struct addr_info_s
 {
-	enum id_addr_type_e type;	/**< The network address type */
-	union ip_addr_u addr;		/**< The network address bin */
-	guint16 port;			/**< The network port */
-	guint16 protocol;		/**< The network protocol */
+	union ip_addr_u addr; /**< The network address bin */
+	guint16 port; /**< The network port */
+	enum id_addr_type_e type : 8; /**< The network address type */
 } addr_info_t;
 
 /**

--- a/metautils/lib/test_addr.c
+++ b/metautils/lib/test_addr.c
@@ -25,11 +25,37 @@ License along with this library.
 #include <string.h>
 #include <stdio.h>
 
-#include "metautils_loggers.h"
-#include "metautils_resolv.h"
-#include "metautils_bits.h"
-#include "common_main.h"
+#include "metautils.h"
 #include "test_addr.h"
+
+static void
+test_codec (void)
+{
+	gint rc;
+	struct addr_info_s addr;
+	const char *original = "127.0.0.1:6000";
+	char resolved[128];
+	rc = l4_address_init_with_url (&addr, original, NULL);
+	g_assert (BOOL(rc));
+
+	GSList *singleton = g_slist_prepend (NULL, &addr);
+	GByteArray *gba = addr_info_marshall_gba (singleton, NULL);
+	g_assert (gba != NULL);
+	GSList *decoded = NULL;
+	gsize len = gba->len;
+	rc = addr_info_unmarshall (&decoded, gba->data, &len, NULL);
+	g_assert (BOOL(rc));
+	g_assert (decoded != NULL);
+
+	for (GSList *l=decoded; l ;l=l->next) {
+		grid_addrinfo_to_string (l->data, resolved, sizeof(resolved));
+		g_print("> %s\n", resolved);
+	}
+
+	g_slist_free_full (decoded, addr_info_clean);
+	g_slist_free (singleton);
+	g_byte_array_free (gba, TRUE);
+}
 
 static void
 test_bad_connect_address(void)
@@ -57,10 +83,9 @@ int
 main(int argc, char **argv)
 {
 	HC_TEST_INIT(argc,argv);
-	g_test_add_func("/metautils/addr/bad_connect",
-			test_bad_connect_address);
-	g_test_add_func("/metautils/gridd_client/good_address",
-			test_good_connect_address);
+	g_test_add_func("/metautils/addr/codec", test_codec);
+	g_test_add_func("/metautils/addr/bad_connect", test_bad_connect_address);
+	g_test_add_func("/metautils/gridd_client/good_address", test_good_connect_address);
 	return g_test_run();
 }
 

--- a/metautils/lib/utils_resolv.c
+++ b/metautils/lib/utils_resolv.c
@@ -166,7 +166,6 @@ grid_string_to_addrinfo(const gchar *start, const gchar *end, struct addr_info_s
 		return 0;
 	}
 	a->port = g_htons(u16port);
-	a->protocol = 0;
 
 	// And now, parse the address
 	if (addr[0] == '[') {


### PR DESCRIPTION
In addition, we got rid of a legacy of the redcurrant's early days, where ports were encoded on 4 bytes integers.