### PR TITLE
m1v2: now able to replace all the properties on a reference with a new set.

### DIFF
--- a/client/c/lib/hc_directory.c
+++ b/client/c/lib/hc_directory.c
@@ -239,7 +239,7 @@ hc_set_reference_property(gs_grid_storage_t *hc, const char *reference,
 		char *pairs[] = {NULL,NULL};
 		GError *e = NULL;
 		pairs[0] = g_strdup_printf("%s=%s", key, value);
-		gint rc = meta1v2_remote_reference_set_property(a, &e, url, pairs);
+		gint rc = meta1v2_remote_reference_set_property(a, &e, url, pairs, FALSE);
 		g_free(pairs[0]);
 		(void) rc;
 		return e;

--- a/meta1v2/meta1_backend.h
+++ b/meta1v2/meta1_backend.h
@@ -143,7 +143,7 @@ GError* meta1_backend_services_set(struct meta1_backend_s *m1,
 
 
 GError* meta1_backend_set_container_properties(struct meta1_backend_s *m1,
-		struct hc_url_s *url, gchar **props);
+		struct hc_url_s *url, gchar **props, gboolean flush);
 
 GError* meta1_backend_del_container_properties(struct meta1_backend_s *m1,
 		struct hc_url_s *url, gchar **names);

--- a/meta1v2/meta1_gridd_dispatcher.c
+++ b/meta1v2/meta1_gridd_dispatcher.c
@@ -533,12 +533,14 @@ meta1_dispatch_v2_PROPSET(struct gridd_reply_ctx_s *reply,
 	GError *err;
 	gchar **strv = NULL;
 	struct hc_url_s *url = metautils_message_extract_url (reply->request);
+	gboolean flush = metautils_message_extract_flag(reply->request,
+			NAME_MSGKEY_FLUSH, FALSE);
 	reply->subject("%s|%s", hc_url_get(url, HCURL_WHOLE), hc_url_get(url, HCURL_HEXID));
 	(void) ignored;
 
 	if (NULL != (err = metautils_message_extract_body_strv(reply->request, &strv)))
 		reply->send_error(CODE_BAD_REQUEST, err);
-	else if (NULL != (err = meta1_backend_set_container_properties(m1, url, strv)))
+	else if (NULL != (err = meta1_backend_set_container_properties(m1, url, strv, flush)))
 		reply->send_error(0, err);
 	else
 		reply->send_reply(CODE_FINAL_OK, "OK");

--- a/meta1v2/meta1_remote.c
+++ b/meta1v2/meta1_remote.c
@@ -350,13 +350,15 @@ meta1v2_remote_configure_reference_service(const addr_info_t *meta1, GError **er
 
 gboolean
 meta1v2_remote_reference_set_property(const addr_info_t *m1, GError **err,
-		struct hc_url_s *url, gchar **pairs)
+		struct hc_url_s *url, gchar **pairs, gboolean flush)
 {
 	EXTRA_ASSERT(m1 != NULL);
 	EXTRA_ASSERT(url != NULL);
 
 	MESSAGE req = metautils_message_create_named(NAME_MSGNAME_M1V2_PROPSET);
 	metautils_message_add_url (req, url);
+	if (flush)
+		metautils_message_add_field_str (req, NAME_MSGKEY_FLUSH, "1");
 	metautils_message_add_body_unref (req, metautils_encode_lines(pairs));
 
 	return oneway_request(m1, err, message_marshall_gba_and_clean(req));

--- a/meta1v2/meta1_remote.h
+++ b/meta1v2/meta1_remote.h
@@ -92,7 +92,7 @@ gboolean meta1v2_remote_reference_get_property(const addr_info_t *m1,
 		GError **err, struct hc_url_s *url, gchar **keys, gchar ***result);
 
 gboolean meta1v2_remote_reference_set_property(const addr_info_t *m1,
-		GError **err, struct hc_url_s *url, gchar **pairs);
+		GError **err, struct hc_url_s *url, gchar **pairs, gboolean flush);
 
 gboolean meta1v2_remote_reference_del_property(const addr_info_t *m1,
 		GError **err, struct hc_url_s *url,

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -29,8 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <meta0v2/meta0_remote.h>
 #include <meta0v2/meta0_utils.h>
 
-#include <meta1v2/meta1_remote.h>
-
 #include <meta2v2/generic.h>
 #include <meta2v2/autogen.h>
 #include <meta2v2/meta2_remote.h>

--- a/meta2v2/meta2_gridd_dispatcher.h
+++ b/meta2v2/meta2_gridd_dispatcher.h
@@ -22,20 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 struct gridd_request_descr_s;
 
-/**
- * The easiest way to retrieve the set of exported function out of
- * the META2 backend.
- *
- * All these functions take a meta1_backend_s as first argument.
- */
 const struct gridd_request_descr_s* meta2_gridd_get_v1_requests(void);
 
-/**
- * The easiest way to retrieve the set of exported function out of
- * the META2 backend.
- *
- * All these functions take a meta1_backend_s as first argument.
- */
 const struct gridd_request_descr_s* meta2_gridd_get_v2_requests(void);
 
 #endif /*OIO_SDS__meta2v2__meta2_gridd_dispatcher_h*/

--- a/proxy/dir_actions.c
+++ b/proxy/dir_actions.c
@@ -511,6 +511,7 @@ action_dir_prop_set (struct req_args_s *args, struct json_object *jargs)
 {
 	GError *err = NULL;
 	gchar **pairs = NULL;
+	gboolean flush = NULL != OPT("flush");
 
 	// Parse the <string>:<string> mapping.
 	GPtrArray *v = g_ptr_array_new ();
@@ -541,7 +542,7 @@ action_dir_prop_set (struct req_args_s *args, struct json_object *jargs)
 		if (!grid_string_to_addrinfo (m1, NULL, &m1a))
 			return NEWERROR (CODE_NETWORK_ERROR, "Invalid M1 address");
 		GError *e = NULL;
-		meta1v2_remote_reference_set_property (&m1a, &e, args->url, pairs);
+		meta1v2_remote_reference_set_property (&m1a, &e, args->url, pairs, flush);
 		return e;
 	}
 


### PR DESCRIPTION
This is consistent with meta2 and sqlx : set + flush.
Flushing and setting an empty array give the same result as calling a delete.