### PR TITLE
oio-conscience-agent: tag.vol added as soon as a volume is monitored

### DIFF
--- a/python/oio/conscience/stats/rawx.py
+++ b/python/oio/conscience/stats/rawx.py
@@ -7,7 +7,6 @@ class RawxStat(HttpStat):
     """Specialization of HttpStat for rawx services"""
 
     rawx_stat_keys = [
-            ("config", "volume", "tag.vol"),
             ("counter", "req.hits", "stat.total_reqpersec"),
             ("counter", "req.time", "stat.total_avreqtime"),
     ]

--- a/python/oio/conscience/stats/volume.py
+++ b/python/oio/conscience/stats/volume.py
@@ -38,5 +38,6 @@ class VolumeStat(BaseStat):
             return {}
 
         stats = {"stat.io": 100.0 * self.oio_sys_io_idle(self.volume),
-                 "stat.space": 100.0 * self.oio_sys_space_idle(self.volume)}
+                 "stat.space": 100.0 * self.oio_sys_space_idle(self.volume),
+                 "tag.vol": self.volume}
         return stats


### PR DESCRIPTION
Fixes #481 