### PR TITLE
Fixes the ability to cleanly reconnect ZooKeeper

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -166,6 +166,10 @@ extern "C" {
 #  define COMMON_CLIENT_TIMEOUT 30.0
 # endif
 
+#ifndef SQLX_SYNC_DEFAULT_ZK_TIMEOUT
+# define SQLX_SYNC_DEFAULT_ZK_TIMEOUT 8765
+#endif
+
 # ifndef SQLX_CLIENT_TIMEOUT
 #  define SQLX_CLIENT_TIMEOUT 30.0
 # endif

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -230,7 +230,6 @@ network_server_init(void)
 
 	result->cnx_max_sys = maxfd;
 	result->cnx_max = (result->cnx_max_sys * 99) / 100;
-	result->cnx_backlog = 50;
 	result->wakeup[0] = wakeup[0];
 	result->wakeup[1] = wakeup[1];
 	result->epollfd = epoll_create(1024);
@@ -857,16 +856,6 @@ network_server_set_maxcnx(struct network_server_s *srv, guint max)
 	if (srv->cnx_max != emax) {
 		GRID_INFO("MAXCNX [%u] changed to [%u]", srv->cnx_max, emax);
 		srv->cnx_max = emax;
-	}
-}
-
-void
-network_server_set_cnx_backlog(struct network_server_s *srv, guint bl)
-{
-	EXTRA_ASSERT(srv != NULL);
-	if (bl != srv->cnx_backlog) {
-		GRID_INFO("CNX BACKLOG changed to [%u]", bl);
-		srv->cnx_backlog = bl;
 	}
 }
 

--- a/server/network_server.h
+++ b/server/network_server.h
@@ -112,9 +112,6 @@ void network_server_set_max_workers(struct network_server_s *srv, guint max);
 
 void network_server_set_maxcnx(struct network_server_s *srv, guint max);
 
-void network_server_set_cnx_backlog(struct network_server_s *srv,
-		guint cnx_bl);
-
 typedef void (*network_transport_factory) (gpointer u,
 		struct network_client_s *clt);
 

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library.
 */
 
+#include <errno.h>
+
 #include <metautils/lib/metautils.h>
 
 #include <zookeeper.h>
