### PR TITLE
rawx: send events to beanstalkd instead of zeromq

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -303,9 +303,11 @@ extern "C" {
 # define OIO_CFG_ZOOKEEPER    "zookeeper"
 # define OIO_CFG_CONSCIENCE   "conscience"
 # define OIO_CFG_ACCOUNTAGENT "event-agent"
+# define OIO_CFG_BEANSTALKD   "beanstalkd"
 
 # define gridcluster_get_zookeeper(ns)  oio_cfg_get_value((ns), OIO_CFG_ZOOKEEPER)
 # define gridcluster_get_eventagent(ns) oio_cfg_get_value((ns), OIO_CFG_ACCOUNTAGENT)
+# define oio_cfg_get_beanstalkd(ns)     oio_cfg_get_value((ns), OIO_CFG_BEANSTALKD)
 # define oio_cfg_get_proxy(ns)          oio_cfg_get_value((ns), OIO_CFG_PROXY)
 # define oio_cfg_get_proxylocal(ns)     oio_cfg_get_value((ns), OIO_CFG_PROXYLOCAL)
 

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -59,7 +59,7 @@ service_invalidate (gconstpointer k)
 {
 	gulong now = oio_ext_monotonic_time () / G_TIME_SPAN_SECOND;
 	SRV_DO(lru_tree_insert (srv_down, g_strdup((const char *)k), (void*)now));
-	GRID_INFO("invalid at %lu %s", now, (const char*)k);
+	GRID_INFO("Service %s considered down", (const char*)k);
 }
 
 const char *

--- a/rawx-apache2/src/CMakeLists.txt
+++ b/rawx-apache2/src/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(mod_dav_rawx MODULE
 set_target_properties(mod_dav_rawx PROPERTIES PREFIX "" SUFFIX .so)
 
 target_link_libraries(mod_dav_rawx
-		metautils rawx
+		metautils rawx beanstalk
 		${APR_LIBRARIES} ${GLIB2_LIBRARIES}
 		${ZLIB_LIBRARIES} ${LZO_LIBRARIES}
 		${ZMQ_LIBRARIES})

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -337,7 +337,7 @@ rawx_hook_child_init(apr_pool_t *pchild, server_rec *s)
 
 	conf->cleanup = _cleanup_child;
 
-	event_agent_addr = gridcluster_get_eventagent(conf->ns_name);
+	event_agent_addr = oio_cfg_get_beanstalkd(conf->ns_name);
 	if (!rawx_event_init(event_agent_addr))
 		DAV_ERROR_POOL(pchild, 0, "Failed to initialize event context");
 	g_free(event_agent_addr);

--- a/rawx-apache2/src/rawx_event.c
+++ b/rawx-apache2/src/rawx_event.c
@@ -1,43 +1,46 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include <zmq.h>
+#include <beanstalk.h>
 #include <glib.h>
 
 #include <core/oioext.h>
+#include "metautils/lib/metautils_sockets.h"
 #include "rawx_event.h"
 
-static void *g_zmq_ctx = NULL;
-static char g_event_addr[RAWX_EVENT_ADDR_SIZE];
+static char beanstalkd_addr[RAWX_EVENT_ADDR_SIZE] = {0};
+static int beanstalkd_port = 11300;
+static int beanstalkd_ttr = 120;
+static int beanstalkd_priority = 0x7fffffff;
 
 int
 rawx_event_init(const char *addr)
 {
 	if (addr == NULL)
-		return 1;
+		return 0;
 
-	g_strlcpy(g_event_addr, addr, sizeof(g_event_addr));
-	g_zmq_ctx = zmq_ctx_new();
-	return g_zmq_ctx != NULL;
+	memset(beanstalkd_addr, 0, sizeof(beanstalkd_addr));
+	const char *port_str = strrchr(addr, ':');
+	if (port_str) {
+		beanstalkd_port = atoi(port_str + 1);
+		strncpy(beanstalkd_addr, addr, port_str - addr);
+	} else {
+		g_strlcpy(beanstalkd_addr, addr, sizeof(beanstalkd_addr));
+	}
+	// TODO: keep an open connection to beanstalkd
+	return 1;
 }
 
 void
 rawx_event_destroy(void)
 {
-	if (g_zmq_ctx != NULL)
-		zmq_ctx_destroy (g_zmq_ctx);
-	g_zmq_ctx = NULL;
-}
-
-static void callback_g_free(void *data, void *hint) {
-	(void) hint;
-	g_free(data);
+	// Nothing to do at the moment
 }
 
 int
 rawx_event_send(const char *event_type, GString *data_json) {
-	if (g_zmq_ctx == NULL)
-		return 1;
+	if (!beanstalkd_addr[0])
+		return 0;
 
 	GString *json = g_string_sized_new(256);
 
@@ -56,74 +59,23 @@ rawx_event_send(const char *event_type, GString *data_json) {
 	return rawx_event_send_raw(json);
 }
 
-struct msg_header_s {
-	guint32 random;
-};
-typedef struct msg_header_s msg_header_t;
-
-static int
-_init_header_part(zmq_msg_t *message) {
-	msg_header_t *data = g_malloc(sizeof(msg_header_t));
-	data->random = g_random_int();
-	return zmq_msg_init_data(message, data, sizeof(msg_header_t),
-			callback_g_free, NULL);
-}
-
-static int
-_init_data_part(zmq_msg_t *message, GString *json) {
-	int data_len = json->len;
-	gchar *data = g_string_free(json, FALSE);
-	return zmq_msg_init_data(message, data, data_len,
-			callback_g_free, NULL);
-}
-
 int
-rawx_event_send_raw(GString *json){
-	int rc;
-	void *sock = NULL;
-	zmq_msg_t zmsg;
-
-	if (g_zmq_ctx == NULL)
-		return 1;
-
-	sock = zmq_socket(g_zmq_ctx, ZMQ_REQ);
-	if (sock == NULL)
-		goto error;
-
-	int opt = 1000;
-	zmq_setsockopt(sock, ZMQ_LINGER, &opt, sizeof(opt));
-
-	rc = zmq_connect(sock, g_event_addr);
-	if (rc < 0)
-		goto error;
-
-	rc = _init_header_part(&zmsg);
-	if (rc < 0)
-		goto error;
-
-	rc = zmq_msg_send(&zmsg, sock, ZMQ_SNDMORE|ZMQ_DONTWAIT);
-	if (rc < 0) {
-		zmq_msg_close(&zmsg);
-		goto error;
+rawx_event_send_raw(GString *json) {
+	int rc = 1;
+	int sock = bs_connect(beanstalkd_addr, beanstalkd_port);
+	if (sock == BS_STATUS_FAIL) {
+		rc = 0;
+		goto end;
 	}
+	sock_set_linger_default(sock);
 
-	rc = _init_data_part(&zmsg, json);
-	if (rc < 0)
-		goto error;
+	int id = bs_put(sock, beanstalkd_priority, 0, beanstalkd_ttr,
+			json->str, json->len);
+	if (id <= 0)
+		rc = 0;
 
-	rc = zmq_msg_send(&zmsg, sock, ZMQ_DONTWAIT);
-	if (rc < 0) {
-		zmq_msg_close(&zmsg);
-		goto error;
-	}
-
-	/* We don't need the response */
-	zmq_close(sock);
-
-	return 1;
-
-error:
-	if (sock != NULL)
-		zmq_close(sock);
-	return 0;
+	bs_disconnect(sock);
+end:
+	g_string_free(json, TRUE);
+	return rc;
 }

--- a/rawx-apache2/src/rawx_event.h
+++ b/rawx-apache2/src/rawx_event.h
@@ -38,7 +38,7 @@ int rawx_event_init(const char *addr);
 void rawx_event_destroy(void);
 
 /**
- * Send event to event agent. This function adds "when" token automatically. 
+ * Send event to event agent. This function adds "when" token automatically.
  *
  * @event_type name of the event
  * @data_json data event in json (this function will free it)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -573,6 +573,7 @@ ${NOZK}zookeeper=${IP}:2181
 #proxy-local=${RUNDIR}/${NS}-proxy.sock
 proxy=${IP}:${PORT_PROXYD}
 event-agent=ipc://${RUNDIR}/event-agent.sock
+beanstalkd=127.0.0.1:11300
 conscience=${CS_ALL_PUB}
 """
 


### PR DESCRIPTION
The implementation is dumb and opens a connection for each event.