### PR TITLE
rawx,sqlx*: new options to preallocate chunks and databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: c
 install:
   - sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse"
-  - sudo apt-add-repository "deb http://mirror.openio.io/pub/repo/mini-dinstall/ trusty/"
+  - sudo apt-add-repository "deb http://mirror.openio.io/pub/repo/openio/sds/15.12/ trusty/"
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes libglib2.0-dev libzookeeper-mt-dev libzmq3-dev libcurl4-gnutls-dev libapreq2-dev libsqlite3-dev libattr1-dev libevent-dev apache2 apache2-dev liblzo2-dev openio-gridinit openio-asn1c openio-sds-librain-dev libjson-c-dev flex bison curl libleveldb1 libleveldb-dev libattr1-dev python-all-dev python-virtualenv beanstalkd
   - virtualenv $HOME/oio && source $HOME/oio/bin/activate

--- a/rainx/rainx_config.h
+++ b/rainx/rainx_config.h
@@ -97,10 +97,6 @@ struct dav_rainx_server_conf_s {
 	apr_pool_t *pool;
 	char docroot[1024];
 	char ns_name[LIMIT_LENGTH_NSNAME];
-	int hash_depth;
-	int hash_width;
-	int fsync_on_close;
-	apr_uint32_t headers_scheme;
 	apr_interval_time_t socket_timeout;
 
 	/* Statistics involved data */
@@ -120,7 +116,6 @@ struct dav_rainx_server_conf_s {
 	int enabled_acl;
 	rawx_conf_t* rainx_conf;
 	apr_thread_mutex_t *rainx_conf_lock;
-	ssize_t FILE_buffer_size; /**< negative or zero means 'unset', positive set the buffer size to this value, but we force a maximum of '131072' */
 };
 
 apr_status_t server_init_master_stat(dav_rainx_server_conf *conf, apr_pool_t *pool, apr_pool_t *plog);

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -83,6 +83,7 @@ dav_rawx_create_server_config(apr_pool_t *p, server_rec *s)
 	conf->hash_depth = 1;
 	conf->hash_width = 3;
 	conf->fsync_on_close = FSYNC_ON_CHUNK_DIR;
+	conf->fallocate = 1;
 	conf->FILE_buffer_size = 0;
 
 	return conf;
@@ -104,6 +105,7 @@ dav_rawx_merge_server_config(apr_pool_t *p, void *base, void *overrides)
 	newconf->hash_depth = child->hash_depth;
 	newconf->hash_width = child->hash_width;
 	newconf->fsync_on_close = child->fsync_on_close;
+	newconf->fallocate = child->fallocate;
 	newconf->FILE_buffer_size = child->FILE_buffer_size;
 	memcpy(newconf->docroot, child->docroot, sizeof(newconf->docroot));
 	memcpy(newconf->ns_name, child->ns_name, sizeof(newconf->ns_name));
@@ -265,6 +267,20 @@ dav_rawx_cmd_gridconfig_fsync_dir(cmd_parms *cmd, void *config, const char *arg1
 		conf->fsync_on_close |= FSYNC_ON_CHUNK_DIR;
 	else
 		conf->fsync_on_close &= ~FSYNC_ON_CHUNK_DIR;
+
+	return NULL;
+}
+
+static const char *
+dav_rawx_cmd_gridconfig_fallocate(cmd_parms *cmd, void *config, const char *arg1)
+{
+	dav_rawx_server_conf *conf;
+	(void) config;
+
+	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
+
+	conf = ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
+	conf->fallocate = _str_to_boolean(arg1);
 
 	return NULL;
 }
@@ -525,6 +541,7 @@ static const command_rec dav_rawx_cmds[] =
     AP_INIT_TAKE1("grid_dir_run",     dav_rawx_cmd_gridconfig_dirrun,      NULL, RSRC_CONF, "run directory"),
     AP_INIT_TAKE1("grid_fsync",       dav_rawx_cmd_gridconfig_fsync,       NULL, RSRC_CONF, "do fsync on file close"),
     AP_INIT_TAKE1("grid_fsync_dir",   dav_rawx_cmd_gridconfig_fsync_dir,   NULL, RSRC_CONF, "do fsync on chunk direcory after renaming .pending"),
+    AP_INIT_TAKE1("grid_fallocate",   dav_rawx_cmd_gridconfig_fallocate,   NULL, RSRC_CONF, "call fallocate when receiving a chunk"),
     AP_INIT_TAKE1("grid_acl",         dav_rawx_cmd_gridconfig_acl,         NULL, RSRC_CONF, "enabled acl"),
     AP_INIT_TAKE1("grid_upload_blocksize",    dav_rawx_cmd_gridconfig_upblock,     NULL, RSRC_CONF, "upload block size"),
     AP_INIT_TAKE1(NULL,  NULL,  NULL, RSRC_CONF, NULL)

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -84,7 +84,6 @@ dav_rawx_create_server_config(apr_pool_t *p, server_rec *s)
 	conf->hash_width = 3;
 	conf->fsync_on_close = FSYNC_ON_CHUNK_DIR;
 	conf->fallocate = 1;
-	conf->FILE_buffer_size = 0;
 
 	return conf;
 }
