### PR TITLE
m2,events: new function send overwritable events with delay

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -47,6 +47,8 @@ extern "C" {
 		|| (C)==CODE_POLICY_NOT_SUPPORTED \
 		|| (C)==CODE_NAMESPACE_NOTMANAGED)
 
+#define VTABLE_HAS(self,T,F) (((T)self)->vtable-> F != NULL)
+
 #define VTABLE_CHECK(self,T,F) do { \
 	g_assert(self != NULL); \
 	g_assert(((T)self)->vtable != NULL); \

--- a/events/CMakeLists.txt
+++ b/events/CMakeLists.txt
@@ -14,6 +14,7 @@ link_directories(
 
 add_library(oioevents SHARED
 	oio_events_queue.c
+	oio_events_queue_buffer.c
 	oio_events_queue_zmq.c
 	oio_events_queue_beanstalkd.c)
 

--- a/events/oio_events_queue.c
+++ b/events/oio_events_queue.c
@@ -43,6 +43,20 @@ oio_events_queue__send (struct oio_events_queue_s *self, gchar *msg)
 	EVTQ_CALL(self,send)(self,msg);
 }
 
+void
+oio_events_queue__send_overwritable(struct oio_events_queue_s *self,
+		gchar *key, gchar *msg)
+{
+	EXTRA_ASSERT (msg != NULL);
+	if (VTABLE_HAS(self,struct oio_events_queue_abstract_s*,send_overwritable)
+			&& key && *key) {
+		EVTQ_CALL(self,send_overwritable)(self,key,msg);
+	} else {
+		EVTQ_CALL(self,send)(self,msg);
+		g_free(key);  // safe if key is NULL
+	}
+}
+
 gboolean
 oio_events_queue__is_stalled (struct oio_events_queue_s *self)
 {
@@ -53,6 +67,12 @@ void
 oio_events_queue__set_max_pending (struct oio_events_queue_s *self, guint v)
 {
 	EVTQ_CALL(self,set_max_pending)(self,v);
+}
+
+void
+oio_events_queue__set_buffering(struct oio_events_queue_s *self, gint64 us)
+{
+	EVTQ_CALL(self,set_buffering)(self,us);
 }
 
 GError *

--- a/events/oio_events_queue.h
+++ b/events/oio_events_queue.h
@@ -25,6 +25,12 @@ void oio_events_queue__destroy (struct oio_events_queue_s *self);
 /* msg's ownership is given to the queue. msg has to be valid JSON */
 void oio_events_queue__send (struct oio_events_queue_s *self, gchar *msg);
 
+/* Send an overwritable event, which may itself overwrite any previous event
+ * sent with the same key. The actual event sending will be delayed
+ * a little. */
+void oio_events_queue__send_overwritable(struct oio_events_queue_s *self,
+		gchar *key, gchar *msg);
+
 /* should emitters stop sending events? whatever, even if it returns TRUE,
  * the queue won't deny events. */
 gboolean oio_events_queue__is_stalled (struct oio_events_queue_s *self);
@@ -33,6 +39,10 @@ gboolean oio_events_queue__is_stalled (struct oio_events_queue_s *self);
  * the number of events waiting */
 void oio_events_queue__set_max_pending (struct oio_events_queue_s *self,
 		guint max);
+
+/* Set the overwritable events buffering delay */
+void oio_events_queue__set_buffering (struct oio_events_queue_s *self,
+		gint64 us);
 
 GError * oio_events_queue__run (struct oio_events_queue_s *self,
 		gboolean (*running) (gboolean pending));

--- a/events/oio_events_queue_buffer.c
+++ b/events/oio_events_queue_buffer.c
@@ -1,0 +1,74 @@
+/*
+OpenIO SDS event queue
+Copyright (C) 2016 OpenIO, original work as part of OpenIO Software Defined Storage
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <core/oio_core.h>
+#include "oio_events_queue_buffer.h"
+
+static GHashTable *
+oio_events_queue_buffer_renew(struct oio_events_queue_buffer_s *buf)
+{
+	g_mutex_lock(&(buf->msg_by_key_lock));
+	GHashTable *old = buf->msg_by_key;
+	buf->msg_by_key = g_hash_table_new_full(g_str_hash, g_str_equal,
+			g_free, g_free);
+	buf->last_renew = oio_ext_monotonic_time();
+	g_mutex_unlock(&(buf->msg_by_key_lock));
+	return old;
+}
+
+void
+oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf,
+		gint64 delay)
+{
+	g_mutex_init(&(buf->msg_by_key_lock));
+	buf->delay = delay;
+	oio_events_queue_buffer_renew(buf);
+}
+
+void
+oio_events_queue_buffer_clean(struct oio_events_queue_buffer_s *buf)
+{
+	g_hash_table_unref(buf->msg_by_key);
+	g_mutex_clear(&(buf->msg_by_key_lock));
+}
+
+void
+oio_events_queue_buffer_set_delay(struct oio_events_queue_buffer_s *buf,
+		gint64 new_delay)
+{
+	buf->delay = new_delay;
+}
+
+void
+oio_events_queue_buffer_maybe_flush(struct oio_events_queue_buffer_s *buf,
+		GHRFunc send, gpointer user_data)
+{
+	if (oio_ext_monotonic_time() > buf->last_renew + buf->delay) {
+		GHashTable *old = oio_events_queue_buffer_renew(buf);
+		g_hash_table_foreach_steal(old, send, user_data);
+		g_hash_table_unref(old);
+	}
+}
+
+void oio_events_queue_buffer_put(struct oio_events_queue_buffer_s *buf,
+		gchar *key, gchar *msg)
+{
+	g_mutex_lock(&(buf->msg_by_key_lock));
+	g_hash_table_insert(buf->msg_by_key, key, msg);
+	g_mutex_unlock(&(buf->msg_by_key_lock));
+}

--- a/events/oio_events_queue_buffer.h
+++ b/events/oio_events_queue_buffer.h
@@ -1,0 +1,42 @@
+/*
+OpenIO SDS event queue
+Copyright (C) 2016 OpenIO, original work as part of OpenIO Software Defined Storage
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OIO_SDS__sqlx__oio_events_queue_buffer_h
+# define OIO_SDS__sqlx__oio_events_queue_buffer_h 1
+
+#include <glib.h>
+
+struct oio_events_queue_buffer_s
+{
+	GHashTable *msg_by_key;
+	GMutex msg_by_key_lock;
+	gint64 last_renew;
+	gint64 delay;
+};
+
+void oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf,
+		gint64 delay);
+void oio_events_queue_buffer_clean(struct oio_events_queue_buffer_s *buf);
+void oio_events_queue_buffer_set_delay(struct oio_events_queue_buffer_s *buf,
+		gint64 new_delay);
+void oio_events_queue_buffer_put(struct oio_events_queue_buffer_s *buf,
+		gchar *key, gchar *msg);
+void oio_events_queue_buffer_maybe_flush(struct oio_events_queue_buffer_s *buf,
+		GHRFunc send, gpointer user_data);
+
+#endif

--- a/events/oio_events_queue_internals.h
+++ b/events/oio_events_queue_internals.h
@@ -26,8 +26,11 @@ struct oio_events_queue_vtable_s
 {
 	void (*destroy) (struct oio_events_queue_s *self);
 	void (*send) (struct oio_events_queue_s *self, gchar *msg);
+	void (*send_overwritable)(struct oio_events_queue_s *self,
+			gchar *key, gchar *msg);
 	gboolean (*is_stalled) (struct oio_events_queue_s *self);
 	void (*set_max_pending) (struct oio_events_queue_s *self, guint v);
+	void (*set_buffering) (struct oio_events_queue_s *self, gint64 v);
 	GError * (*run) (struct oio_events_queue_s *self, gboolean (*) (gboolean));
 };
 

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -745,10 +745,7 @@ _container_state (struct sqlx_sqlite3_s *sq3)
 	}
 	void append_const (GString *gs, const char *k, const char *v) {
 		sep (gs);
-		if (v)
-			g_string_append_printf (gs, "\"%s\":\"%s\"", k, v);
-		else
-			g_string_append_printf (gs, "\"%s\":null", k);
+		oio_str_gstring_append_json_pair(gs, k, v);
 	}
 	void append (GString *gs, const char *k, gchar *v) {
 		append_const (gs, k, v);
@@ -780,7 +777,9 @@ meta2_backend_add_modified_container(struct meta2_backend_s *m2b,
 {
 	EXTRA_ASSERT(m2b != NULL);
 	if (m2b->notifier)
-		oio_events_queue__send (m2b->notifier, _container_state (sq3));
+		oio_events_queue__send_overwritable(m2b->notifier,
+				g_strdup(sqlx_admin_get_str(sq3, SQLX_ADMIN_BASENAME)),
+				_container_state (sq3));
 }
 
 GError*


### PR DESCRIPTION
This will reduce the number of events sent by meta2 to account-server:
maximum one event by container each second.