### PR TITLE
Jfs elections timers

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -170,6 +170,22 @@ extern "C" {
 #  define SQLX_CLIENT_TIMEOUT 30.0
 # endif
 
+/* Timeout for synchronisation requests (USE, GETVERS)
+   in seconds */
+# ifndef SQLX_SYNC_TIMEOUT
+#  define SQLX_SYNC_TIMEOUT 4.0
+# endif
+
+/* Timeout for SQLX_REPLICATE requests, in seconds */
+# ifndef SQLX_REPLI_TIMEOUT
+#  define SQLX_REPLI_TIMEOUT 10.0
+# endif
+
+/* Timeout for operations that require copying a DB */
+# ifndef SQLX_RESYNC_TIMEOUT
+#  define SQLX_RESYNC_TIMEOUT 30.0
+# endif
+
 # ifndef M2V2_CLIENT_TIMEOUT
 #  define M2V2_CLIENT_TIMEOUT 10.0
 # endif

--- a/proxy/sqlx_actions.c
+++ b/proxy/sqlx_actions.c
@@ -242,7 +242,7 @@ action_sqlx_copyto (struct req_args_s *args, struct json_object *jargs)
 		struct gridd_client_s *c = gridd_client_create(to, req, NULL, NULL);
 		g_byte_array_unref (req);
 		gridd_client_start (c);
-		gridd_client_set_timeout (c, 30.0);
+		gridd_client_set_timeout (c, SQLX_RESYNC_TIMEOUT);
 		GError *e = gridd_client_loop (c);
 		gridd_client_free (c);
 		if (!first)

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -192,11 +192,11 @@ struct election_member_s
 	guint log_index : 8;
 	enum election_step_e step : 8;
 
-	char requested_USE : 1;
-	char requested_PIPEFROM : 1;
-	char requested_EXIT : 1;
-	char pending_PIPEFROM : 1;
-	char pending_watch : 1;
+	unsigned char requested_USE : 1;
+	unsigned char requested_PIPEFROM : 1;
+	unsigned char requested_EXIT : 1;
+	unsigned char pending_PIPEFROM : 1;
+	unsigned char pending_watch : 1;
 
 	struct logged_event_s log[EVENTLOG_SIZE];
 };

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -319,13 +319,13 @@ _DEQUE_add (struct election_member_s *m)
 	EXTRA_ASSERT(m->next == NULL);
 	struct deque_beacon_s *beacon = m->manager->members_by_state + m->step;
 
-	m->prev = beacon->back;
-	beacon->back = m;
-
-	if (!beacon->front) {
-		m->next = beacon->front;
-		beacon->front = m;
+	if (beacon->back) {
+		m->prev = beacon->back;
+		beacon->back->next = m;
 	}
+	beacon->back = m;
+	if (!beacon->front)
+		beacon->front = m;
 	++ beacon->count;
 }
 
@@ -2288,7 +2288,6 @@ election_manager_play_timers (struct election_manager_s *manager, guint max)
 
 	guint count = 0;
 	char descr[512];
