### PR TITLE
Jfs tools fixes 20150810

### DIFF
--- a/tools/sds-bootstrap.py
+++ b/tools/sds-bootstrap.py
@@ -332,7 +332,7 @@ uid=${UID}
 gid=${GID}
 working_dir=${TMPDIR}
 inherit_env=1
-env.PATH=${PATH}:${HOME}/.local/bin:${CODEDIR}/bin:/bin:/usr/bin:/usr/local/bin
+#env.PATH=${PATH}:${HOME}/.local/bin:${CODEDIR}/bin:/bin:/usr/bin:/usr/local/bin
 env.LD_LIBRARY_PATH=${HOME}/.local/@LD_LIBDIR@:${LIBDIR}
 
 #limit.core_size=-1

--- a/tools/sds-reset.sh
+++ b/tools/sds-reset.sh
@@ -100,10 +100,10 @@ nice gridinit -s OIO,gridinit -d ${SDS}/conf/gridinit.conf
 
 ZK=$(${PREFIX}-cluster --local-cfg | grep "$NS/zookeeper" ; exit 0)
 if [ -n "$ZK" ] ; then
-	#zk-reset.py "$NS"
 	opts=
 	for srvtype in ${AVOID} ; do opts="${opts} --avoid=${srvtype}" ; done
 	if [ $ZKSLOW -ne 0 ] ; then opts="${opts} --slow" ; fi
+	zk-reset.py "$NS"
 	zk-bootstrap.py $opts "$NS"
 fi
 


### PR DESCRIPTION
commit 7f4a596809be7ea48f5a84f87e88e4d2e5b87936

    tools: oio-reset.sh now cleans the META0 registrations with zk-reset.py
    This allows subsequent tests to be ran with the same ZK service.
    The META0 registrations were the only permanent nodes created by services in ZK.

commit c559491d5eaf0cfdd5334f18a0c546b37903e86c

    tools: zk-reset.py's default action is now to clean the META0 services registered.
    For the old-style complete flush, use the -a/--all CLI options.

commit 2748bdfea9d596b42c01fef0547057e9c0993823

    tools: oio-bootstrap.py doesn't force the PATH for gridinit.
    The path is inherited from the user's env.
    This is necessary for python scripts installed in an virtualenv.
