### PR TITLE
adds support for apache2 binary path on debian

### DIFF
--- a/rawx-apache2/src/tests/test_rawx.py
+++ b/rawx-apache2/src/tests/test_rawx.py
@@ -14,7 +14,7 @@ import io
 import binascii
 import re
 
-httpd_binary = '/usr/sbin/httpd'
+httpd_binary = '/usr/sbin/httpd' if os.path.exists('/usr/sbin/httpd') else '/usr/sbin/apache2'
 namespace = 'DEVREMI'
 rawx_module = '/home/fr19895/src/autotools/rawx-apache2/src/.libs/mod_dav_rawx.so'
 rawx_url = ("127.0.0.1", "65535")

--- a/tools/sds-bootstrap.py
+++ b/tools/sds-bootstrap.py
@@ -407,7 +407,7 @@ env.LD_LIBRARY_PATH=${HOME}/.local/lib:${LIBDIR}
 template_gridinit_rawx = """
 [Service.${NS}-${SRVTYPE}-${SRVNUM}]
 group=${NS},localhost,${SRVTYPE}
-command=${EXE_PREFIX}-svc-monitor -s SDS,${NS},${SRVTYPE},${SRVNUM} -p 1 -m '${EXE_PREFIX}-rawx-monitor.py' -i '${NS}|${SRVTYPE}|${IP}:${PORT}' -c '/usr/sbin/httpd -D FOREGROUND -f ${CFGDIR}/${NS}-${SRVTYPE}-httpd-${SRVNUM}.conf'
+command=${EXE_PREFIX}-svc-monitor -s SDS,${NS},${SRVTYPE},${SRVNUM} -p 1 -m '${EXE_PREFIX}-rawx-monitor.py' -i '${NS}|${SRVTYPE}|${IP}:${PORT}' -c '${HTTPD_BINARY} -D FOREGROUND -f ${CFGDIR}/${NS}-${SRVTYPE}-httpd-${SRVNUM}.conf'
 enabled=true
 start_at_boot=false
 on_die=respawn
@@ -452,6 +452,7 @@ CODEDIR = '@CMAKE_INSTALL_PREFIX@'
 LIBDIR = CODEDIR + '/@LD_LIBDIR@'
 PATH = HOME+"/.local/bin:@CMAKE_INSTALL_PREFIX@/bin"
 port = 6000
+HTTPD_BINARY = '/usr/sbin/httpd' if os.path.exists('/usr/sbin/httpd') else '/usr/sbin/apache2'
 
 def mkdir_noerror (d):
 	try:
@@ -520,7 +521,8 @@ def generate (ns, ip, options={}):
 			UID=str(os.geteuid()), GID=str(os.getgid()), USER=str(pwd.getpwuid(os.getuid()).pw_name),
 			VERSIONING=versioning, STGPOL=stgpol,
 			M2_REPLICAS=meta2_replicas, M2_DISTANCE=str(1),
-			SQLX_REPLICAS=sqlx_replicas, SQLX_DISTANCE=str(1))
+			SQLX_REPLICAS=sqlx_replicas, SQLX_DISTANCE=str(1),
+			HTTPD_BINARY=HTTPD_BINARY)
 	if options.NO_ZOOKEEPER is not None:
 		env['NOZK'] = '#'
 	else:


### PR DESCRIPTION
Hello everyone,

On Debian, the path to the Apache2 binary is not `/usr/sbin/httpd` but `/usr/sbin/apache2`. This caused errors in `syslog` for me on Ubuntu (which is Debian based).

Is there any other weird behaviour I should have noticed ? All I saw were errors in syslog, but I couldn't verify what was actually wrong. What is Apache used for ?

Also, are there any tests I can run before committing and making pull requests ? I'm not sure what the process is for testing.

Best regards,
Conrad