-
 	g_mutex_lock (&manager->lock);
 	for (const int *pi=steps; *pi >= 0 && (!max || count < max) ;++pi) {
 		struct deque_beacon_s *beacon = manager->members_by_state + *pi;

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2299,12 +2299,14 @@ election_manager_play_timers (struct election_manager_s *manager, guint max)
 		   avoids loops and wrong game on pointers. */
 		GSList *l0 = _DEQUE_extract (beacon);
 		for (GSList *l=l0; l && (!max || count < max) ;l=l->next) {
+
 			struct election_member_s *m = l->data;
 			enum sqlx_action_e action = _member_get_next_action (m);
 			if (GRID_TRACE_ENABLED()) {
 				member_descr (m, descr, sizeof(descr));
 				GRID_TRACE("action [%s] %s", _action2str(action), descr);
 			}
+
 			if (action == ACTION_EXPIRE) {
 				if (m->refcount == 1) {
 					count ++;

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1754,8 +1754,15 @@ restart_election(struct election_member_s *member)
 static gboolean
 member_concerned_by_GETVERS(struct election_member_s *member, guint *reqid)
 {
-	if (*reqid != member->reqid_GETVERS)
+	if (*reqid > member->reqid_GETVERS) {
+		GRID_WARN("GETVERS replied from the future! (expected %u, got %u)",
+				member->reqid_GETVERS, *reqid);
 		return FALSE;
+	} else if (*reqid < member->reqid_GETVERS) {
+		GRID_WARN("GETVERS replied from the past! (expected %u, got %u)",
+				member->reqid_GETVERS, *reqid);
+		return FALSE;
+	}
 	if (member->pending_GETVERS > 0) {
 		if (! -- member->pending_GETVERS)
 			member->reqid_GETVERS = 0;

--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -157,7 +157,7 @@ struct election_counts_s election_manager_count (struct election_manager_s *m);
 /* Perform the 'timer' action on one item of each status.
    This includes expiring the election, retrying, pinging peers, etc.
    Returns the number of items activated. */
-guint election_manager_play_timers (struct election_manager_s *m);
+guint election_manager_play_timers (struct election_manager_s *m, guint max);
 
 void election_manager_exit_all (struct election_manager_s *m,
 		gint64 oldest, gboolean persist);

--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -154,10 +154,10 @@ GError* election_manager_create (struct replication_config_s *config,
 
 struct election_counts_s election_manager_count (struct election_manager_s *m);
 
-/* Perform the 'timer' action on the first election that needs it.
-   This includes expiring the election, retrying it, ping peers, etc.
-   Returns TRUE if at least one election has been managed. */
-gboolean election_manager_play_timers (struct election_manager_s *m);
+/* Perform the 'timer' action on one item of each status.
+   This includes expiring the election, retrying, pinging peers, etc.
+   Returns the number of items activated. */
+guint election_manager_play_timers (struct election_manager_s *m);
 
 void election_manager_exit_all (struct election_manager_s *m,
 		gint64 oldest, gboolean persist);

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -104,7 +104,7 @@ License along with this library.
 	EXTRA_ASSERT((M)->vtable); \
 	/* EXTRA_ASSERT((M)->sync); */ \
 	EXTRA_ASSERT((M)->peering); \
-	EXTRA_ASSERT((M)->lrutree_members != NULL);\
+	EXTRA_ASSERT((M)->members_by_key != NULL);\
 	CONFIG_CHECK((M)->config); \
 } while (0)
 

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -73,9 +73,6 @@ License along with this library.
 #  define SQLX_DELAY_PING_FINAL 300 * G_TIME_SPAN_SECOND
 # endif
 
-/* Timeout for SQLX_REPLICATE requests, in seconds */
-#define SQLX_REPLICATION_TIMEOUT 10.0
-
 /* Size of buffer for reading dump file */
 #define SQLX_DUMP_BUFFER_SIZE 32768
 

--- a/sqliterepo/replication.c
+++ b/sqliterepo/replication.c
@@ -306,7 +306,7 @@ _replicate_on_peers(gchar **peers, struct sqlx_repctx_s *ctx)
 	clients = gridd_client_create_many(peers, encoded, NULL, NULL);
 	g_byte_array_unref(encoded);
 
-	gridd_clients_set_timeout(clients, SQLX_REPLICATION_TIMEOUT);
+	gridd_clients_set_timeout(clients, SQLX_REPLI_TIMEOUT);
 
 	gridd_clients_start(clients);
 	err = gridd_clients_loop(clients);

--- a/sqliterepo/replication_client.c
+++ b/sqliterepo/replication_client.c
@@ -65,7 +65,7 @@ peer_restore(const gchar *target, struct sqlx_name_s *name,
 	if (!client)
 		return NEWERROR(CODE_INTERNAL_ERROR, "Failed to create client to [%s], bad address?", target);
 
-	gridd_client_set_timeout(client, 30.0);
+	gridd_client_set_timeout(client, SQLX_RESYNC_TIMEOUT);
 	gridd_client_start(client);
 	if (!(err = gridd_client_loop(client)))
 		err = gridd_client_error(client);
@@ -87,7 +87,7 @@ peers_restore(gchar **targets, struct sqlx_name_s *name,
 	GByteArray *encoded = _pack_RESTORE(name, dump);
 	struct gridd_client_s **clients = gridd_client_create_many(targets, encoded, NULL, NULL);
 	g_byte_array_unref(encoded);
-	gridd_clients_set_timeout(clients, 30.0);
+	gridd_clients_set_timeout(clients, SQLX_RESYNC_TIMEOUT);
 
 	gridd_clients_start(clients);
 	if (!(err = gridd_clients_loop(clients)))

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -406,7 +406,7 @@ _direct_use (struct sqlx_peering_s *self,
 	mc->client = gridd_client_factory_create_client (p->factory);
 	gridd_client_connect_url (mc->client, url);
 	gridd_client_request (mc->client, req, NULL, NULL);
-	gridd_client_set_timeout(mc->client, 1.0);
+	gridd_client_set_timeout(mc->client, SQLX_SYNC_TIMEOUT);
 	gridd_client_pool_defer(p->pool, mc);
 	g_byte_array_unref(req);
 }
@@ -459,7 +459,7 @@ _direct_pipefrom (struct sqlx_peering_s *self,
 
 	gridd_client_connect_url (mc->ec.client, url);
 	gridd_client_request(mc->ec.client, req, NULL, NULL);
-	gridd_client_set_timeout(mc->ec.client, 30.0);
+	gridd_client_set_timeout(mc->ec.client, SQLX_RESYNC_TIMEOUT);
 	gridd_client_pool_defer(p->pool, &mc->ec);
 
 	g_byte_array_unref(req);
@@ -553,7 +553,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 	gridd_client_request (mc->ec.client, req, mc, on_reply_GETVERS);
 	g_byte_array_unref(req);
 
-	gridd_client_set_timeout(mc->ec.client, 1.0);
+	gridd_client_set_timeout(mc->ec.client, SQLX_SYNC_TIMEOUT);
 	gridd_client_pool_defer(p->pool, &mc->ec);
 }
 

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -761,17 +761,14 @@ _task_react_elections(gpointer p)
 	if (!PSRV(p)->flag_replicable)
 		return;
 
-	guint count = 0;
+	gint64 t = oio_ext_monotonic_time();
+	guint count = election_manager_play_timers (PSRV(p)->election_manager);
+	t = t - oio_ext_monotonic_time();
 
-	const gint64 deadline = oio_ext_monotonic_time() +
-		500 * G_TIME_SPAN_MILLISECOND;
-	while (election_manager_play_timers (PSRV(p)->election_manager)) {
-		++ count;
-		if (oio_ext_monotonic_time () > deadline)
-			break;
+	if (count || t > (500*G_TIME_SPAN_MILLISECOND)) {
+		GRID_DEBUG("Reacted %u elections in %"G_GINT64_FORMAT"ms",
+				count, t / G_TIME_SPAN_MILLISECOND);
 	}
-	if (count)
-		GRID_DEBUG("Reacted %u elections", count);
 }
 
 static void

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -113,6 +113,7 @@ struct sqlx_service_s
 	guint max_bases;
 	guint max_passive;
 	guint max_active;
+	guint max_elections_timers_per_round;
 
 	//-------------------------------------------------------------------
 	// Variables used during the startup time of the server, but not used

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -531,7 +531,7 @@ test_single (void)
 	_test_transition (EVT_NONE, NULL, STEP_CANDREQ);
 #endif
 
-	g_assert_cmpuint (0, ==, election_manager_play_timers (manager));
+	g_assert_cmpuint (0, ==, election_manager_play_timers (manager, 0));
 
 	g_array_remove_index_fast (sync->pending, 0);
 	_pending (0);
@@ -557,21 +557,26 @@ test_single (void)
 
 	CLOCK += manager->delay_fail_pending + 1;
 	g_assert_cmpuint (_refcount(), ==, 2);
-	g_assert_cmpuint (1, ==, election_manager_play_timers (manager));
-	g_assert_cmpuint (0, ==, election_manager_play_timers (manager));
+	g_assert_cmpuint (1, ==, election_manager_play_timers (manager, 0));
+	g_assert_cmpuint (0, ==, election_manager_play_timers (manager, 0));
 	CLOCK += manager->delay_expire_failed + 1;
-	g_assert_cmpuint (1, ==, election_manager_play_timers (manager));
+	g_assert_cmpuint (1, ==, election_manager_play_timers (manager, 0));
 
 	_pending (EXISTS_DONE, DELETE, 0);
 	g_assert_cmpuint (_refcount(), ==, 3);
 
-	g_assert_cmpuint (0, ==, election_manager_play_timers (manager));
+	g_assert_cmpuint (0, ==, election_manager_play_timers (manager, 0));
 
 	election_manager_clean (manager);
 	sqlx_peering__destroy (peering);
 	sqlx_sync_close (sync);
 	sqlx_sync_clear (sync);
 	g_array_free (iv, TRUE);
+}
+
+static void
+test_sets (void)
+{
 }
 
 static void
@@ -664,5 +669,6 @@ main(int argc, char **argv)
 	g_test_add_func("/sqlx/election/create_ok", test_create_ok);
 	g_test_add_func("/sqlx/election/election_init", test_election_init);
 	g_test_add_func ("/sqliterepo/election/single", test_single);
+	g_test_add_func ("/sqliterepo/election/sets", test_sets);
 	return g_test_run();
 }


### PR DESCRIPTION
* Elections organized in per-state lists: attempt to make a better management of staled elections, with a higher priority on timers for pending and failed states.
* better default timeouts on synchronicity requests (from 1s to 4s)
* more warnings on specific error-prone situations