### PR TITLE
Fixes on 0.8.1

### DIFF
--- a/meta2v2/generic.h
+++ b/meta2v2/generic.h
@@ -128,6 +128,8 @@ GError* _db_count_bean(const struct bean_descriptor_s *descr,
 GError* _db_get_FK_by_name(gpointer bean, const gchar *name,
 		sqlite3 *db, on_bean_f cb, gpointer u);
 
+GError* _db_del_FK_by_name(gpointer bean, const gchar *name, sqlite3 *db);
+
 GError* _db_count_FK_by_name(gpointer bean, const gchar *name,
 		sqlite3 *db, gint64 *pcount);
 

--- a/meta2v2/m2gen.py
+++ b/meta2v2/m2gen.py
@@ -450,7 +450,7 @@ properties = generator.add_bean(Struct("properties") \
 	.field(Text("key")) \
 	.field(Blob("value")) \
 	.PK(("alias","alias_version","key")) \
-	.index('properties_index_by_header', ['alias']) \
+	.index('properties_index_by_header_version', ['alias', 'alias_version']) \
 	.set_sql_name("properties_v2")).set_order(5)
 
 contents = generator.add_bean(Struct("contents") \

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -507,6 +507,10 @@ _create_container_init_phase(struct sqlx_sqlite3_s *sq3,
 		m2db_set_ctime (sq3, time(0));
 		sqlx_admin_init_i64(sq3, META2_INIT_FLAG, 1);
 	}
+	if (!err && params->properties) {
+		for (gchar **p=params->properties; *p && *(p+1) ;p+=2)
+			sqlx_admin_set_str (sq3, *p, *(p+1));
+	}
 	if (!params->local)
 		err = sqlx_transaction_end(repctx, err);
 	return err;

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -63,6 +63,8 @@ meta2_filter_action_create_container(struct gridd_filter_ctx_s *ctx,
 		g_ptr_array_add (tmp, metautils_message_extract_string_copy (reply->request, *p));
 	}
 	params.properties = (gchar**) metautils_gpa_to_array (tmp, TRUE);
+	g_strfreev (headers);
+	headers = NULL;
 
 retry:
 	err = meta2_backend_create_container(m2b, url, &params);

--- a/metautils/lib/metautils_strings.h
+++ b/metautils/lib/metautils_strings.h
@@ -92,6 +92,8 @@ void g_free1(gpointer p1, gpointer p2);
 /** Frees the second argument and ignores the first */
 void g_free2(gpointer p1, gpointer p2);
 
+gboolean metautils_str_has_caseprefix (const char *str, const char *prefix);
+
 static inline const gchar *
 none(const gchar *src)
 {

--- a/metautils/lib/test_str.c
+++ b/metautils/lib/test_str.c
@@ -138,6 +138,22 @@ test_hex2bin(void)
 	g_assert(CHECK("\x01\x10","0110"));
 }
 
+static void
+test_prefix (void)
+{
+	g_assert (metautils_str_has_caseprefix ("X", "X"));
+	g_assert (metautils_str_has_caseprefix ("X", "x"));
+	g_assert (metautils_str_has_caseprefix ("Xa", "X"));
+	g_assert (metautils_str_has_caseprefix ("Xa", "x"));
+
+	g_assert (!metautils_str_has_caseprefix ("X", "Y"));
+	g_assert (!metautils_str_has_caseprefix ("X", "y"));
+	g_assert (!metautils_str_has_caseprefix ("Xa", "Y"));
+	g_assert (!metautils_str_has_caseprefix ("Xa", "y"));
+
+	g_assert (!metautils_str_has_caseprefix ("X", "Xa"));
+}
+
 int
 main(int argc, char **argv)
 {
@@ -151,6 +167,7 @@ main(int argc, char **argv)
 	g_test_add_func("/metautils/str/ishexa", test_ishexa);
 	g_test_add_func("/metautils/str/strlen", test_strlen_len);
 	g_test_add_func("/metautils/str/hex2bin", test_hex2bin);
+	g_test_add_func("/metautils/str/prefix", test_prefix);
 	return g_test_run();
 }
 

--- a/metautils/lib/utils_strings.c
+++ b/metautils/lib/utils_strings.c
@@ -196,3 +196,14 @@ metautils_cfg_get_bool(const gchar *value, gboolean def)
 	return def;
 }
 
+gboolean
+metautils_str_has_caseprefix (const char *str, const char *prefix)
+{
+	const char *s = str, *p = prefix;
+	for (; *s && *p ;++s,++p) {
+		if (g_ascii_tolower (*s) != g_ascii_tolower (*p))
+			return FALSE;
+	}
+	return !*p;
+}
+

--- a/proxy/.functests
+++ b/proxy/.functests
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-SRC_DIR=$(python -c "import os; print os.path.dirname(os.path.realpath('$0'))")
-
-cd $SRC_DIR/tests/functional
-nosetests --exe $@
-rvalue=$?
-cd -
-exit $rvalue

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -53,14 +53,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define OPT(N)    _req_get_option(args,(N))
 #define TOK(N)    _req_get_token(args,(N))
-#define CID()     TOK("CID") ?: OPT("cid")
+#define CID()     (TOK("CID") ?: OPT("cid"))
 #define NS()      TOK("NS")
-#define ACCOUNT() TOK("ACCOUNT") ?: OPT("acct")
-#define POOL()    TOK("POOL") ?: OPT("pool")
+#define ACCOUNT() (TOK("ACCOUNT") ?: OPT("acct"))
+#define POOL()    (TOK("POOL") ?: OPT("pool"))
 #define TYPE()    (TOK("TYPE") ?: OPT("type"))
-#define REF()     TOK("REF") ?: OPT("ref")
-#define PATH()    TOK("PATH") ?: OPT("path")
-#define SEQ()     TOK("SEQ") ?: OPT("seq")
+#define REF()     (TOK("REF") ?: OPT("ref"))
+#define PATH()    (TOK("PATH") ?: OPT("path"))
+#define SEQ()     (TOK("SEQ") ?: OPT("seq"))
 #define VERSION() OPT("version")
 
 #define PUSH_DO(Action) do { \

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -535,7 +535,7 @@ _container_headers_to_props (struct req_args_s *args)
 		(void)u;
 		if (!metautils_str_has_caseprefix (k, PROXYD_HEADER_PREFIX "container-meta-"))
 			return FALSE;
-		k += sizeof(PROXYD_HEADER_PREFIX "content-meta-");
+		k += sizeof(PROXYD_HEADER_PREFIX "container-meta-") - 1;
 		if (g_str_has_prefix (k, "user-")) {
 			k += sizeof("user-");
 			g_ptr_array_add (tmp, g_strconcat ("user.", k, NULL));

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -303,6 +303,14 @@ _reply_simplified_beans (struct req_args_s *args, GError *err, GSList *beans, gb
 			header = l0->data;
 			continue;
 		}
+		if (&descr_struct_PROPERTIES == DESCR(l0->data)) {
+			struct bean_PROPERTIES_s *prop = l0->data;
+			gchar *k = g_strdup_printf (PROXYD_HEADER_PREFIX "content-meta-x-%s", PROPERTIES_get_key(prop)->str);
+			GByteArray *v = PROPERTIES_get_value (prop);
+			args->rp->add_header(k, g_strndup ((gchar*)v->data, v->len));
+			g_free (k);
+			continue;
+		}
 		if (&descr_struct_CHUNKS != DESCR(l0->data))
 			continue;
 		struct bean_CHUNKS_s *chunk = l0->data;
@@ -497,7 +505,7 @@ _load_simplified_content (struct req_args_s *args, struct json_object *jbody, GS
 
 		gboolean run_headers (gpointer k, gpointer v, gpointer u) {
 			(void)u;
-			if (!g_str_has_prefix((gchar*)k, PROXYD_HEADER_PREFIX "content-meta-x-"))
+			if (!metautils_str_has_caseprefix ((gchar*)k, PROXYD_HEADER_PREFIX "content-meta-x-"))
 				return FALSE;
 			const gchar *rk = ((gchar*)k) + sizeof(PROXYD_HEADER_PREFIX "content-meta-x-") - 1;
 			struct bean_PROPERTIES_s *prop = _bean_create (&descr_struct_PROPERTIES);
@@ -505,6 +513,7 @@ _load_simplified_content (struct req_args_s *args, struct json_object *jbody, GS
 			PROPERTIES_set_alias_version (prop, 0);
 			PROPERTIES_set2_key (prop, rk);
 			PROPERTIES_set2_value (prop, (guint8*)v, strlen((gchar*)v));
+			beans = g_slist_prepend (beans, prop);
 			return FALSE;
 		}
 		g_tree_foreach (args->rq->tree_headers, run_headers, NULL);
@@ -524,7 +533,7 @@ _container_headers_to_props (struct req_args_s *args)
 	GPtrArray *tmp;
 	gboolean run_headers (char *k, char *v, gpointer u) {
 		(void)u;
-		if (!g_str_has_prefix(k, PROXYD_HEADER_PREFIX "container-meta-"))
+		if (!metautils_str_has_caseprefix (k, PROXYD_HEADER_PREFIX "container-meta-"))
 			return FALSE;
 		k += sizeof(PROXYD_HEADER_PREFIX "content-meta-");
 		if (g_str_has_prefix (k, "user-")) {
@@ -1555,19 +1564,18 @@ retry:
 	}
 
 	json_object_put (jbody);
-	return _reply_beans (args, err, NULL);
+	return _reply_m2_error (args, err);
 }
 
 enum http_rc_e
 action_m2_content_delete (struct req_args_s *args)
 {
-	GSList *beans = NULL;
 	GError *hook (struct meta1_service_url_s *m2, gboolean *next) {
 		(void) next;
 		return m2v2_remote_execute_DEL (m2->host, args->url);
 	}
 	GError *err = _resolve_service_and_do (NAME_SRVTYPE_META2, 0, args->url, hook);
-	return _reply_simplified_beans (args, err, beans, TRUE);
+	return _reply_m2_error (args, err);
 }
 
 static enum http_rc_e

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -537,11 +537,11 @@ _container_headers_to_props (struct req_args_s *args)
 			return FALSE;
 		k += sizeof(PROXYD_HEADER_PREFIX "container-meta-") - 1;
 		if (g_str_has_prefix (k, "user-")) {
-			k += sizeof("user-");
+			k += sizeof("user-") - 1;
 			g_ptr_array_add (tmp, g_strconcat ("user.", k, NULL));
 			g_ptr_array_add (tmp, g_strdup (v));
 		} else if (g_str_has_prefix (k, "sys-")) {
-			k += sizeof("sys-");
+			k += sizeof("sys-") - 1;
 			g_ptr_array_add (tmp, g_strconcat ("sys.", k, NULL));
 			g_ptr_array_add (tmp, g_strdup (v));
 		}

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -596,6 +596,9 @@ sqlx_service_specific_fini(void)
 	if (SRV.zk_url)
 		oio_str_clean(&SRV.zk_url);
 
+	if (SRV.clients_pool)
+		gridd_client_pool_destroy (SRV.clients_pool);
+
 	if (SRV.lb)
 		grid_lbpool_destroy (SRV.lb);
 

--- a/tools/sds-bootstrap.py
+++ b/tools/sds-bootstrap.py
@@ -100,15 +100,6 @@ start_at_boot=false
 command=redis-server ${CFGDIR}/${NS}-redis-${SRVNUM}.conf
 """
 
-template_flask_gridinit = """
-[service.${NS}-flask]
-group=${NS},localhost,flask
-on_die=respawn
-enabled=true
-start_at_boot=false
-command=/usr/bin/gunicorn --preload -w 2 -b ${IP}:${PORT} oio.sds.admin-flask:app
-"""
-
 template_account_server_gridinit = """
 [service.${NS}-account-server]
 group=${NS},localhost,account-server
@@ -493,7 +484,6 @@ def generate (ns, ip, options={}):
 	port_cs = next_port()
 	port_agent = next_port() # for TCP connection is use by Java applications
 	port_proxy = next_port()
-	port_flask = next_port()
 	port_account = next_port()
 	port_event_agent = next_port()
 	rawx = []
@@ -606,12 +596,6 @@ def generate (ns, ip, options={}):
 		env['PORT'] = p
 		with open(CFGDIR + '/' + ns + '-rawx-httpd-' + str(n) + '.conf', 'w+') as f:
 			f.write(tpl.safe_substitute(env))
-
-	# administration flask
-	env['PORT'] = port_flask
-	with open(CFGDIR + '/' + 'gridinit.conf', 'a+') as f:
-		tpl = Template(template_flask_gridinit)
-		f.write(tpl.safe_substitute(env))
 
 	# redis
 	if options.ALLOW_REDIS is not None:


### PR DESCRIPTION
* sqlx: fixed minor one-shot memleak e895a79
* m2v2: fixed memleak when creating containers 26496c9
* m2v2: fixed memleak when purging obsolete aliases eb75f0b
* m2v2: fixed "bean leak" when purging exceeding aliases (properties not removed). 81c1f29
* m2v2: fixed "bean leak" when deleting explicit aliases (properties not removed). 81c1f29
* proxy: Fixed compile-time warnings 81c1f29
* proxy: properties returned in headers when getting objects 81c1f29
* proxy: headers matching now case-insensitive 81c1f29
* proxy: In addition, request handlers returning invariable and dummy outputs (empty lists, empty sets) now return nothing. 81c1f29
* tools: bootstrap doesn't deploy the admin flask (it is destined to disappear in the next release and is already used by no one). 81c1f29