### PR TITLE
Fixed several optimisations around up/down services

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -154,8 +154,11 @@ enum {
 
 typedef gint64 (*time_hook_f) (void);
 
-/* Must the service addresses be shuffled or not */
+/* Must the service addresses be shuffled or not when uploading chunks */
 extern volatile int oio_sds_no_shuffle;
+
+/* Must the service addresses be shuffled or not (out from the directory) */
+extern volatile int oio_dir_no_shuffle;
 
 /* Let/Set it to NULL for the system time.
  * Microsecond precision */

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -32,9 +32,9 @@ GSList * oio_ext_gslist_shuffle(GSList *src);
  * greater than 1. */
 void oio_ext_array_shuffle (gpointer *array, gsize len);
 
-/** Sorts 'src' in place, placing first the items with a FALSE predicate
- * then the items with a TRUE predicate */
-void oio_ext_array_partition (gpointer *array, gsize len,
+/** Sorts 'src' in place, placing first the items with a TRUE predicate
+ * then the items with a FALSE predicate */
+gsize oio_ext_array_partition (gpointer *array, gsize len,
 		gboolean (*predicate)(gconstpointer));
 
 /** Forward declaration from the json-c. It helps us avoiding an incude. */

--- a/core/sds.c
+++ b/core/sds.c
@@ -53,10 +53,6 @@ struct oio_sds_s
 struct oio_error_s;
 struct oio_url_s;
 
-volatile int oio_sds_default_autocreate = 0;
-
-volatile int oio_sds_no_shuffle = 0;
-
 static CURL *
 _curl_get_handle_proxy (struct oio_sds_s *sds)
 {

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -99,7 +99,7 @@ _get_peers(struct sqlx_service_s *ss, struct sqlx_name_s *n,
 	oio_url_set(u, OIOURL_NS, ss->ns_name);
 	if (!sqlx_name_extract (n, u, NAME_SRVTYPE_META2, &seq)) {
 		oio_url_pclean (&u);
-		return NEWERROR(CODE_BAD_REQUEST, "Invalid type name: '%s'", n->type);
+		return BADREQ("Invalid type name: '%s'", n->type);
 	}
 
 retry:

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -46,7 +46,7 @@ validate_srvtype (const char * n)
 gboolean
 service_is_ok (gconstpointer k)
 {
-	gpointer v; 
+	gpointer v;
 	SRV_DO(v = lru_tree_get (srv_down, k));
 	return v == NULL;
 }
@@ -57,7 +57,7 @@ service_invalidate (gconstpointer k)
 	gulong now = oio_ext_monotonic_time () / G_TIME_SPAN_SECOND;
 	SRV_DO(lru_tree_insert (srv_down, g_strdup((const char *)k), (void*)now));
 	GRID_INFO("invalid at %lu %s", now, (const char*)k);
-} 
+}
 
 const char *
 _req_get_option (struct req_args_s *args, const char *name)
@@ -152,7 +152,8 @@ _qualify_service_url (gconstpointer p)
 {
 	gboolean rc = FALSE;
 	gchar *u = meta1_strurl_get_address ((const char*)p);
-	if (u) rc = service_is_ok (u);
+	if (u)
+		rc = service_is_ok (u);
 	g_free (u);
 	return rc;
 }
@@ -181,7 +182,11 @@ _resolve_service_and_do (const char *t, gint64 seq, struct oio_url_s *u,
 		err = NEWERROR (CODE_CONTAINER_NOTFOUND, "No service located");
 	else {
 		/* just consider the URL part. The resolver already pre-shuffled it. */
-		oio_ext_array_partition ((void**)uv, g_strv_length(uv), _qualify_service_url);
+
+		gsize pivot = oio_ext_array_partition ((void**)uv, g_strv_length(uv),
+				_qualify_service_url);
+		if (pivot > 0 && !oio_dir_no_shuffle)
+			oio_ext_array_shuffle ((void**)uv, pivot);
 
 		for (gchar **pm2 = uv; *pm2; ++pm2) {
 			struct meta1_service_url_s *m1u = meta1_unpack_url (*pm2);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -94,6 +94,11 @@ action_status(struct req_args_s *args)
 	g_string_append_printf(gstr, "cache.srv.ttl = %lu\n", s.services.ttl);
 	g_string_append_printf(gstr, "cache.srv.clock = %lu\n", s.clock);
 
+	gint64 count_down = 0;
+	SRV_DO(count_down = lru_tree_count(srv_down));
+	g_string_append_printf(gstr, "down.srv.count = %"G_GINT64_FORMAT"\n",
+			count_down);
+
 	args->rp->set_body_gstr(gstr);
 	args->rp->set_status(HTTP_CODE_OK, "OK");
 	args->rp->set_content_type("text/x-java-properties");

--- a/tests/unit/test_ext.c
+++ b/tests/unit/test_ext.c
@@ -25,20 +25,45 @@ static void
 test_shuffle_array (void)
 {
 	void *tab[10];
-	for (int i=0; i<10 ;++i)
+	for (guint i=0; i<10 ;++i)
 		tab[i] = NULL;
-	for (long unsigned int i=0; i<8 ;i++)
-		tab[i+1] = (void*)i;
+	for (gulong i=1; i<9 ;i++)
+		tab[i] = (void*)i;
 	oio_ext_array_shuffle (tab+1, 8);
 	g_assert_null (tab[0]);
 	g_assert_null (tab[9]);
+}
+
+static void
+test_partition (void)
+{
+	gboolean _is_even (gconstpointer p) {
+		return 0 != (((gulong)p) % 2);
+	}
+
+	void *tab[8];
+	for (guint i=0; i<8 ;++i)
+		tab[i] = NULL;
+	for (gulong i=0; i<8 ;++i)
+		tab[i] = (void*)i;
+
+	/* tab = {0,1,2,3,4,5,6,7} */
+	gsize pivot = oio_ext_array_partition (tab, 8, _is_even);
+	/* tab = {1,3,5,7} :: {0,2,4,6} */
+
+	g_assert (pivot == 4);
+	for (guint i=0; i<pivot ;++i)
+		g_assert_true (_is_even (tab[i]));
+	for (guint i=pivot; i<8 ;++i)
+		g_assert_false (_is_even (tab[i]));
 }
 
 int
 main (int argc, char **argv)
 {
 	HC_TEST_INIT(argc,argv);
-	g_test_add_func("/core/shuffle/array", test_shuffle_array);
+	g_test_add_func("/core/ext/shuffle", test_shuffle_array);
+	g_test_add_func("/core/ext/partition", test_partition);
 	return g_test_run();
 }
 


### PR DESCRIPTION
There were partition/shuffle problems when looping on lists of services.
* the ok/nok qualification of services didn't work (in the resolver)
* the shuffling was potentially broken by a subsequent partition ok ok/nok services.
* both weren't called at all in several cases.

Fixes #306 