### PR TITLE
Fixes #339 (Log format oioproxy)

### DIFF
--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -229,6 +229,7 @@ handler_action (gpointer u, struct http_request_s *rq,
 			args.flags |= FLAG_NOEMPTY;
 
 		args.url = url = _metacd_load_url (&args);
+		rp->subject(oio_url_get(url, OIOURL_HEXID));
 		req_handler_f handler = path_matching_get_udata (*matchings);
 		GRID_TRACE("URL %s", oio_url_get(args.url, OIOURL_WHOLE));
 		rc = (*handler) (&args);

--- a/proxy/transport_http.h
+++ b/proxy/transport_http.h
@@ -61,6 +61,7 @@ struct http_reply_ctx_s
 	void (*set_body_gstr) (GString *gstr);
 	void (*set_body_gba) (GByteArray *gstr);
 
+	void (*subject) (const char *id);
 	void (*finalize) (void);
 	void (*access_tail) (const char *fmt, ...);
 };


### PR DESCRIPTION
To fix #339 , a field has been added before the `req_id`, and it is set to "-" when not set, and set to the `container_id` when meaningful.