### PR TITLE
rawx: fixed attr in replies

### DIFF
--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -59,7 +59,7 @@ __set_header(request_rec *r, const char *n, const char *v)
 	if (!v) return;
 	apr_table_setn(r->headers_out, apr_pstrcat(r->pool,
 				RAWX_HEADER_PREFIX, n, NULL),
-				apr_pescape_urlencoded(r->pool, v));
+				apr_pstrdup(r->pool, v));
 }
 
 static dav_error *
@@ -454,7 +454,7 @@ request_fill_headers(request_rec *r, struct content_textinfo_s *c0,
 	__set_header(r, "container-id",  c0->container_id);
 
 	__set_header(r, "content-id",           c0->content_id);
-	__set_header(r, "content-path",         c0->path);
+	__set_header(r, "content-path",         apr_pescape_urlencoded (r->pool, c0->path));
 	__set_header(r, "content-size",         c0->size);
 	__set_header(r, "content-version",      c0->version);
 	__set_header(r, "content-chunksnb",     c0->chunk_nb);


### PR DESCRIPTION
Everything was unnecessarily encoded.