### PR TITLE
proxy: fixed container's autocreation

### DIFF
--- a/metautils/lib/metautils_errors.h
+++ b/metautils/lib/metautils_errors.h
@@ -56,6 +56,7 @@ License along with this library.
 #define CODE_IS_REDIRECT(C) (((C) > CODE_BEACON_REDIRECT) && ((C) < CODE_BEACON_ERROR))
 
 #define CODE_IS_NOTFOUND(C) ((C)==CODE_CONTAINER_NOTFOUND \
+		|| (C)==CODE_SRV_NOLINK \
 		|| (C)==CODE_USER_NOTFOUND \
 		|| (C)==CODE_ACCOUNT_NOTFOUND \
 		|| (C)==CODE_CONTENT_NOTFOUND)

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -841,7 +841,7 @@ _m2_container_create (struct req_args_s *args)
 	GError *err;
 retry:
 	err = _resolve_service_and_do (NAME_SRVTYPE_META2, 0, args->url, hook_m2);
-	if (err && err->code == CODE_USER_NOTFOUND) {
+	if (err && CODE_IS_NOTFOUND(err->code)) {
 		if (autocreate) {
 			autocreate = FALSE; /* autocreate just once */
 			g_clear_error (&err);


### PR DESCRIPTION
The case of a "user created but no service linked" was not managed.