### PR TITLE
conscience: Better timeout management for service's scores

### DIFF
--- a/cluster/conscience/conscience_srvtype.c
+++ b/cluster/conscience/conscience_srvtype.c
@@ -195,10 +195,11 @@ conscience_srvtype_remove_expired(struct conscience_srvtype_s * srvtype,
 	while (g_hash_table_iter_next(&iter, &key, &value)) {
 		struct conscience_srv_s *pService = value;
 		if (!pService->locked && pService->score.timestamp < oldest) {
-			if (callback)
-				callback(pService, u);
-			g_hash_table_iter_steal(&iter);
-			conscience_srv_destroy(pService);
+			if (pService->score.value > 0) {
+				if (callback)
+					callback(pService, u);
+				pService->score.value = 0;
+			}
 			count++;
 		}
 	}

--- a/cluster/conscience/conscience_srvtype.c
+++ b/cluster/conscience/conscience_srvtype.c
@@ -182,7 +182,12 @@ conscience_srvtype_remove_expired(struct conscience_srvtype_s * srvtype,
 	g_assert_nonnull (srvtype);
 
 	guint count = 0U;
-	time_t oldest = oio_ext_monotonic_seconds() - srvtype->score_expiration;
+
+	time_t oldest = oio_ext_monotonic_seconds();
+	if (oldest > srvtype->score_expiration)
+		oldest -= srvtype->score_expiration;
+	else
+		oldest = 0;
 
 	GHashTableIter iter;
 	gpointer key, value;

--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -127,7 +127,7 @@ extern "C" {
 
 /* in seconds */
 # ifndef PROXYD_TTL_KNOWN_SERVICES
-#  define PROXYD_TTL_KNOWN_SERVICES 3600
+#  define PROXYD_TTL_KNOWN_SERVICES 432000 /* 5 days in seconds */
 # endif
 
 # ifndef PROXYD_DEFAULT_PERIOD_DOWNSTREAM


### PR DESCRIPTION
* proxy: expiration of known services set to 5 days
* conscience: check more robust for small clocks
* conscience: scored to 0 instead of service removed