### PR TITLE
Jfs fixes 20160125

### DIFF
--- a/cluster/lib/CMakeLists.txt
+++ b/cluster/lib/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(gridcluster SHARED
 set_target_properties(gridcluster PROPERTIES SOVERSION ${ABI_VERSION})
 
 target_link_libraries(gridcluster
-		metautils
+		metautils oiosds
 		-lm ${GLIB2_LIBRARIES})
 
 add_executable (tool_sysstat tool_sysstat.c)

--- a/cluster/lib/gridcluster.h
+++ b/cluster/lib/gridcluster.h
@@ -50,18 +50,12 @@ GError * conscience_remote_get_types (const char *cs, GSList **out);
 GError * conscience_remote_push_services (const char *cs, GSList *ls);
 GError * conscience_remote_remove_services(const char *cs, const char *type, GSList *ls);
 
-GError * conscience_agent_get_namespace (const char *cs, struct namespace_info_s **out);
-GError * conscience_agent_get_services (const char *cs, const gchar *type, GSList **out);
-GError * conscience_agent_get_types (const char *cs, GSList **out);
-GError * conscience_agent_push_services (const char *cs, GSList *ls);
-GError * conscience_agent_remove_services(const char *cs, const char *type);
-
 /* Requests the the best target (conscience, agent proxy) ------------------- */
 
 GError* conscience_get_namespace (const char *ns, struct namespace_info_s **out);
 GError* conscience_get_services (const char *ns, const char *type, GSList **out);
 GError* conscience_get_types (const char *ns, GSList **out);
-GError* conscience_push_services (const char *ns, GSList *ls);
+GError* conscience_push_service (const char *ns, struct service_info_s *si);
 GError* conscience_remove_services (const char *ns, const char *type);
 
 GError* register_namespace_service (const struct service_info_s *si);

--- a/core/cs.c
+++ b/core/cs.c
@@ -70,7 +70,7 @@ oio_cs_client__flush_services (struct oio_cs_client_s *self,
 GError *
 oio_cs_client__list_services (struct oio_cs_client_s *self,
 		const char *in_type,
-		void (*on_reg) (const struct oio_cs_registration_s *reg))
+		void (*on_reg) (const struct oio_cs_registration_s *reg, int score))
 {
 	if (!in_type || !*in_type)
 		return BADREQ("Missing srvtype");
@@ -168,7 +168,7 @@ static GError * _cs_PROXY__unlock_service (struct oio_cs_client_s *self,
 
 static GError * _cs_PROXY__list_services (struct oio_cs_client_s *self,
 		const char *in_type,
-		void (*on_reg) (const struct oio_cs_registration_s *reg));
+		void (*on_reg) (const struct oio_cs_registration_s *reg, int score));
 
 static GError * _cs_PROXY__list_types (struct oio_cs_client_s *self,
 		void (*on_type) (const char *srvtype));
@@ -287,7 +287,7 @@ _cs_PROXY__unlock_service (struct oio_cs_client_s *self,
 GError *
 _cs_PROXY__list_services (struct oio_cs_client_s *self,
 		const char *in_type,
-		void (*on_reg) (const struct oio_cs_registration_s *reg))
+		void (*on_reg) (const struct oio_cs_registration_s *reg, int score))
 {
 	g_assert (self != NULL);
 	struct oio_cs_client_PROXY_s *cs = (struct oio_cs_client_PROXY_s*) self;
@@ -321,7 +321,7 @@ _cs_PROXY__list_services (struct oio_cs_client_s *self,
 				struct oio_cs_registration_s reg = {0};
 				err = _unpack_registration (item, &reg, &score);
 				if (!err && on_reg)
-					(on_reg)(&reg);
+					(on_reg)(&reg, score);
 			}
 		}
 		if (jbody) json_object_put (jbody);

--- a/core/cs_internals.h
+++ b/core/cs_internals.h
@@ -43,7 +43,7 @@ struct oio_cs_client_vtable_s
 
 	GError * (*list_services) (struct oio_cs_client_s *self,
 			const char *in_type,
-			void (*on_reg) (const struct oio_cs_registration_s *reg));
+			void (*on_reg) (const struct oio_cs_registration_s *reg, int score));
 
 	GError * (*list_types) (struct oio_cs_client_s *self,
 			void (*on_type) (const char *srvtype));

--- a/core/oiocs.h
+++ b/core/oiocs.h
@@ -50,7 +50,7 @@ GError * oio_cs_client__unlock_service (struct oio_cs_client_s *self,
 
 GError * oio_cs_client__list_services (struct oio_cs_client_s *self,
 		const char *in_type,
-		void (*on_reg) (const struct oio_cs_registration_s *reg));
+		void (*on_reg) (const struct oio_cs_registration_s *reg, int score));
 
 GError * oio_cs_client__list_types (struct oio_cs_client_s *self,
 		void (*on_type) (const char *srvtype));

--- a/core/proxy.c
+++ b/core/proxy.c
@@ -353,6 +353,9 @@ static GError *
 _proxy_call (CURL *h, const char *method, const char *url,
 		struct http_ctx_s *in, struct http_ctx_s *out)
 {
+	if (!oio_ext_get_reqid ())
+		oio_ext_set_random_reqid();
+
 	gint64 t = g_get_monotonic_time ();
 	GError *err = _proxy_call_notime (h, method, url, in, out);
 	t = g_get_monotonic_time () - t;

--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -319,7 +319,11 @@ _client_manage_reply(struct gridd_client_s *client, MESSAGE reply)
 	}
 
 	/* all other are considered errors */
-	err = NEWERROR(status, "Request error: %s", message);
+	if (status != CODE_REDIRECT)
+		err = NEWERROR(status, "Request error: %s", message);
+	else
+		err = NEWERROR(status, "%s", message);
+
 	g_free(message);
 	if (!client->keepalive)
 		_client_reset_cnx(client);

--- a/proxy/actions.h
+++ b/proxy/actions.h
@@ -33,6 +33,8 @@ enum http_rc_e action_cache_set_max_high (struct req_args_s *args);
 
 enum http_rc_e action_lb_choose (struct req_args_s *args);
 
+enum http_rc_e action_local_list (struct req_args_s *args);
+
 enum http_rc_e action_conscience_info (struct req_args_s *args);
 enum http_rc_e action_conscience_list (struct req_args_s *args);
 enum http_rc_e action_conscience_register (struct req_args_s *args);

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -82,6 +82,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern gchar *nsname;
 extern gboolean flag_cache_enabled;
 extern gdouble m2_timeout_all;
+extern time_t nsinfo_refresh_delay;
+
+/* how long the proxy remembers the srv it registered ino the conscience */
+extern time_t cs_expire_local_services;
 
 extern struct grid_lbpool_s *lbpool;
 extern struct hc_resolver_s *resolver;
@@ -90,7 +94,10 @@ extern GMutex csurl_mutex;
 extern gchar *csurl;
 
 extern GMutex push_mutex;
+/* staging area for services being sent up. <struct service_info_s*> */
 extern struct lru_tree_s *push_queue;
+/* holder for services registered within the last 5 seconds */
+extern struct lru_tree_s *srv_registered;
 
 extern GMutex nsinfo_mutex;
 extern gchar **srvtypes;
@@ -101,6 +108,7 @@ extern struct lru_tree_s *srv_down;
 
 enum
 {
+	/* consider empty results sets as errors */
 	FLAG_NOEMPTY = 0x0001,
 };
 

--- a/proxy/transport_http.h
+++ b/proxy/transport_http.h
@@ -22,14 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # include <server/slab.h>
 
-/**
- * @defgroup server_transhttp HTTP features
- * @ingroup server
- * @brief
- * @details
- * @{
- */
-
 /* Avoids an include */
 struct network_client_s;
 
@@ -64,6 +56,7 @@ struct http_reply_ctx_s
 	void (*subject) (const char *id);
 	void (*finalize) (void);
 	void (*access_tail) (const char *fmt, ...);
+	void (*no_access) (void);
 };
 
 enum http_rc_e { HTTPRC_DONE, HTTPRC_NEXT, HTTPRC_ABORT };
