### PR TITLE
Protected init phases in m{0,1}v2

### DIFF
--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -211,7 +211,8 @@ _post_config(struct sqlx_service_s *ss)
 	transport_gridd_dispatcher_add_requests(ss->dispatcher,
 			meta1_gridd_get_requests(), m1);
 
-	for (gboolean done = FALSE; !done ;) {
+	gboolean done = FALSE;
+	while (!done && grid_main_is_running ()) {
 		/* Preloads the prefixes locally managed: It happens often that
 		 * meta1 starts before gridagent, and _reload_prefixes() fails
 		 * for this reason. */
@@ -222,6 +223,10 @@ _post_config(struct sqlx_service_s *ss)
 			g_clear_error(&err);
 			g_usleep(1 * G_TIME_SPAN_SECOND);
 		}
+	}
+	if (!done) {
+		GRID_INFO("Stopped while loading M0 prefixes");
+		return FALSE;
 	}
 
 	grid_task_queue_register(ss->gtq_reload, 5,

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -288,8 +288,7 @@ network_server_clean(struct network_server_s *srv)
 	network_server_close_servers(srv);
 
 	if (srv->endpointv) {
-		struct endpoint_s **u;
-		for (u=srv->endpointv; *u ;u++)
+		for (struct endpoint_s **u=srv->endpointv; *u ;u++)
 			g_free(*u);
 		g_free(srv->endpointv);
 	}
@@ -646,6 +645,8 @@ network_server_run(struct network_server_s *srv)
 		srv->thread_events = NULL;
 	}
 
+	/* XXX(jfs): seems legit but requires exit critical path to be reviewed.
+	_stop_pools (srv); */
 	ARM_WAKER(srv, EPOLL_CTL_DEL);
 
 	GRID_DEBUG("Server %p exiting its main loop", srv);
@@ -834,7 +835,7 @@ void
 network_server_set_max_workers(struct network_server_s *srv, guint max)
 {
 	EXTRA_ASSERT(srv != NULL);
-	if (!srv->pool_workers)
+	if (!grid_main_is_running() || !srv->pool_workers)
 		return;
 	g_thread_pool_set_max_threads (srv->pool_workers, CLAMP(max, 1, G_MAXUINT16), NULL);
 }

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -136,8 +136,9 @@ struct sqlx_service_s
 	// Turn to TRUE to avoid locking the repository volume
 	gboolean flag_nolock;
 
-	// Is the registration task to be executed?
-	gboolean flag_noregister;
+	// Allows the service to avoid initiating an event_queue. To be set by
+	// services that know they won't evr generate events (meta0)
+	gboolean flag_no_event;
 
 	// Controls the election mode:
 	// TRUE :  ELECTION_MODE_QUORUM


### PR DESCRIPTION
+ m0v2 doesn't allocate an event queue