### PR TITLE
refactor functional tests config loading

### DIFF
--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -3,3 +3,4 @@ coverage
 nose
 nosehtmloutput
 mock>=1.0
+fixtures>=1.4.0

--- a/python/tests/functional/account/test_backend.py
+++ b/python/tests/functional/account/test_backend.py
@@ -1,28 +1,18 @@
-import unittest
-import json
 from time import sleep, time
-
-import os
 
 import redis
 from oio.account.backend import AccountBackend
 from oio.common.utils import Timestamp
+from tests.utils import BaseTestCase
 
 
-class TestAccountBackend(unittest.TestCase):
+class TestAccountBackend(BaseTestCase):
     def setUp(self):
-        self._load_config()
+        h, p = self.conf['redis'].split(':', 2)
+        self.redis_host, self.redis_port = h, int(p)
         self.conn = redis.Redis(host=self.redis_host, port=self.redis_port,
                                 db=3)
         self.conn.flushdb()
-
-    def _load_config(self):
-        self.test_dir = os.path.expanduser('~/.oio/sds/')
-        with open(self.test_dir + 'conf/test.conf') as f:
-            self.conf = json.load(f)
-        redis = self.conf['redis']
-        h, p = redis.split(':', 2)
-        self.redis_host, self.redis_port = h, int(p)
 
     def tearDown(self):
         self.conn.flushdb()

--- a/python/tests/functional/account/test_server.py
+++ b/python/tests/functional/account/test_server.py
@@ -1,28 +1,19 @@
-import unittest
 import json
 
-import os
-
 from oio.account.server import create_app
+from tests.utils import BaseTestCase
 
 
-class TestAccountServer(unittest.TestCase):
+class TestAccountServer(BaseTestCase):
     def setUp(self):
-        self._load_config()
+        h, p = self.conf['redis'].split(':', 2)
+        self.redis_host, self.redis_port = h, int(p)
         conf = {'redis_host': self.redis_host,
                 'redis_port': self.redis_port}
         self.account_id = 'test'
 
         self.app = create_app(conf).test_client()
         self._create_account()
-
-    def _load_config(self):
-        self.test_dir = os.path.expanduser('~/.oio/sds/')
-        with open(self.test_dir + 'conf/test.conf') as f:
-            self.conf = json.load(f)
-        redis = self.conf['redis']
-        h, p = redis.split(':', 2)
-        self.redis_host, self.redis_port = h, int(p)
 
     def _create_account(self):
         self.app.put('/v1.0/account/create',

--- a/python/tests/functional/audit/test_audit_storage.py
+++ b/python/tests/functional/audit/test_audit_storage.py
@@ -1,5 +1,4 @@
 import unittest
-import json
 import string
 import hashlib
 import random
@@ -17,13 +16,6 @@ from oio.blob.client import BlobClient
 class TestBlobAuditorFunctional(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestBlobAuditorFunctional, self).__init__(*args, **kwargs)
-        self._load_config()
-
-    def _load_config(self):
-
-        self.test_dir = os.path.expanduser('~/.oio/sds/')
-        with open(self.test_dir + 'conf/test.conf') as f:
-            self.conf = json.load(f)
         self.namespace = self.conf['namespace']
         self.account = self.conf['account']
 

--- a/python/tests/functional/container/test_container.py
+++ b/python/tests/functional/container/test_container.py
@@ -1,29 +1,19 @@
 import json
-import unittest
 import random
 import string
 import hashlib
-import os
 
 import requests
 from requests import Request
+from tests.utils import BaseTestCase
 
 
-class TestMeta2Functional(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super(TestMeta2Functional, self).__init__(*args, **kwargs)
-        self._load_config()
-
-    def _load_config(self):
-        self.test_dir = os.path.expanduser('~/.oio/sds/')
-        with open(self.test_dir + 'conf/test.conf') as f:
-            self.conf = json.load(f)
+class TestMeta2Functional(BaseTestCase):
+    def setUp(self):
+        super(TestMeta2Functional, self).setUp()
         self.namespace = self.conf['namespace']
         self.proxyd = self.conf['proxyd_uri'] + "/v2.0"
         self.account = self.conf['account']
-
-        self.session = requests.session()
-
         self.chars = (string.ascii_lowercase + string.ascii_uppercase +
                       string.digits)
 
@@ -33,13 +23,11 @@ class TestMeta2Functional(unittest.TestCase):
         self.proxyd_m2 = (self.proxyd + "/m2/" + self.namespace + '/' +
                           self.account)
 
-        self.h = hashlib.new('ripemd160')
+        self.h = hashlib.new('md5')
 
         self.id_generator = lambda n: ''.join(
             random.choice(self.chars) for _ in range(n))
-
-    def setUp(self):
-        super(TestMeta2Functional, self).setUp()
+        self.session = requests.session()
 
         self.list_paths = list()
 

--- a/python/tests/functional/reference/test_directory.py
+++ b/python/tests/functional/reference/test_directory.py
@@ -1,23 +1,17 @@
 import json
-import unittest
 import random
 import string
 import urlparse
 import time
-import os
 
 import requests
 
+from tests.utils import BaseTestCase
 
-class TestDirectoryFunctional(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super(TestDirectoryFunctional, self).__init__(*args, **kwargs)
-        self._load_config()
 
-    def _load_config(self):
-        self.test_dir = os.path.expanduser('~/.oio/sds/')
-        with open(self.test_dir + 'conf/test.conf') as f:
-            self.conf = json.load(f)
+class TestDirectoryFunctional(BaseTestCase):
+    def setUp(self):
+        super(TestDirectoryFunctional, self).setUp()
         self.namespace = self.conf['namespace']
         self.proxyd_uri = self.conf['proxyd_uri'] + "/v2.0/dir/"
         self.proxyd_uri2 = self.conf['proxyd_uri'] + "/v2.0/cs/"
@@ -28,9 +22,6 @@ class TestDirectoryFunctional(unittest.TestCase):
 
         self.chars = (string.ascii_lowercase + string.ascii_uppercase +
                       string.digits)
-
-    def setUp(self):
-        super(TestDirectoryFunctional, self).setUp()
 
         self.address = "{0}{1}/{2}".format(self.proxyd_uri, self.namespace,
                                            self.account)

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import sys
+import os
+import fixtures
+import json
+import testtools
+
+
+def get_config(defaults=None):
+    conf = {}
+    if defaults is not None:
+        conf.update(defaults)
+
+    default_conf_path = os.path.expanduser('~/.oio/sds/conf/test.conf')
+    conf_file = os.environ.get('SDS_TEST_CONFIG_FILE', default_conf_path)
+
+    try:
+        with open(conf_file, 'r') as f:
+            conf = json.load(f)
+    except SystemExit:
+        if not os.path.exists(conf_file):
+            reason = 'file not found'
+        elif not os.access(conf_file, os.R_OK):
+            reason = 'permission denied'
+        else:
+            reason = 'n/a'
+            print('Unable to read test config %s (%s)' % (conf_file, reason),
+                  file=sys.stderr)
+    return conf
+
+
+class BaseTestCase(testtools.TestCase):
+    def setUp(self):
+        super(BaseTestCase, self).setUp()
+        self.useFixture(fixtures.TempHomeDir())
+        self.conf = get_config()

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,6 +11,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = nosetests {posargs:tests/unit}
+passenv = SDS_*
 
 [testenv:cover]
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
To load config for functional tests, use the `SDS_TEST_CONFIG_FILE` env variable.