@@ -106,7 +105,6 @@ dav_rawx_merge_server_config(apr_pool_t *p, void *base, void *overrides)
 	newconf->hash_width = child->hash_width;
 	newconf->fsync_on_close = child->fsync_on_close;
 	newconf->fallocate = child->fallocate;
-	newconf->FILE_buffer_size = child->FILE_buffer_size;
 	memcpy(newconf->docroot, child->docroot, sizeof(newconf->docroot));
 	memcpy(newconf->ns_name, child->ns_name, sizeof(newconf->ns_name));
 	update_rawx_conf(p, &(newconf->rawx_conf), newconf->ns_name);
@@ -300,26 +298,6 @@ dav_rawx_cmd_gridconfig_dirrun(cmd_parms *cmd, void *config, const char *arg1)
 
 	DAV_DEBUG_POOL(cmd->pool, 0, "mutex_key=[%s]", conf->shm.path);
 	DAV_DEBUG_POOL(cmd->pool, 0, "shm_key=[%s]", conf->shm.path);
-
-	return NULL;
-}
-
-static const char *
-dav_rawx_cmd_gridconfig_upblock(cmd_parms *cmd, void *config, const char *arg1)
-{
-	dav_rawx_server_conf *conf;
-	(void) config;
-
-	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
-
-	conf = ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-
-	if (arg1 && *arg1) {
-		int s = atoi(arg1);
-		if (s > 0) {
-			conf->FILE_buffer_size = CLAMP(s, RAWX_BUF_MIN, RAWX_BUF_MAX);
-		}
-	}
 
 	return NULL;
 }
@@ -543,7 +521,6 @@ static const command_rec dav_rawx_cmds[] =
     AP_INIT_TAKE1("grid_fsync_dir",   dav_rawx_cmd_gridconfig_fsync_dir,   NULL, RSRC_CONF, "do fsync on chunk direcory after renaming .pending"),
     AP_INIT_TAKE1("grid_fallocate",   dav_rawx_cmd_gridconfig_fallocate,   NULL, RSRC_CONF, "call fallocate when receiving a chunk"),
     AP_INIT_TAKE1("grid_acl",         dav_rawx_cmd_gridconfig_acl,         NULL, RSRC_CONF, "enabled acl"),
-    AP_INIT_TAKE1("grid_upload_blocksize",    dav_rawx_cmd_gridconfig_upblock,     NULL, RSRC_CONF, "upload block size"),
     AP_INIT_TAKE1(NULL,  NULL,  NULL, RSRC_CONF, NULL)
 };
 

--- a/rawx-apache2/src/rawx_config.h
+++ b/rawx-apache2/src/rawx_config.h
@@ -124,7 +124,6 @@ struct dav_rawx_server_conf_s {
 
 	int enabled_acl;
 	rawx_conf_t* rawx_conf;
-	ssize_t FILE_buffer_size; /**< negative or zero means 'unset', positive set the buffer size to this value, but we force a maximum of '131072' */
 };
 
 apr_status_t server_init_master_stat(dav_rawx_server_conf *conf, apr_pool_t *pool, apr_pool_t *plog);

