### PR TITLE
proxy, sqliterepo: fixed odd behavior due to nested functions.

### DIFF
--- a/proxy/transport_http.c
+++ b/proxy/transport_http.c
@@ -278,13 +278,18 @@ http_parser_destroy(struct http_parser_s *parser)
 	g_free(parser);
 }
 
+static gint
+_cmp (gconstpointer p0, gconstpointer p1, gpointer p2)
+{
+	(void) p2;
+	g_assert (p0 != NULL);
+	g_assert (p1 != NULL);
+	return g_ascii_strcasecmp(p0, p1);
+}
+
 static struct http_request_s *
 http_request_create(struct network_client_s *client)
 {
-	gint _cmp (gconstpointer p0, gconstpointer p1, gpointer p2) {
-		(void) p2;
-		return g_ascii_strcasecmp(p0, p1);
-	}
 	struct http_request_s *req;
 	req = g_malloc0(sizeof(*req));
 	req->client = client;

--- a/sqliterepo/replication.c
+++ b/sqliterepo/replication.c
@@ -106,14 +106,11 @@ context_get_pending_table(GTree *tree, const hashstr_t *key)
 	return subtree;
 }
 
+static void _clean_value(gpointer v) { if (v) g_tree_destroy(v); }
+
 static void
 context_flush_pending(struct sqlx_repctx_s *ctx)
 {
-	void _clean_value(gpointer v) {
-		if (v)
-			g_tree_destroy(v);
-	}
-
 	if (!ctx)
 		return;
 	if (ctx->pending)


### PR DESCRIPTION
With gcc >= 5.1 and glib2 >= 2.44, a bug appeared in embedded function used outside of the original context of their declaration.