@@ -97,7 +90,5 @@ struct http_request_dispatcher_s * transport_http_build_dispatcher(
 
 const gchar * http_request_get_header(struct http_request_s *req,
 		const gchar *n);
-
-/** @} */
 
 #endif /*OIO_SDS__proxy__transport_http_h*/

--- a/tests/func/test_cs.c
+++ b/tests/func/test_cs.c
@@ -94,8 +94,9 @@ test_proxied_deregister (void)
 		reg.kv_tags = tags;
 		err = oio_cs_client__register_service (cs, srvtype, &reg);
 		g_assert_no_error (err);
-		void on_reg (const struct oio_cs_registration_s *preg) {
-			GRID_DEBUG("turn=%d id=%s url=%s", i, preg->id, preg->url);
+		void on_reg (const struct oio_cs_registration_s *preg, int score) {
+			GRID_DEBUG("turn=%d id=%s url=%s score=%d",
+					i, preg->id, preg->url, score);
 		}
 		err = oio_cs_client__list_services (cs, srvtype, on_reg);
 		g_assert_no_error (err);

--- a/tools/sds-reset.sh
+++ b/tools/sds-reset.sh
@@ -137,7 +137,7 @@ done
 
 # wait for meta1 to be known in the conscience (this is necessary for the
 # init phase of the meta0
-while [ 0 -ge $(${PREFIX}-cluster -r "$NS" | grep -c meta1) ] ; do
+while [ ${REPLICATION_DIRECTORY} -gt $(${PREFIX}-cluster -r "$NS" | grep -c meta1) ] ; do
 	sleep 1
 done
 


### PR DESCRIPTION
* proxy+cluster: cluster now also uses the proxy to reach the conscience
* proxy feature to avoid logging succesful accesses for "too common" requests. It avoids flooding the log service.
* core/cs: interface slightly changed (score now returned when listing services.)
* core/proxy: reqID lazily set to a random hexstring
* tools/oio-reset.sh: # of meta1 checked before meta0 init
* metautils/gridd_client: redirection error should not be modified
