### PR TITLE
Jfs improvements 20151015

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,6 +31,9 @@ target_link_libraries(oiosds_test oiosds)
 set_target_properties(oiosds_test PROPERTIES
 		SOVERSION ${ABI_VERSION})
 
+add_executable(test_oio_ext test_ext.c)
+target_link_libraries(test_oio_ext oiocore)
+
 add_executable(test_oio_str test_str.c)
 target_link_libraries(test_oio_str oiocore)
 
@@ -58,7 +61,8 @@ install(TARGETS oiocore oiosds
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		PUBLIC_HEADER DESTINATION include)
 
-add_test(NAME metautils/url COMMAND test_oio_url)
+add_test(NAME core/ext COMMAND test_oio_ext)
+add_test(NAME core/url COMMAND test_oio_url)
 add_test(NAME core/str COMMAND test_oio_str)
 add_test(NAME core/sds COMMAND /usr/bin/env python ${CMAKE_CURRENT_SOURCE_DIR}/test_oiosds.py)
 

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -28,6 +28,15 @@ extern "C" {
 /** Shuffles the single linked list. The original <src> MUST NOT be reused. */
 GSList * oio_ext_gslist_shuffle(GSList *src);
 
+/** Shuffles <array> in place. <len> is the len of the array. <len> must be
+ * greater than 1. */
+void oio_ext_array_shuffle (gpointer *array, gsize len);
+
+/** Sorts 'src' in place, placing first the items with a FALSE predicate
+ * then the items with a TRUE predicate */
+void oio_ext_array_partition (gpointer *array, gsize len,
+		gboolean (*predicate)(gconstpointer));
+
 /** Forward declaration from the json-c. It helps us avoiding an incude. */
 struct json_object;
 

--- a/core/test_ext.c
+++ b/core/test_ext.c
@@ -1,0 +1,47 @@
+/*
+OpenIO SDS metautils
+Copyright (C) 2015 OpenIO, original work as part of OpenIO Software Defined Storage
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+#include <glib.h>
+#include "oiolog.h"
+#include "oioext.h"
+
+static void
+test_shuffle_array (void)
+{
+	void *tab[10];
+	for (int i=0; i<10 ;++i)
+		tab[i] = NULL;
+	for (long unsigned int i=0; i<8 ;i++)
+		tab[i+1] = (void*)i;
+	oio_ext_array_shuffle (tab+1, 8);
+	g_assert_null (tab[0]);
+	g_assert_null (tab[9]);
+}
+
+int
+main (int argc, char **argv)
+{
+	g_test_init (&argc, &argv, NULL);
+	oio_log_lazy_init ();
+	oio_log_init_level(GRID_LOGLVL_INFO);
+	g_log_set_default_handler(oio_log_stderr, NULL);
+
+	g_test_add_func("/core/shuffle/array", test_shuffle_array);
+	return g_test_run();
+}
+

--- a/meta1v2/meta1_prefixes.c
+++ b/meta1v2/meta1_prefixes.c
@@ -93,7 +93,8 @@ _cache_load_from_m0(struct meta1_prefixes_set_s *m1ps,
 		const gchar *ns_name,
 		const struct addr_info_s *local_addr,
 		struct addr_info_s *m0_addr,
-		GArray **updated_prefixes)
+		GArray **updated_prefixes,
+		gboolean *meta0_ok)
 {
 	GError *err = NULL;
 	GSList *m0info_list = NULL;
@@ -113,6 +114,7 @@ _cache_load_from_m0(struct meta1_prefixes_set_s *m1ps,
 		return NULL;
 	}
 
+	*meta0_ok = TRUE;
 	guint8 *cache = _cache_from_m0l(m0info_list, local_addr);
 	GPtrArray *by_prefix = meta0_utils_list_to_array(m0info_list);
 
@@ -148,10 +150,8 @@ _cache_load_from_m0(struct meta1_prefixes_set_s *m1ps,
 }
 
 static GError*
-_cache_load_from_ns(struct meta1_prefixes_set_s *m1ps,
-		const gchar *ns_name,
-		const gchar *local_url,
-		GArray **updated_prefixes)
+_cache_load_from_ns(struct meta1_prefixes_set_s *m1ps, const gchar *ns_name,
+		const gchar *local_url, GArray **updated_prefixes, gboolean *meta0_ok)
 {
 	struct addr_info_s local_ai;
 	GError *err = NULL;
@@ -193,7 +193,7 @@ _cache_load_from_ns(struct meta1_prefixes_set_s *m1ps,
 		}
 
 		err = _cache_load_from_m0(m1ps, ns_name, &local_ai,
-				&(si->addr),updated_prefixes);
+				&(si->addr), updated_prefixes, meta0_ok);
 		if (!err) {
 			done = TRUE;
 			break;
@@ -269,7 +269,7 @@ meta1_prefixes_manage_all(struct meta1_prefixes_set_s *m1ps,
 
 GError*
 meta1_prefixes_load(struct meta1_prefixes_set_s *m1ps,
-		const gchar *ns_name, const gchar *local_url, GArray **updated_prefixes)
+		const gchar *ns_name, const gchar *local_url, GArray **updated_prefixes, gboolean *meta0_ok)
 {
 	GError *err = NULL;
 
@@ -277,7 +277,7 @@ meta1_prefixes_load(struct meta1_prefixes_set_s *m1ps,
 	EXTRA_ASSERT(ns_name != NULL);
 	EXTRA_ASSERT(local_url != NULL);
 
-	err = _cache_load_from_ns(m1ps, ns_name, local_url, updated_prefixes);
+	err = _cache_load_from_ns(m1ps, ns_name, local_url, updated_prefixes, meta0_ok);
 	if (NULL != err)
 		g_prefix_error(&err, "NS loading error : ");
 	else

--- a/meta1v2/meta1_prefixes.h
+++ b/meta1v2/meta1_prefixes.h
@@ -43,7 +43,8 @@ struct meta1_prefixes_set_s* meta1_prefixes_init(void);
 GError* meta1_prefixes_load(struct meta1_prefixes_set_s *m1ps,
 		const gchar *ns_name,
 		const gchar *local_url,
-		GArray **updated_prefixes);
+		GArray **updated_prefixes,
+		gboolean *meta0_ok);
 
 /**
  * @param m1ps

--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -42,22 +42,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "./meta1_gridd_dispatcher.h"
 
 static struct meta1_backend_s *m1 = NULL;
+static volatile gboolean already_succeeded = FALSE;
 
 static GError*
 _reload_prefixes(struct sqlx_service_s *ss, gboolean init)
 {
-	GError *err;
+	gboolean meta0_ok = FALSE;
 	GArray *updated_prefixes=NULL;
-	struct meta1_prefixes_set_s *m1ps;
-
-	m1ps = meta1_backend_get_prefixes(m1);
-	err = meta1_prefixes_load(m1ps, ss->ns_name, ss->url->str, &updated_prefixes);
+	struct meta1_prefixes_set_s *m1ps = meta1_backend_get_prefixes(m1);
+	GError *err = meta1_prefixes_load(m1ps, ss->ns_name, ss->url->str,
+			&updated_prefixes, &meta0_ok);
 	if (err) {
 		g_prefix_error(&err, "Reload error: ");
 		if (updated_prefixes)
 			g_array_free(updated_prefixes, TRUE);
 		return err;
 	}
+	if (meta0_ok)
+		already_succeeded = TRUE;
 
 	if (updated_prefixes && !init) {
 		if (updated_prefixes->len)
@@ -96,6 +98,11 @@ _reload_prefixes(struct sqlx_service_s *ss, gboolean init)
 static void
 _task_reload_prefixes(gpointer p)
 {
+	static volatile guint tick_reload = 0;
+
+	if (already_succeeded && 0 != (tick_reload++ % 32))
+		return;
+
 	GError *err = _reload_prefixes(PSRV(p), FALSE);
 	if (err) {
 		GRID_WARN("Failed to reload the meta1 prefixes : (%d) %s",
@@ -218,9 +225,9 @@ _post_config(struct sqlx_service_s *ss)
 
 	grid_task_queue_register(ss->gtq_reload, 5,
 			_task_reload_policies, NULL, ss);
-	grid_task_queue_register(ss->gtq_reload, 11,
+	grid_task_queue_register(ss->gtq_reload, 1,
 			(GDestroyNotify)sqlx_task_reload_lb, NULL, ss);
-	grid_task_queue_register(ss->gtq_reload, 31,
+	grid_task_queue_register(ss->gtq_reload, 1,
 			_task_reload_prefixes, NULL, ss);
 
 	m1->notify.udata = ss;

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -186,7 +186,7 @@ _post_config(struct sqlx_service_s *ss)
 	// Register few meta2 tasks
 	grid_task_queue_register(ss->gtq_reload, 5,
 			_task_reconfigure_m2, NULL, ss);
-	grid_task_queue_register(ss->gtq_reload, 10,
+	grid_task_queue_register(ss->gtq_reload, 1,
 			(GDestroyNotify)sqlx_task_reload_lb, NULL, ss);
 
 	m2->notify.udata = ss;

--- a/metautils/lib/test_str.c
+++ b/metautils/lib/test_str.c
@@ -101,20 +101,6 @@ test_lower(void)
 }
 
 static void
-test_ishexa(void)
-{
-	// not hexa
-	g_assert(!oio_str_ishexa("g",1));
-	// wrong size
-	g_assert(!oio_str_ishexa("g",0));
-	g_assert(!oio_str_ishexa("0",0));
-	g_assert(oio_str_ishexa("0",1));
-	g_assert(oio_str_ishexa("",0));
-	// validate hexa chars
-	g_assert(oio_str_ishexa("0123456789ABCDEFabcdef",22));
-}
-
-static void
 test_strlen_len(void)
 {
 	gsize len(const gchar *s, gsize l) {
@@ -123,19 +109,6 @@ test_strlen_len(void)
 	g_assert(len("plop", strlen("plop")) == strlen("plop"));
 	for (guint i=0; i < sizeof("plopplop")+1; ++i)
 		g_assert(len("plopplop", i) == MIN(i,sizeof("plopplop")-1));
-}
-
-static void
-test_hex2bin(void)
-{
-	gboolean check(const guint8 *s, gsize slen, const gchar *t0) {
-		gsize tlen = 2 + (slen * 2);
-		gchar *t = g_malloc0(tlen);
-		oio_str_bin2hex(s, slen, t, tlen);
-		return 0 == g_strcmp0(t, t0);
-	}
-	#define CHECK(B,T) check((guint8*)(B),sizeof(B)-1,(T))
-	g_assert(CHECK("\x01\x10","0110"));
 }
 
 static void
@@ -164,9 +137,7 @@ main(int argc, char **argv)
 	g_test_add_func("/metautils/str/strlcpy_pns", test_strlcpy_pns);
 	g_test_add_func("/metautils/str/upper", test_upper);
 	g_test_add_func("/metautils/str/lower", test_lower);
-	g_test_add_func("/metautils/str/ishexa", test_ishexa);
 	g_test_add_func("/metautils/str/strlen", test_strlen_len);
-	g_test_add_func("/metautils/str/hex2bin", test_hex2bin);
 	g_test_add_func("/metautils/str/prefix", test_prefix);
 	return g_test_run();
 }


### PR DESCRIPTION
commit aa78a055f7298d3a2bdbd4250a2d1e01c6e9f09a

    Speeds up the startup of services.
    More agressive delays for:
    * LB refresh
    * prefix loading in meta1
    The period between the iterations is shortened until the first success.

commit 41f6fa1b617b2292d2f9a71d133e098b4689d7f2

    core: added features to shuffle and partition arrays.
    These will be necessary for the resolvers to manage array of targets:
    * shuffling to avoid hitting always the same target
    * partioning to prefer services with no known problems.
