### PR TITLE
adds "oio" prefix to "event-agent" binary

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,6 @@
+if (NOT DEFINED EXE_PREFIX)
+	set(EXE_PREFIX "oio")
+endif ()
 
 set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in")
 set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")


### PR DESCRIPTION
Hello everyone :smiley: 

I had some errors about "oio-event-agent" not being found. It seems it was related to a missing binary prefix. This commit seems to fix it.

Feel free to ask any questions :)

Best regards,
Conrad