@@ -177,35 +179,47 @@ zk_main_watch(zhandle_t *zh, int type, int state, const char *path,
 {
 	metautils_ignore_signals();
 
-	struct sqlx_sync_s *ss = watcherCtx;
-	(void) zh;
-	(void) path;
+	GRID_DEBUG("%s(%p,%d,%d,%s,%p)", __FUNCTION__,
+			zh, type, state, path, watcherCtx);
 
-	if (type == ZOO_SESSION_EVENT &&
-			state == ZOO_CONNECTING_STATE) {
+	struct sqlx_sync_s *ss = watcherCtx;
+	EXTRA_ASSERT (ss != NULL);
+
+	if (type != ZOO_SESSION_EVENT)
+		return;
+
+	if (state == ZOO_EXPIRED_SESSION_STATE) {
 		GRID_WARN("Zookeeper: (re)connecting to [%s]", ss->zk_url);
 		if (ss->zh)
 			zookeeper_close(ss->zh);
 		if (NULL != ss->on_exit)
 			ss->on_exit(ss->on_exit_ctx);
+
+		/* XXX(jfs): forget the previous ID and reconnect */
+		memset (&ss->zk_id, 0, sizeof(ss->zk_id));
 		ss->zh = zookeeper_init(ss->zk_url, zk_main_watch,
-			SQLX_SYNC_DEFAULT_ZK_TIMEOUT, &ss->zk_id, ss, 0);
+				SQLX_SYNC_DEFAULT_ZK_TIMEOUT, &ss->zk_id, ss, 0);
+		if (!ss->zh) {
+			GRID_ERROR("ZooKeeper init failure: (%d) %s",
+					errno, strerror(errno));
+			grid_main_set_status (2);
+			grid_main_stop ();
+		}
+	}
+	else if (state == ZOO_AUTH_FAILED_STATE) {
+		GRID_WARN("Zookeeper: auth problem to [%s]", ss->zk_url);
+	}
+	else if (state == ZOO_ASSOCIATING_STATE) {
+		GRID_DEBUG("Zookeeper: associating to [%s]", ss->zk_url);
+	}
+	else if (state == ZOO_CONNECTED_STATE) {
+		memcpy(&(ss->zk_id), zoo_client_id(ss->zh), sizeof(clientid_t));
+		GRID_INFO("Zookeeper: connected to [%s] id=%"G_GINT64_FORMAT,
+				ss->zk_url, ss->zk_id.client_id);
 	}
 	else {
-		if (state == ZOO_EXPIRED_SESSION_STATE) {
-			GRID_WARN("Zookeeper: expired session to [%s]", ss->zk_url);
-		}
-		else if (state == ZOO_AUTH_FAILED_STATE) {
-			GRID_WARN("Zookeeper: auth problem to [%s]", ss->zk_url);
-		}
-		else if (state == ZOO_ASSOCIATING_STATE) {
-			GRID_DEBUG("Zookeeper: associating to [%s]", ss->zk_url);
-		}
-		else if (state == ZOO_CONNECTED_STATE) {
-			memcpy(&(ss->zk_id), zoo_client_id(ss->zh), sizeof(clientid_t));
-			GRID_INFO("Zookeeper: connected to [%s] id=%"G_GINT64_FORMAT,
-					ss->zk_url, ss->zk_id.client_id);
-		}
+		GRID_INFO("Zookeeper: unmanaged event [%s] id=%"G_GINT64_FORMAT,
+				ss->zk_url, ss->zk_id.client_id);
 	}
 }
 
@@ -216,7 +230,8 @@ _open(struct sqlx_sync_s *ss)
 	EXTRA_ASSERT(ss->vtable == &VTABLE);
 	if (NULL != ss->zh)
 		return NEWERROR(CODE_INTERNAL_ERROR, "BUG : ZK connection already initiated");
-	ss->zh = zookeeper_init(ss->zk_url, zk_main_watch, 4000, NULL, ss, 0);
+	ss->zh = zookeeper_init(ss->zk_url, zk_main_watch,
+			SQLX_SYNC_DEFAULT_ZK_TIMEOUT, NULL, ss, 0);
 	if (NULL == ss->zh)
 		return NEWERROR(CODE_INTERNAL_ERROR, "ZK connection failure");
 	return NULL;

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -20,10 +20,6 @@ License along with this library.
 #ifndef OIO_SDS__sqliterepo__synchro_h
 # define OIO_SDS__sqliterepo__synchro_h 1
 
-#ifndef SQLX_SYNC_DEFAULT_ZK_TIMEOUT
-# define SQLX_SYNC_DEFAULT_ZK_TIMEOUT 4000
-#endif
-
 /**
  * SYNCHRONICITY module :
  *

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -110,8 +110,6 @@ static struct grid_main_option_s common_options[] =
 		"Timeout when opening bases in use by another thread "
 			"(milliseconds). -1 means wait forever, 0 return "
 			"immediately." },
-	{"CnxBacklog", OT_INT64, {.i64=&SRV.cnx_backlog},
-		"Number of connections allowed when all workers are busy"},
 
 	{"MaxBases", OT_UINT, {.u = &SRV.cfg_max_bases},
 		"Limits the number of concurrent open bases" },
@@ -443,7 +441,6 @@ sqlx_service_action(void)
 
 	gridd_client_pool_set_max(SRV.clients_pool, SRV.max_active);
 	network_server_set_maxcnx(SRV.server, SRV.max_passive);
-	network_server_set_cnx_backlog(SRV.server, SRV.cnx_backlog);
 	sqlx_repository_configure_maxbases(SRV.repository, SRV.max_bases);
 
 	election_manager_set_peering(SRV.election_manager, SRV.peering);
@@ -522,7 +519,6 @@ sqlx_service_set_defaults(void)
 {
 	SRV.max_elections_timers_per_round = SQLX_MAX_TIMER_PER_ROUND;
 	SRV.open_timeout = DEFAULT_CACHE_OPEN_TIMEOUT / G_TIME_SPAN_MILLISECOND;
-	SRV.cnx_backlog = 50;
 
 	SRV.cfg_max_bases = 0;
 	SRV.cfg_max_passive = 0;

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -109,7 +109,6 @@ struct sqlx_service_s
 	/* This is configured during the "configure" step, and can be overriden
 	   in the _post_config hook. */
 	gint64 open_timeout;
-	gint64 cnx_backlog;
 	guint max_bases;
 	guint max_passive;
 	guint max_active;


### PR DESCRIPTION
* Longer timeout by default (4s -> 8s, helps under heavy loads)
* Upon expired sessions, re-opens a new session, with a brand new ID