### PR TITLE
sqlx: smoother exit sequence for sqliterepo-based

### DIFF
--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -554,6 +554,8 @@ sqlx_service_specific_fini(void)
 	}
 	if (SRV.election_manager)
 		election_manager_exit_all(SRV.election_manager, 0, TRUE);
+	if (SRV.sync)
+		sqlx_sync_close(SRV.sync);
 
 	// Cleanup
 	if (SRV.gtq_admin)


### PR DESCRIPTION
Avoids calling zookeeper hooks on closed elections.