### PR TITLE
rawx  + beanstalkd: fixes (design, memleak)

### DIFF
--- a/events/oio_events_queue.h
+++ b/events/oio_events_queue.h
@@ -44,4 +44,6 @@ GError * oio_events_queue__run (struct oio_events_queue_s *self,
 GError * oio_events_queue_factory__create (const char *cfg,
 		struct oio_events_queue_s **out);
 
+GError * oio_events_queue_factory__check_config (const char *cfg);
+
 #endif /*OIO_SDS__sqlx__oio_events_queue_h*/

--- a/events/oio_events_queue_beanstalkd.c
+++ b/events/oio_events_queue_beanstalkd.c
@@ -240,6 +240,8 @@ _q_destroy (struct oio_events_queue_s *self)
 	struct _queue_BEANSTALKD_s *q = (struct _queue_BEANSTALKD_s*) self;
 	EXTRA_ASSERT(q->vtable == &vtable_BEANSTALKD);
 	g_async_queue_unref (q->queue);
+	oio_str_clean (&q->endpoint);
+	q->vtable = NULL;
 	g_free (q);
 }
 

--- a/events/oio_events_queue_beanstalkd.c
+++ b/events/oio_events_queue_beanstalkd.c
@@ -95,24 +95,25 @@ static int
 _send (int fd, struct iovec *iov, unsigned int iovcount)
 {
 	int w;
-	struct pollfd pfd = {0};
-	pfd.fd = fd;
-	pfd.events = POLLIN;
 retry:
 	w = writev (fd, iov, 3);
 	if (w < 0) {
 		if (errno == EINTR)
 			goto retry;
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			struct pollfd pfd = {0};
+			pfd.fd = fd;
+			pfd.events = POLLOUT;
 			metautils_syscall_poll (&pfd, 1, 1000);
 			goto retry;
 		}
 		return 0;
 	}
 
