### PR TITLE
m0v2 init sequence fixed

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -198,6 +198,10 @@ extern "C" {
 #  define M1V2_CLIENT_TIMEOUT 10.0
 # endif
 
+# ifndef M0V2_INIT_TIMEOUT
+#  define M0V2_INIT_TIMEOUT 30.0
+# endif
+
 # ifndef M0V2_CLIENT_TIMEOUT
 #  define M0V2_CLIENT_TIMEOUT 10.0
 # endif

--- a/meta0v2/meta0_remote.c
+++ b/meta0v2/meta0_remote.c
@@ -105,7 +105,8 @@ meta0_remote_fill(const char *m0, gchar **urls, guint nbreplicas)
 	gchar *body = g_strjoinv("\n", urls);
 	metautils_message_set_BODY(request, body, strlen(body));
 	g_free(body);
-	return _m0_remote_no_return (m0, message_marshall_gba_and_clean(request));
+	return gridd_client_exec (m0, M0V2_INIT_TIMEOUT,
+			message_marshall_gba_and_clean(request));
 }
 
 GError*
@@ -117,7 +118,8 @@ meta0_remote_fill_v2(const char *m0, guint nbreplicas, gboolean nodist)
 	metautils_message_add_field_strint64(request, NAME_MSGKEY_REPLICAS, nbreplicas);
 	if (nodist)
 		metautils_message_add_field_struint(request, NAME_MSGKEY_NODIST, nodist);
-	return _m0_remote_no_return (m0, message_marshall_gba_and_clean(request));
+	return gridd_client_exec (m0, M0V2_INIT_TIMEOUT,
+			message_marshall_gba_and_clean(request));
 }
 
 GError*

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -526,6 +526,7 @@ sqlx_repository_set_elections(sqlx_repository_t *repo,
 {
 	EXTRA_ASSERT(repo != NULL);
 	EXTRA_ASSERT(repo->election_manager == NULL);
+	EXTRA_ASSERT(manager != NULL);
 	if (repo)
 		repo->election_manager = manager;
 }
@@ -1012,6 +1013,13 @@ sqlx_repository_open_and_lock(sqlx_repository_t *repo,
 	}
 
 	_open_clean_args(&args);
+
+	/* XXX(jfs): patching the db handle so it has the lastest election_manager
+	   allows reusing a handle from the cache, and that was initiated during
+	   the _post_config hook (when the election_manager was not associated yet
+	   to the repository. */
+	if (!err && result)
+		(*result)->manager = repo->election_manager;
 
 	if (!err && repo->open_callback && result) {
 		err = repo->open_callback(*result, repo->open_callback_data);


### PR DESCRIPTION
* Fixes a wrong DB init in sqliterepo that (currently) only happens in meta0 when the base is opened from the cache, before an election_manager is ready to use. This helps fixing #193 (try this, @racciari )
* Extends the timeout when filling the base.
* allows oio-reset.sh to deploy several meta0