### PR TITLE
use /usr/bin/env for python scripts shebangs

### DIFF
--- a/meta2v2/m2gen.py
+++ b/meta2v2/m2gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 index = 0
 def next_seq():

--- a/python/bin/oio-account-server
+++ b/python/bin/oio-account-server
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from optparse import OptionParser
 

--- a/python/bin/oio-blob-auditor
+++ b/python/bin/oio-blob-auditor
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from oio.blob.auditor import BlobAuditor
 from oio.common.daemon import run_daemon

--- a/python/bin/oio-blob-mover
+++ b/python/bin/oio-blob-mover
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from oio.blob.mover import BlobMover
 from oio.common.daemon import run_daemon

--- a/python/bin/oio-conscience-agent
+++ b/python/bin/oio-conscience-agent
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from oio.conscience.agent import ConscienceAgent
 from oio.common.daemon import run_daemon

--- a/python/bin/oio-event-agent
+++ b/python/bin/oio-event-agent
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from oio.sds.event.agent import EventAgent
 from oio.common.daemon import run_daemon

--- a/python/oio/account/server.py
+++ b/python/oio/account/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2015 OpenIO, original work as part of
 # OpenIO Software Defined Storage
 #

--- a/tools/account-agent.py
+++ b/tools/account-agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # account-agent.py, a script forwarding notifications to an account service
 # Copyright (C) 2015 OpenIO, original work as part of OpenIO Software Defined Storage

--- a/tools/account-monitor.py
+++ b/tools/account-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # account-monitor.py, a monitoring script for the account service
 # Copyright (C) 2015 OpenIO, original work as part of

--- a/tools/rainx-monitor.py
+++ b/tools/rainx-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # rainx-monitor.py, a monitoring script for rainx services
 # Copyright (C) 2014 Worldine, original work aside of Redcurrant

--- a/tools/rawx-monitor.py
+++ b/tools/rawx-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # rainx-monitor.py, a monitoring script for rainx services
 # Copyright (C) 2014 Worldine, original work aside of Redcurrant

--- a/tools/redis-monitor.py
+++ b/tools/redis-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # redis-monitor.py, a monitoring script for redis services
 # Copyright (C) 2014 Worldine, original work aside of Redcurrant

--- a/tools/zk-bootstrap.py
+++ b/tools/zk-bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # zk-bootstrap.py, a script initating a Zookeeper instance for OpenIO SDS.
 # Copyright (C) 2014 Worldine, original work as part of Redcurrant

--- a/tools/zk-reset.py
+++ b/tools/zk-reset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # zk-reset.py, a script resetting a Zookeeper instance for OpenIO SDS.
 # Copyright (C) 2014 Worldine, original work as part of Redcurrant


### PR DESCRIPTION
This makes it easier to work on systems with multiple versions of python installed.