### PR TITLE
common_main: std{err,out} redirected when syslog'ing, even if not daemon

### DIFF
--- a/metautils/lib/common_main.c
+++ b/metautils/lib/common_main.c
@@ -508,6 +508,11 @@ grid_main(int argc, char ** argv, struct grid_main_callbacks * callbacks)
 	}
 	grid_main_install_sighandlers();
 
+	if (flag_daemon || *syslog_id) {
+		stdout = freopen("/dev/null", "w", stdout);
+		stderr = freopen("/dev/null", "w", stderr);
+	}
+
 	if (flag_daemon) {
 		stdin = freopen("/dev/null", "r", stdin);
 		if (-1 == daemon(1,0)) {
@@ -515,8 +520,6 @@ grid_main(int argc, char ** argv, struct grid_main_callbacks * callbacks)
 			grid_main_fini();
 			return 1;
 		}
-		stdout = freopen("/dev/null", "w", stdout);
-		stderr = freopen("/dev/null", "w", stderr);
 		grid_main_write_pid_file();
 	}
 


### PR DESCRIPTION
Avoids putrefying the process with unmanaged SIGPIPE, when happening in threads not ignoring the signal.