### PR TITLE
sqliterepo: fix lack of decache upon a GETVERS error

### DIFF
--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -185,8 +185,11 @@ _get_peers(struct sqlx_service_s *ss, struct sqlx_name_s *n,
 	s[1] = n->base[3];
 	((guint8*)cid)[1] = g_ascii_strtoull((gchar*)s, NULL, 16);
 
-	if (nocache)
+	if (nocache) {
 		_reload_prefixes(ss, FALSE);
+		if (!result)
+			return NULL;
+	}
 
 	gchar **peers = meta1_prefixes_get_peers(
 			meta1_backend_get_prefixes(m1), cid);

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -102,8 +102,14 @@ _get_peers(struct sqlx_service_s *ss, struct sqlx_name_s *n,
 	}
 
 retry:
-	if (nocache)
+	if (nocache) {
 		hc_decache_reference_service(ss->resolver, u, n->type);
+		if (!result) {
+			oio_url_pclean (&u);
+			return NULL;
+		}
+	}
+
 	peers = NULL;
 	err = hc_resolve_reference_service(ss->resolver, u, n->type, &peers);
 

--- a/sqlx/sqlx_server.c
+++ b/sqlx/sqlx_server.c
@@ -98,8 +98,13 @@ _get_peers(struct sqlx_service_s *ss, struct sqlx_name_s *n,
 		return NEWERROR(CODE_BAD_REQUEST, "Invalid base name");
 	}
 
-	if (nocache)
+	if (nocache) {
 		hc_decache_reference_service(ss->resolver, u, n->type);
+		if (!result) {
+			oio_url_pclean (&u);
+			return NULL;
+		}
+	}
 
 	gchar **peers = NULL;
 	GError *err = hc_resolve_reference_service(ss->resolver, u, n->type, &peers);

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -52,6 +52,7 @@ struct sqlx_service_config_s
 	const guint repo_hash_depth;
 	const guint repo_hash_width;
 
+	/* if <nocache> is FALSE and <result> is NULL, then only decache */
 	GError* (*get_peers) (struct sqlx_service_s *ss,
 			struct sqlx_name_s *n, gboolean nocache,
 			gchar ***result);


### PR DESCRIPTION
Avoids recreate deleted bases.