### PR TITLE
sqlx: Fix zeromq3 compatibility

### DIFF
--- a/sqlx/oio_events_queue.c
+++ b/sqlx/oio_events_queue.c
@@ -503,6 +503,6 @@ exit:
 	if (zagent) zmq_close (zagent);
 	if (zpull) zmq_close (zpull);
 	if (zpush) zmq_close (zpush);
-	if (zctx) zmq_ctx_term (zctx);
+	if (zctx) zmq_term (zctx);
 	return err;
 }


### PR DESCRIPTION
`zmq_ctx_term` replaced by `zmq_term`.