### PR TITLE
metautils: fixed 32bits timestamp

### DIFF
--- a/metautils/lib/common_main.h
+++ b/metautils/lib/common_main.h
@@ -73,7 +73,7 @@ struct grid_main_option_s {
 };
 
 /** Number of seconds since Epoch when the debug level has been updated. */
-extern time_t main_log_level_update;
+extern gint64 main_log_level_update;
 
 extern char syslog_id[64];
 


### PR DESCRIPTION
Compilation failed on 32bits platforms such RaspberryPi.