-	while (w > 0) {
+	while (w > 0 && iovcount > 0) {
 		if (iov[0].iov_len <= (size_t)w) {
 			w -= iov[0].iov_len;
+			iov[0].iov_len = 0;
 			iov ++;
 			iovcount --;
 		} else {
@@ -120,10 +121,8 @@ retry:
 			w = 0;
 		}
 	}
-	if (iovcount > 0) {
-		metautils_syscall_poll (&pfd, 1, 1000);
+	if (iovcount > 0)
 		goto retry;
-	}
 
 	GRID_TRACE("BEANSTALKD put sent!");
 	return 1;
@@ -164,7 +163,7 @@ _q_run (struct oio_events_queue_s *self, gboolean (*running) (gboolean pending))
 	EXTRA_ASSERT (q != NULL && q->vtable == &vtable_BEANSTALKD);
 	EXTRA_ASSERT (running != NULL);
 
-	while ((*running)(g_async_queue_length(q->queue))) {
+	while ((*running)(0 < g_async_queue_length(q->queue))) {
 
 		/* find an event, prefering the last that failed */
 		gchar *msg = saved;
@@ -184,6 +183,11 @@ _q_run (struct oio_events_queue_s *self, gboolean (*running) (gboolean pending))
 					g_clear_error (&err);
 					saved = msg;
 					msg = NULL;
+
+					/* Avoid looping crazily until the beanstalkd becomes up
+					 * again, let's sleep a little bit. */
+					g_usleep (250 * G_TIME_SPAN_MILLISECOND);
+					continue;
 				} else {
 					GRID_DEBUG("BEANSTALKD: reconnected to %s", q->endpoint);
 				}

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -179,6 +179,21 @@ dav_rawx_cmd_gridconfig_docroot(cmd_parms *cmd, void *config, const char *arg1)
 	return NULL;
 }
 
+static apr_status_t
+_cleanup (void *p)
+{
+	rawx_conf_t *conf = p;
+	if (NULL != conf->ni) {
+		namespace_info_free (conf->ni);
+		conf->ni = NULL;
+	}
+	if (NULL != conf->sp) {
+		storage_policy_clean (conf->sp);
+		conf->sp = NULL;
+	}
+	return APR_SUCCESS;
+}
+
 static const char *
 dav_rawx_cmd_gridconfig_namespace(cmd_parms *cmd, void *config, const char *arg1)
 {
@@ -196,27 +211,28 @@ dav_rawx_cmd_gridconfig_namespace(cmd_parms *cmd, void *config, const char *arg1
 	/* Prepare COMPRESSION / ACL CONF when we get ns name */
 	namespace_info_t* ns_info;
 	GError *local_error = conscience_get_namespace(conf->ns_name, &ns_info);
-        if(!ns_info) {
+	if (!ns_info) {
 		DAV_DEBUG_POOL(cmd->temp_pool, 0,
-			"Failed to get namespace info from ns [%s]", conf->ns_name);
+				"Failed to get namespace info from ns [%s]", conf->ns_name);
 		return apr_pstrcat(cmd->temp_pool, "Failed to get namespace info from ns: ",
 				conf->ns_name, NULL);
-        }
+	}
 
 	conf->rawx_conf = apr_palloc(cmd->pool, sizeof(rawx_conf_t));
+	apr_pool_cleanup_register (cmd->pool, conf->rawx_conf, _cleanup, _cleanup);
 
-	char * stgpol = NULL;
-	stgpol = namespace_storage_policy(ns_info, ns_info->name);
-	if(NULL != stgpol) {
+	gchar * stgpol = namespace_storage_policy(ns_info, ns_info->name);
+	if (NULL != stgpol) {
 		conf->rawx_conf->sp = storage_policy_init(ns_info, stgpol);
+		oio_str_clean (&stgpol);
 	} else {
 		conf->rawx_conf->sp = NULL;
 	}
+	g_assert (stgpol == NULL);
 
 	conf->rawx_conf->ni = ns_info;
-
 	conf->rawx_conf->acl = _get_acl(cmd->pool, ns_info);
-        conf->rawx_conf->last_update = time(0);
+	conf->rawx_conf->last_update = oio_ext_monotonic_seconds();
 
 	if(local_error)
 		g_clear_error(&local_error);

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -338,8 +338,12 @@ rawx_hook_child_init(apr_pool_t *pchild, server_rec *s)
 	conf->cleanup = _cleanup_child;
 
 	gchar *event_agent_addr = gridcluster_get_eventagent(conf->ns_name);
-	if (!rawx_event_init(s, event_agent_addr))
-		DAV_ERROR_POOL(pchild, 0, "Failed to initialize event context");
+	GError *err = rawx_event_init(event_agent_addr);
+	if (NULL != err) {
+		DAV_ERROR_POOL(pchild, 0, "Failed to initialize event context: (%d) %s",
+				err->code, err->message);
+		g_clear_error (&err);
+	}
 	g_free(event_agent_addr);
 
 	oio_log_to_syslog ();

--- a/rawx-apache2/src/rawx_config_utils.c
+++ b/rawx-apache2/src/rawx_config_utils.c
@@ -130,7 +130,7 @@ update_rawx_conf(apr_pool_t* p, rawx_conf_t **rawx_conf, const gchar* ns_name)
 
 	new_conf->ni = ns_info;
 	new_conf->acl = _get_acl(p, ns_info);
-	new_conf->last_update = time(0);
+	new_conf->last_update = oio_ext_monotonic_seconds();
 
 	*rawx_conf = new_conf;
 	return TRUE;

--- a/rawx-apache2/src/rawx_event.c
+++ b/rawx-apache2/src/rawx_event.c
@@ -8,41 +8,46 @@
 #include "mod_dav_rawx.h"
 #include "rawx_event.h"
 
-static struct oio_events_queue_s *q = NULL;
+static char s_queue_address[1024];
 
-int
-rawx_event_init (server_rec *s, const char *addr)
+GError *
+rawx_event_init (const char *addr)
 {
-	if (addr == NULL)
-		return 1;
-
-	GError *err = oio_events_queue_factory__create (addr, &q);
+	if (!addr)
+		return NULL;
+	GError *err = oio_events_queue_factory__check_config (addr);
 	if (err) {
-		ap_log_error (__FILE__, __LINE__, 0, APLOG_WARNING, 0, s,
-				"Event queue creation failed: (%d) %s", err->code, err->message);
-		g_clear_error (&err);
+		g_prefix_error (&err, "Configuration error: ");
+		return err;
 	}
-	return q != NULL;
+	s_queue_address[0] = 0;
+	g_strlcpy (s_queue_address, addr, sizeof(s_queue_address));
+	return NULL;
 }
 
 void
 rawx_event_destroy (void)
 {
-	if (q != NULL)
-		oio_events_queue__destroy (q);
-	q = NULL;
+	s_queue_address[0] = 0;
 }
 
 static gboolean _running (gboolean pending) { return pending; }
 
-int
+GError *
 rawx_event_send (const char *event_type, GString *data_json)
 {
-	if (q == NULL)
-		return 1;
+	if (!s_queue_address[0])
+		return NULL;
+
+	struct oio_events_queue_s *q = NULL;
+
+	GError *err = oio_events_queue_factory__create (s_queue_address, &q);
+	if (err) {
+		g_prefix_error (&err, "Event queue creation failed: ");
+		return err;
+	}
 
 	GString *json = g_string_sized_new(256);
-
 	g_string_append_printf(json,
 			"{"
 			"\"event\":\"%s\","
@@ -52,10 +57,11 @@ rawx_event_send (const char *event_type, GString *data_json)
 			event_type,
 			oio_ext_real_time() / G_TIME_SPAN_SECOND,
 			data_json->str);
-
 	g_string_free(data_json, TRUE);
-
 	oio_events_queue__send (q, g_string_free (json, FALSE));
-	oio_events_queue__run (q, _running);
-	return 1;
+
+	err = oio_events_queue__run (q, _running);
+	oio_events_queue__destroy (q);
+	q = NULL;
+	return err;
 }

--- a/rawx-apache2/src/rawx_event.h
+++ b/rawx-apache2/src/rawx_event.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @return 0 if KO, !=0 if OK
  */
-int rawx_event_init(server_rec *s, const char *addr);
+GError* rawx_event_init(const char *addr);
 
 
 /**
@@ -43,8 +43,8 @@ void rawx_event_destroy(void);
  * @event_type name of the event
  * @data_json data event in json (this function will free it)
  *
- * @return 0 if KO, !=0 if OK
+ * @return NULL if OK, or a GError describing the problem
  */
-int rawx_event_send(const char *event_type, GString *data_json);
+GError* rawx_event_send(const char *event_type, GString *data_json);
 
 #endif /*OIO_SDS__rawx_apache2__src__rawx_event_h*/


### PR DESCRIPTION
* events / beanstalkd: better check to detect the queue is empty
* events / beanstalkd: memleak fixed, happened once par queue creation
* rawx: 1 queue / request to force one thread manage its own events
* rawx: minor one-shot memleaks fixed