--- a/rawx-apache2/src/rawx_config.h
+++ b/rawx-apache2/src/rawx_config.h
@@ -108,6 +108,7 @@ struct dav_rawx_server_conf_s {
 	int hash_depth;
 	int hash_width;
 	int fsync_on_close;
+	int fallocate;
 	char event_agent_addr[RAWX_EVENT_ADDR_SIZE];
 
 	/* Statistics involved data */

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -707,16 +707,6 @@ rawx_repo_stream_create(const dav_resource *resource, dav_stream **result)
 		return server_create_and_stat_error(resource_get_server_config(resource), p,
 			MAP_IO2HTTP(rv), 0, "An error occurred while opening a resource.");
 	}
-	// TODO(fvennetier): remove this option, we never proved its efficiency
-	else if (conf->FILE_buffer_size > 0) {
-		int s = CLAMP(conf->FILE_buffer_size, RAWX_BUF_MIN, RAWX_BUF_MAX);
-		char *buf = apr_pcalloc(p, s);
-		if (0 != setvbuf(ds->f, buf, _IOFBF, (ssize_t)s)) {
-			DAV_DEBUG_REQ(resource->info->request, 0,
-					"setvbuf failed : (errno=%d) %s",
-					errno, strerror(errno));
-		}
-	}
 
 	/* Preallocate disk space for the chunk */
 	apr_int64_t chunk_size = 0;

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -80,7 +80,7 @@ License along with this library.
 #define SQLX_DUMP_CHUNK_SIZE (8*1024*1024)
 
 /* Page size at database creation (should be multiple of storage block size) */
-#define SQLX_DEFAULT_PAGE_SIZE "4096"
+#define SQLX_DEFAULT_PAGE_SIZE 4096
 
 #define MEMBER(D)   ((struct election_member_s*)(D))
 #define MMANAGER(D) MEMBER(D)->manager
@@ -149,6 +149,9 @@ struct sqlx_repository_s
 	/* Limits for the base's holder */
 	guint bases_count;
 	guint bases_max;
+
+	/* sqlite page size for new bases */
+	guint page_size;
 
 	enum sqlx_sync_mode_e sync_mode_solo;
 	enum sqlx_sync_mode_e sync_mode_repli;

--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -125,6 +125,7 @@ struct sqlx_repo_config_s
 
 	enum sqlx_sync_mode_e sync_repli; /**< Which value for pragma synchronous'
 									   for replicated bases */
+	guint page_size;
 };
 
 /* ------------------------------------------------------------------------- */

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -120,6 +120,9 @@ static struct grid_main_option_s common_options[] =
 	{"MaxWorkers", OT_UINT, {.u=&SRV.cfg_max_workers},
 		"Limits the number of worker threads" },
 
+	{"PageSize", OT_UINT, {.u=&SRV.cfg_page_size},
+		"Page size of SQLite databases (0=use sqlite default)" },
+
 	{"CacheEnabled", OT_BOOL, {.b = &SRV.flag_cached_bases},
 		"If set, each base will be cached in a way it won't be accessed"
 			" by several requests in the same time."},
@@ -555,6 +558,7 @@ sqlx_service_set_defaults(void)
 	SRV.cfg_max_passive = 0;
 	SRV.cfg_max_active = 0;
 	SRV.cfg_max_workers = 200;
+	SRV.cfg_page_size = 4096;
 	SRV.flag_replicable = TRUE;
 	SRV.flag_autocreate = TRUE;
 	SRV.flag_delete_on = TRUE;

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -128,6 +128,8 @@ struct sqlx_service_s
 	guint cfg_max_active;
 	guint cfg_max_workers;
 
+	guint cfg_page_size;
+
 	guint sync_mode_repli;
 	guint sync_mode_solo;
 

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -184,9 +184,8 @@ grid_fsync             disabled
 # At the end of an upload, perform a fsync() on the directory holding the chunk
 grid_fsync_dir         enabled
 
-# If set, gives the internal FILE a buffer of this size. If not set (default),
-# let the default buffer used by the glibc.
-#grid_upload_blocksize 131072
+# Preallocate space for the chunk file (enabled by default)
+#grid_fallocate enabled
 
 # Triggers Access Control List (acl)
 # DO NOT USE, this is broken


### PR DESCRIPTION
- rawx: new "grid_fallocate" option (enabled by default), to tell
  the server to preallocate the space for the chunk, and
  possibly fail at the beginnig of the upload if there is not enough
- m0,m1,m2,sqlx: new "PageSize" commandline option to change the
  sqlite database page_size (defaults to 4096 bytes)