### PR TITLE
Integrates TTL directly into the LRU

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -29,6 +29,8 @@ extern "C" {
 #  define EXTRA_ASSERT(X)
 # endif
 
+#define OLDEST(now,delay) (((now)>(delay)) ? ((now)-(delay)) : 0)
+
 #define ON_ENUM(P,E) case P##E: return #E
 
 #define CODE_IS_NETWORK_ERROR(C) ((C) < CODE_TEMPORARY)

--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -79,14 +79,16 @@ extern "C" {
 #  define PROXYD_PATH_MAXLEN 2048
 # endif
 
+/* in oio_ext_monotonic_time() precision */
 # ifndef PROXYD_DEFAULT_TTL_SERVICES
-#  define PROXYD_DEFAULT_TTL_SERVICES 3600
+#  define PROXYD_DEFAULT_TTL_SERVICES G_TIME_SPAN_HOUR
 # endif
 
 # ifndef PROXYD_DEFAULT_MAX_SERVICES
 #  define PROXYD_DEFAULT_MAX_SERVICES 200000
 # endif
 
+/* in oio_ext_monotonic_time() precision */
 # ifndef PROXYD_DEFAULT_TTL_CSM0
 #  define PROXYD_DEFAULT_TTL_CSM0 0
 # endif
@@ -116,26 +118,28 @@ extern "C" {
 # endif
 
 /* in seconds */
-# ifndef PROXYD_TTL_DEAD_LOCAL_SERVICES
-#  define PROXYD_TTL_DEAD_LOCAL_SERVICES 30
-# endif
-
-/* in seconds */
-# ifndef PROXYD_TTL_DOWN_SERVICES
-#  define PROXYD_TTL_DOWN_SERVICES 5
-# endif
-
-/* in seconds */
-# ifndef PROXYD_TTL_KNOWN_SERVICES
-#  define PROXYD_TTL_KNOWN_SERVICES 432000 /* 5 days in seconds */
-# endif
-
 # ifndef PROXYD_DEFAULT_PERIOD_DOWNSTREAM
-#  define PROXYD_DEFAULT_PERIOD_DOWNSTREAM 2 /*s*/
+#  define PROXYD_DEFAULT_PERIOD_DOWNSTREAM 2
 # endif
 
+/* in seconds */
 # ifndef PROXYD_DEFAULT_PERIOD_UPSTREAM
-#  define PROXYD_DEFAULT_PERIOD_UPSTREAM 1 /*s*/
+#  define PROXYD_DEFAULT_PERIOD_UPSTREAM 1
+# endif
+
+/* in oio_ext_monotonic_time() precision */
+# ifndef PROXYD_TTL_DEAD_LOCAL_SERVICES
+#  define PROXYD_TTL_DEAD_LOCAL_SERVICES (30*G_TIME_SPAN_SECOND)
+# endif
+
+/* in oio_ext_monotonic_time() precision */
+# ifndef PROXYD_TTL_DOWN_SERVICES
+#  define PROXYD_TTL_DOWN_SERVICES (5*G_TIME_SPAN_SECOND)
+# endif
+
+/* in oio_ext_monotonic_time() precision */
+# ifndef PROXYD_TTL_KNOWN_SERVICES
+#  define PROXYD_TTL_KNOWN_SERVICES (5*G_TIME_SPAN_DAY)
 # endif
 
 # ifndef GCLUSTER_RUN_DIR

--- a/metautils/lib/lrutree.c
+++ b/metautils/lib/lrutree.c
@@ -23,29 +23,31 @@ License along with this library.
 
 struct _node_s
 {
-    RB_ENTRY(_node_s) entry;
-    struct _node_s *prev;
-    struct _node_s *next;
+	RB_ENTRY(_node_s) entry;
+	struct _node_s *prev;
+	struct _node_s *next;
 
-    gpointer k;
-    gpointer v;
+	gint64 ctime;
+	gint64 atime;
+	gpointer k;
+	gpointer v;
 };
 
 struct lru_tree_s
 {
-    GCompareFunc kcmp;
-    GDestroyNotify kfree;
-    GDestroyNotify vfree;
-    guint32 flags;
+	GCompareFunc kcmp;
+	GDestroyNotify kfree;
+	GDestroyNotify vfree;
+	guint32 flags;
 
 	gint64 count;
 
 	// Red-Black tree 'by key'
-    RB_HEAD(_tree_s, _node_s) base;
+	RB_HEAD(_tree_s, _node_s) base;
 
 	// LRU double-ended queue
-    struct _node_s *first;
-    struct _node_s *last;
+	struct _node_s *first;
+	struct _node_s *last;
 };
 
 /* Nodes handling ---------------------------------------------------------- */
@@ -53,76 +55,76 @@ struct lru_tree_s
 static void
 _node_cleanup(struct lru_tree_s *lt, struct _node_s *node)
 {
-    if (lt->vfree && node->v)
-        lt->vfree(node->v);
-    if (lt->kfree && node->k)
-        lt->kfree(node->k);
-    node->k = node->v = NULL;
+	if (lt->vfree && node->v)
+		lt->vfree(node->v);
+	if (lt->kfree && node->k)
+		lt->kfree(node->k);
+	node->k = node->v = NULL;
 }
 
 static int
 _node_compare(gpointer u, const struct _node_s *n0, const struct _node_s *n1)
 {
-    struct lru_tree_s *lt = u;
-    return lt->kcmp(n0->k, n1->k);
+	struct lru_tree_s *lt = u;
+	return lt->kcmp(n0->k, n1->k);
 }
 
 static struct _node_s*
 _node_create(gpointer k, gpointer v)
 {
-    struct _node_s *n = SLICE_NEW0(struct _node_s);
-    n->k = k;
-    n->v = v;
-    return n;
+	struct _node_s *n = SLICE_NEW0(struct _node_s);
+	n->k = k;
+	n->v = v;
+	return n;
 }
 
 static void
 _node_destroy(struct lru_tree_s *lt, struct _node_s *node)
 {
-    _node_cleanup(lt, node);
-    SLICE_FREE(struct _node_s, node);
+	_node_cleanup(lt, node);
+	SLICE_FREE(struct _node_s, node);
 }
 
 static void
 _node_update(struct lru_tree_s *lt, struct _node_s *node, gpointer k,
-        gpointer v)
+		gpointer v)
 {
-    _node_cleanup(lt, node);
-    node->k = k;
-    node->v = v;
+	_node_cleanup(lt, node);
+	node->k = k;
+	node->v = v;
 }
 
 static void
 _node_deq_extract(struct lru_tree_s *lt, struct _node_s *node)
 {
-    // special case if the node is first or last
-    if (lt->first == node)
-        lt->first = node->next;
-    if (lt->last == node)
-        lt->last = node->prev;
+	// special case if the node is first or last
+	if (lt->first == node)
+		lt->first = node->next;
+	if (lt->last == node)
+		lt->last = node->prev;
 
-    // Now do local ring removal
-    if (node->prev)
-        node->prev->next = node->next;
-    if (node->next)
-        node->next->prev = node->prev;
+	// Now do local ring removal
+	if (node->prev)
+		node->prev->next = node->next;
+	if (node->next)
+		node->next->prev = node->prev;
 
-    node->next = node->prev = NULL;
+	node->next = node->prev = NULL;
 }
 
 static void
 _node_deq_push_front(struct lru_tree_s *lt, struct _node_s *node)
 {
-    if (!lt->first) {
-        node->prev = node->next = NULL;
-        lt->first = lt->last = node;
-    }
-    else {
-        node->prev = NULL;
-        node->next = lt->first;
-        lt->first->prev = node;
-        lt->first = node;
-    }
+	if (!lt->first) {
+		node->prev = node->next = NULL;
+		lt->first = lt->last = node;
+	}
+	else {
+		node->prev = NULL;
+		node->next = lt->first;
+		lt->first->prev = node;
+		lt->first = node;
+	}
 }
 
 /* Red-Black tree handling ------------------------------------------------- */
@@ -135,23 +137,23 @@ RB_GENERATE_STATIC(_tree_s, _node_s, entry, _node_compare);
 
 struct lru_tree_s*
 lru_tree_create(GCompareFunc cmp, GDestroyNotify kfree, GDestroyNotify vfree,
-        guint32 options)
+		guint32 options)
 {
-    struct lru_tree_s *lt = SLICE_NEW0(struct lru_tree_s);
-    lt->kcmp = cmp;
-    lt->kfree = kfree;
-    lt->vfree = vfree;
-    lt->flags = options;
-    RB_INIT(&(lt->base));
+	struct lru_tree_s *lt = SLICE_NEW0(struct lru_tree_s);
+	lt->kcmp = cmp;
+	lt->kfree = kfree;
+	lt->vfree = vfree;
+	lt->flags = options;
+	RB_INIT(&(lt->base));
 
-    return lt;
+	return lt;
 }
 
 void
 lru_tree_destroy(struct lru_tree_s *lt)
 {
-    if (!lt)
-        return;
+	if (!lt)
+		return;
 
 	while (lt->first) {
 		struct _node_s *n = lt->first;
@@ -160,148 +162,150 @@ lru_tree_destroy(struct lru_tree_s *lt)
 		_node_destroy(lt, n);
 	}
 
-    SLICE_FREE(struct lru_tree_s, lt);
+	SLICE_FREE(struct lru_tree_s, lt);
 }
 
 void
 lru_tree_insert(struct lru_tree_s *lt, gpointer k, gpointer v)
 {
-    struct _node_s fake, *node;
+	struct _node_s fake, *node;
 
-    EXTRA_ASSERT(lt != NULL);
-    EXTRA_ASSERT(k != NULL);
-    EXTRA_ASSERT(v != NULL);
+	EXTRA_ASSERT(lt != NULL);
+	EXTRA_ASSERT(k != NULL);
+	EXTRA_ASSERT(v != NULL);
 
-    fake.k = k;
-    if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake))) {
-        node = _node_create(k, v);
-        RB_INSERT(_tree_s, lt, &(lt->base), node);
+	fake.k = k;
+	if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake))) {
+		node = _node_create(k, v);
+		RB_INSERT(_tree_s, lt, &(lt->base), node);
 		++ lt->count;
-    }
-    else {
-        _node_deq_extract(lt, node);
-        _node_update(lt, node, k, v);
-    }
+	}
+	else {
+		_node_deq_extract(lt, node);
+		_node_update(lt, node, k, v);
+	}
 
-    _node_deq_push_front(lt, node);
+	_node_deq_push_front(lt, node);
+	node->ctime = node->atime = oio_ext_monotonic_time ();
 }
 
 gpointer
 lru_tree_get(struct lru_tree_s *lt, gconstpointer k)
 {
-    struct _node_s fake, *node;
+	struct _node_s fake, *node;
 
-    EXTRA_ASSERT(lt != NULL);
-    EXTRA_ASSERT(k != NULL);
+	EXTRA_ASSERT(lt != NULL);
+	EXTRA_ASSERT(k != NULL);
 
-    fake.k = k;
-    node = RB_FIND(_tree_s, lt, &(lt->base), &fake);
+	fake.k = k;
+	node = RB_FIND(_tree_s, lt, &(lt->base), &fake);
 
-    if (!node)
-        return NULL;
+	if (!node)
+		return NULL;
 
-    if (!(lt->flags & LTO_NOATIME)) {
-        _node_deq_extract(lt, node);
-        _node_deq_push_front(lt, node);
-    }
+	if (!(lt->flags & LTO_NOATIME)) {
+		_node_deq_extract(lt, node);
+		_node_deq_push_front(lt, node);
+		node->atime = oio_ext_monotonic_time();
+	}
 
-    return node->v;
+	return node->v;
 }
 
 gboolean
 lru_tree_remove(struct lru_tree_s *lt, gconstpointer k)
 {
-    struct _node_s fake, *node;
+	struct _node_s fake, *node;
 
-    EXTRA_ASSERT(lt != NULL);
-    EXTRA_ASSERT(k != NULL);
+	EXTRA_ASSERT(lt != NULL);
+	EXTRA_ASSERT(k != NULL);
 
-    fake.k = k;
-    if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake)))
-        return FALSE;
+	fake.k = k;
+	if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake)))
+		return FALSE;
 
-    RB_REMOVE(_tree_s, &(lt->base), node);
-    _node_deq_extract(lt, node);
+	RB_REMOVE(_tree_s, &(lt->base), node);
+	_node_deq_extract(lt, node);
 	-- lt->count;
 
-    _node_destroy(lt, node);
-    return TRUE;
+	_node_destroy(lt, node);
+	return TRUE;
 }
 
 gpointer
 lru_tree_steal(struct lru_tree_s *lt, gconstpointer k)
 {
-    struct _node_s fake, *node;
-    gpointer result;
+	struct _node_s fake, *node;
+	gpointer result;
 
-    EXTRA_ASSERT(lt != NULL);
-    EXTRA_ASSERT(k != NULL);
+	EXTRA_ASSERT(lt != NULL);
+	EXTRA_ASSERT(k != NULL);
 
-    fake.k = k;
-    if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake)))
-        return NULL;
+	fake.k = k;
+	if (!(node = RB_FIND(_tree_s, lt, &(lt->base), &fake)))
+		return NULL;
 
-    RB_REMOVE(_tree_s, &(lt->base), node);
-    _node_deq_extract(lt, node);
+	RB_REMOVE(_tree_s, &(lt->base), node);
+	_node_deq_extract(lt, node);
 	-- lt->count;
 
-    result = node->v;
-    node->v = NULL;
-    _node_destroy(lt, node);
-    return result;
+	result = node->v;
+	node->v = NULL;
+	_node_destroy(lt, node);
+	return result;
 }
 
 static gboolean
 _get(struct lru_tree_s *lt, gpointer *pk, gpointer *pv, struct _node_s *node,
-        int steal)
+		int steal)
 {
-    EXTRA_ASSERT(pk != NULL);
-    EXTRA_ASSERT(pv != NULL);
+	EXTRA_ASSERT(pk != NULL);
+	EXTRA_ASSERT(pv != NULL);
 
-    if (!node)
-        return FALSE;
+	if (!node)
+		return FALSE;
 
-    // steal the values
-    *pk = node->k;
-    *pv = node->v;
+	// steal the values
+	*pk = node->k;
+	*pv = node->v;
 
-    if (steal) { // clean the structures
-        node->k = node->v = NULL;
-        RB_REMOVE(_tree_s, &(lt->base), node);
-        _node_deq_extract(lt, node);
-        _node_destroy(lt, node);
+	if (steal) { // clean the structures
+		node->k = node->v = NULL;
+		RB_REMOVE(_tree_s, &(lt->base), node);
+		_node_deq_extract(lt, node);
+		_node_destroy(lt, node);
 		-- lt->count;
-    }
+	}
 
-    return TRUE;
+	return TRUE;
 }
 
 gboolean
 lru_tree_get_first(struct lru_tree_s *lt, gpointer *pk, gpointer *pv)
 {
-    EXTRA_ASSERT(lt != NULL);
-    return _get(lt, pk, pv, lt->first, 0);
+	EXTRA_ASSERT(lt != NULL);
+	return _get(lt, pk, pv, lt->first, 0);
 }
 
 gboolean
 lru_tree_steal_first(struct lru_tree_s *lt, gpointer *pk, gpointer *pv)
 {
-    EXTRA_ASSERT(lt != NULL);
-    return _get(lt, pk, pv, lt->first, 1);
+	EXTRA_ASSERT(lt != NULL);
+	return _get(lt, pk, pv, lt->first, 1);
 }
 
 gboolean
 lru_tree_get_last(struct lru_tree_s *lt, gpointer *pk, gpointer *pv)
 {
-    EXTRA_ASSERT(lt != NULL);
-    return _get(lt, pk, pv, lt->last, 0);
+	EXTRA_ASSERT(lt != NULL);
+	return _get(lt, pk, pv, lt->last, 0);
 }
 
 gboolean
 lru_tree_steal_last(struct lru_tree_s *lt, gpointer *pk, gpointer *pv)
 {
-    EXTRA_ASSERT(lt != NULL);
-    return _get(lt, pk, pv, lt->last, 1);
+	EXTRA_ASSERT(lt != NULL);
+	return _get(lt, pk, pv, lt->last, 1);
 }
 
 void
@@ -321,12 +325,10 @@ lru_tree_foreach_TREE(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata)
 void
 lru_tree_foreach_DEQ(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata)
 {
-	struct _node_s *node = NULL;
-
 	EXTRA_ASSERT(lt != NULL);
 	EXTRA_ASSERT(h != NULL);
 
-	for (node = lt->first; node ;node=node->next) {
+	for (struct _node_s *node = lt->first; node ;node=node->next) {
 		if (h(node->k, node->v, hdata))
 			return;
 	}
@@ -337,5 +339,39 @@ lru_tree_count(struct lru_tree_s *lt)
 {
 	EXTRA_ASSERT(lt != NULL);
 	return lt->count;
+}
+
+static void
+_remove_last (struct lru_tree_s *lt)
+{
+	gpointer k = NULL, v = NULL;
+	if (_get(lt, &k, &v, lt->last, TRUE)) {
+		if (k && lt->kfree) lt->kfree (k);
+		if (v && lt->vfree) lt->vfree (v);
+	}
+}
+
+guint
+lru_tree_remove_older (struct lru_tree_s *lt, gint64 oldest)
+{
+	EXTRA_ASSERT(lt != NULL);
+	guint removed = 0;
+	while (lt->last && lt->first->atime < oldest) {
+		_remove_last (lt);
+		++ removed;
+	}
+	return removed;
+}
+
+guint
+lru_tree_remove_exceeding (struct lru_tree_s *lt, guint count)
+{
+	EXTRA_ASSERT(lt != NULL);
+	guint removed = 0;
+	while (lt->last && lt->count > count) {
+		_remove_last (lt);
+		++ removed;
+	}
+	return removed;
 }
 

--- a/metautils/lib/lrutree.c
+++ b/metautils/lib/lrutree.c
@@ -27,7 +27,6 @@ struct _node_s
 	struct _node_s *prev;
 	struct _node_s *next;
 
-	gint64 ctime;
 	gint64 atime;
 	gpointer k;
 	gpointer v;
@@ -186,7 +185,7 @@ lru_tree_insert(struct lru_tree_s *lt, gpointer k, gpointer v)
 	}
 
 	_node_deq_push_front(lt, node);
-	node->ctime = node->atime = oio_ext_monotonic_time ();
+	node->atime = oio_ext_monotonic_time ();
 }
 
 gpointer

--- a/metautils/lib/lrutree.h
+++ b/metautils/lib/lrutree.h
@@ -37,104 +37,40 @@ struct lru_tree_s;
 struct lru_tree_s* lru_tree_create(GCompareFunc compare,
 		GDestroyNotify kfree, GDestroyNotify vfree, guint32 options);
 
-/**
- * Destroys the LRU-Tree and calls the liberation hook for each stored
- * pair.
- *
- * @param lt may be NULL
- */
+/* Destroys the LRU-Tree and calls the liberation hook for each stored
+   pair. */
 void lru_tree_destroy(struct lru_tree_s *lt);
 
-/**
- * Associates 'k' with 'v' in this container.
- *
- * @param lt not NULL
- * @param k not NULL
- * @param v noy NULL
- */
+guint lru_tree_remove_older (struct lru_tree_s *lt, gint64 oldest);
+
+guint lru_tree_remove_exceeding (struct lru_tree_s *lt, guint count);
+
 void lru_tree_insert(struct lru_tree_s *lt, gpointer k, gpointer v);
 
-/**
- * @param lt not NULL
- * @param k not NULL
- * @return the value associated to 'k'
- */
 gpointer lru_tree_get(struct lru_tree_s *lt, gconstpointer k);
 
-/**
- * @param lt not NULL
- * @param k not NULL
- * @return FALSE if removed or something else if the v has been removed.
- */
+/* Returns TRUE if the item keyed with 'k' has been removed. */
 gboolean lru_tree_remove(struct lru_tree_s *lt, gconstpointer k);
 
-/**
- * @param lt not NULL
- * @param k not NULL
- * @return NULL if not found or the 'v' associated to k
- */
+/* Returns NULL if not found or the item associated to 'k' */
 gpointer lru_tree_steal(struct lru_tree_s *lt, gconstpointer k);
 
-/**
- * @param lt not NULL
- * @param pk not NULL
- * @param pv not NULL
- * @return TRUE is pk and pv set
- */
 gboolean lru_tree_get_first(struct lru_tree_s *lt, gpointer *pk,
 		gpointer *pv);
 
-/**
- * @param lt not NULL
- * @param pk not NULL
- * @param pv not NULL
- * @return TRUE is pk and pv set
- */
 gboolean lru_tree_steal_first(struct lru_tree_s *lt, gpointer *pk,
 		gpointer *pv);
 
-/**
- * @param lt not NULL
- * @param pk not NULL
- * @param pv not NULL
- * @return TRUE is pk and pv set
- */
 gboolean lru_tree_get_last(struct lru_tree_s *lt, gpointer *pk,
 		gpointer *pv);
 
-/**
- * @param lt not NULL
- * @param pk not NULL
- * @param pv not NULL
- * @return TRUE is pk and pv set
- */
 gboolean lru_tree_steal_last(struct lru_tree_s *lt, gpointer *pk,
 		gpointer *pv);
 
-/**
- * Run the elements according to the TREE order, i.e. the order got from the
- * comparison function.
- *
- * @param lt not NULL
- * @param h a not NULL hook to be called on each tree element
- * @param hdata a (maybe NULL) arbitrary argument passed to each hook call.
- */
 void lru_tree_foreach_TREE(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata);
 
-/**
- * Run the elementsaccording to their last access order. The last element
- * will be the LRU elements.
- *
- * @see lru_tree_foreach()
- * @param h a not NULL hook to be called on each 2queue element
- * @param hdata a (maybe NULL) arbitrary argument passed to each hook call.
- */
 void lru_tree_foreach_DEQ(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata);
 
-/**
- * @param lt not NULL
- * @return the number of elements in lt
- */
 gint64 lru_tree_count(struct lru_tree_s *lt);
 
 #endif /*OIO_SDS__metautils__lib__lrutree_h*/

--- a/metautils/lib/lrutree.h
+++ b/metautils/lib/lrutree.h
@@ -52,24 +52,7 @@ gpointer lru_tree_get(struct lru_tree_s *lt, gconstpointer k);
 /* Returns TRUE if the item keyed with 'k' has been removed. */
 gboolean lru_tree_remove(struct lru_tree_s *lt, gconstpointer k);
 
-/* Returns NULL if not found or the item associated to 'k' */
-gpointer lru_tree_steal(struct lru_tree_s *lt, gconstpointer k);
-
-gboolean lru_tree_get_first(struct lru_tree_s *lt, gpointer *pk,
-		gpointer *pv);
-
-gboolean lru_tree_steal_first(struct lru_tree_s *lt, gpointer *pk,
-		gpointer *pv);
-
-gboolean lru_tree_get_last(struct lru_tree_s *lt, gpointer *pk,
-		gpointer *pv);
-
-gboolean lru_tree_steal_last(struct lru_tree_s *lt, gpointer *pk,
-		gpointer *pv);
-
-void lru_tree_foreach_TREE(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata);
-
-void lru_tree_foreach_DEQ(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata);
+void lru_tree_foreach(struct lru_tree_s *lt, GTraverseFunc h, gpointer hdata);
 
 gint64 lru_tree_count(struct lru_tree_s *lt);
 

--- a/proxy/cache_actions.c
+++ b/proxy/cache_actions.c
@@ -213,7 +213,6 @@ action_cache_status (struct req_args_s *args)
 	hc_resolver_info (resolver, &s);
 
 	GString *gstr = g_string_new ("{");
-	g_string_append_printf (gstr, " \"clock\":%lu,", s.clock);
 	g_string_append_printf (gstr, " \"csm0\":{"
 		"\"count\":%" G_GINT64_FORMAT ",\"max\":%u,\"ttl\":%lu},",
 		s.csm0.count, s.csm0.max, s.csm0.ttl);

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -57,9 +57,10 @@ service_is_ok (gconstpointer k)
 void
 service_invalidate (gconstpointer k)
 {
-	gulong now = oio_ext_monotonic_time () / G_TIME_SPAN_SECOND;
-	SRV_WRITE(lru_tree_insert (srv_down, g_strdup((const char *)k), (void*)now));
-	GRID_INFO("invalid at %lu %s", now, (const char*)k);
+	gchar *k0 = g_strdup((const char *)k);
+	SRV_WRITE(lru_tree_insert (srv_down, k0, GINT_TO_POINTER(1)));
+	if (GRID_DEBUG_ENABLED())
+		GRID_DEBUG("invalid at %lu %s", oio_ext_monotonic_seconds(), (const char*)k);
 }
 
 const char *
@@ -325,9 +326,8 @@ _request_has_flag (struct req_args_s *args, const char *header,
 void
 service_learn (const char *key)
 {
-	gulong now = oio_ext_monotonic_seconds ();
 	gchar *k = g_strdup(key);
-	SRV_WRITE(lru_tree_insert(srv_known, k, (void*)now));
+	SRV_WRITE(lru_tree_insert(srv_known, k, GINT_TO_POINTER(1)));
 }
 
 gboolean

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -100,18 +100,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern gchar *nsname;
 extern gboolean flag_cache_enabled;
 extern gboolean flag_local_scores;
-extern time_t nsinfo_refresh_m0;
 
 /* how long the proxy remembers the srv it registered ino the conscience */
-extern time_t cs_expire_local_services;
+extern gint64 cs_expire_local_services;
 
 /* how long the proxy remembers dead services */
-/* TODO(jfs): convert time_t seconds to gint64 monotonic microseconds. */
-extern time_t cs_down_services;
+extern gint64 cs_down_services;
 
 /* how long the proxy remembers services from the conscience */
-/* TODO(jfs): convert time_t seconds to gint64 monotonic microseconds. */
-extern time_t cs_known_services;
+extern gint64 cs_known_services;
 
 extern struct grid_lbpool_s *lbpool;
 extern struct hc_resolver_s *resolver;

--- a/proxy/cs_actions.c
+++ b/proxy/cs_actions.c
@@ -292,7 +292,7 @@ action_local_list (struct req_args_s *args)
 		return FALSE;
 	}
 
-	PUSH_DO(lru_tree_foreach_DEQ(srv_registered, _on_service, NULL));
+	PUSH_DO(lru_tree_foreach(srv_registered, _on_service, NULL));
 	g_string_append_c (gs, ']');
 
 	return _reply_success_json (args, gs);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -555,7 +555,7 @@ _task_push (gpointer p)
 	}
 
 	PUSH_DO(lru = push_queue; push_queue = _push_queue_create());
-	lru_tree_foreach_DEQ(lru, _list, NULL);
+	lru_tree_foreach(lru, _list, NULL);
 
 	if (!tmp) {
 		GRID_TRACE("Push: no service to be pushed");

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -34,10 +34,10 @@ static GThread *downstream_thread = NULL;
 guint csurl_refresh_delay = PROXYD_PERIOD_RELOAD_CSURL;
 guint srvtypes_refresh_delay = PROXYD_PERIOD_RELOAD_SRVTYPES;
 guint nsinfo_refresh_delay = PROXYD_PERIOD_RELOAD_NSINFO;
-time_t nsinfo_refresh_m0 = PROXYD_PERIOD_RELOAD_M0INFO;
-time_t cs_expire_local_services = PROXYD_TTL_DEAD_LOCAL_SERVICES;
-time_t cs_down_services = PROXYD_TTL_DOWN_SERVICES;
-time_t cs_known_services = PROXYD_TTL_KNOWN_SERVICES;
+
+gint64 cs_expire_local_services = PROXYD_TTL_DEAD_LOCAL_SERVICES;
+gint64 cs_down_services = PROXYD_TTL_DOWN_SERVICES;
+gint64 cs_known_services = PROXYD_TTL_KNOWN_SERVICES;
 
 // Configuration
 
@@ -45,16 +45,17 @@ static GSList *config_urlv = NULL;
 
 static guint lb_downstream_delay = PROXYD_DEFAULT_PERIOD_DOWNSTREAM;
 static guint lb_upstream_delay = PROXYD_DEFAULT_PERIOD_UPSTREAM;
-static guint dir_low_ttl = PROXYD_DEFAULT_TTL_SERVICES;
+static guint dir_low_ttl = PROXYD_DEFAULT_TTL_SERVICES / G_TIME_SPAN_SECOND;
 static guint dir_low_max = PROXYD_DEFAULT_MAX_SERVICES;
-static guint dir_high_ttl = PROXYD_DEFAULT_TTL_CSM0;
+static guint dir_high_ttl = PROXYD_DEFAULT_TTL_CSM0 / G_TIME_SPAN_SECOND;
 static guint dir_high_max = PROXYD_DEFAULT_MAX_CSM0;
+
+gchar *nsname = NULL;
 gboolean flag_cache_enabled = TRUE;
 gboolean flag_local_scores = FALSE;
 
 struct grid_lbpool_s *lbpool = NULL;
 struct hc_resolver_s *resolver = NULL;
-gchar *nsname = NULL;
 
 GRWLock csurl_rwlock = {0};
 gchar **csurl = NULL;
@@ -105,12 +106,10 @@ action_status(struct req_args_s *args)
 	g_string_append_printf(gstr, "gauge cache.dir.count = %"G_GINT64_FORMAT"\n", s.csm0.count);
 	g_string_append_printf(gstr, "gauge cache.dir.max = %u\n", s.csm0.max);
 	g_string_append_printf(gstr, "gauge cache.dir.ttl = %lu\n", s.csm0.ttl);
-	g_string_append_printf(gstr, "gauge cache.dir.clock = %lu\n", s.clock);
 
 	g_string_append_printf(gstr, "gauge cache.srv.count = %"G_GINT64_FORMAT"\n", s.services.count);
 	g_string_append_printf(gstr, "gauge cache.srv.max = %u\n", s.services.max);
 	g_string_append_printf(gstr, "gauge cache.srv.ttl = %lu\n", s.services.ttl);
-	g_string_append_printf(gstr, "gauge cache.srv.clock = %lu\n", s.clock);
 
 	gint64 cd, ck;
 	SRV_READ(cd = lru_tree_count(srv_down); ck = lru_tree_count(srv_known));
@@ -277,27 +276,12 @@ _push_queue_create (void)
 // Administrative tasks --------------------------------------------------------
 
 static guint
-_expire_services (struct lru_tree_s *lru, time_t delay)
+_expire_services (struct lru_tree_s *lru, const gint64 delay)
 {
-	gchar *k = NULL;
-	gpointer v = NULL;
+	if (delay <= 0) return 0;
+	const gint64 now = oio_ext_monotonic_time();
 	guint count = 0;
-
-	g_assert (delay >= 0);
-	gulong oldest = oio_ext_monotonic_seconds();
-	oldest = (oldest > (gulong)delay) ? oldest - (gulong)delay : 0;
-
-	SRV_WRITE(while (lru_tree_get_last(lru, (void**)&k, &v)) {
-		EXTRA_ASSERT(k != NULL);
-		EXTRA_ASSERT(v != NULL);
-		gulong when = (gulong)v;
-		if (when >= oldest)
-			break;
-		lru_tree_steal_last(lru, (void**)&k, &v);
-		g_free(k);
-		++ count;
-	});
-
+	SRV_WRITE(count = lru_tree_remove_older(lru, OLDEST(now,delay)));
 	return count;
 }
 
@@ -323,13 +307,12 @@ static void
 _task_expire_resolver (gpointer p)
 {
 	(void) p;
-	hc_resolver_set_now (resolver, oio_ext_monotonic_seconds());
-	guint count = hc_resolver_expire (resolver);
-	if (count)
-		GRID_DEBUG ("Expired %u resolver entries", count);
-	count = hc_resolver_purge (resolver);
-	if (count)
-		GRID_DEBUG ("Purged %u resolver ", count);
+	guint count_expire = hc_resolver_expire (resolver);
+	guint count_purge = hc_resolver_purge (resolver);
+	if (count_expire || count_purge) {
+		GRID_DEBUG ("Resolver: expired %u, purged %u",
+				count_expire, count_purge);
+	}
 }
 
 static void
@@ -337,8 +320,6 @@ _local_score_update (const struct service_info_s *si0)
 {
 	gchar *k = service_info_key (si0);
 	STRING_STACKIFY(k);
-	/* XXX(jfs): requires LTO_NOATIME to be set on <srv_registered> to avoid
-	   disturbing the sequence */
 	struct service_info_s *si = lru_tree_get (srv_registered, k);
 	if (si) si->score.value = si0->score.value;
 }
@@ -549,39 +530,16 @@ _task_reload_srvtypes (gpointer p)
 		g_strfreev (newset);
 }
 
-static guint
-_expire_local (time_t pivot, GString *dbg)
-{
-	guint count = 0;
-	gchar *k = NULL;
-	struct service_info_s *si = NULL;
-
-	while (lru_tree_get_last (srv_registered, (void**)&k, (void**)&si)) {
-		if (si->score.timestamp > pivot)
-			break;
-		lru_tree_steal_last (srv_registered, (void**)&k, (void**)&si);
-		if (dbg->len < 128) {
-			if (dbg->len > 0) g_string_append_c (dbg, ',');
-			g_string_append (dbg, k);
-		}
-		g_free (k);
-		service_info_clean (si);
-		++ count;
-	}
-	return count;
-}
-
 static void
 _task_expire_local (gpointer p)
 {
 	(void) p;
-	time_t pivot = oio_ext_monotonic_seconds () - cs_expire_local_services;
-	GString *dbg = g_string_new ("");
+	const gint64 now = oio_ext_monotonic_time ();
+	const gint64 oldest = OLDEST(now,cs_expire_local_services);
 	guint count;
-	PUSH_DO(count = _expire_local (pivot, dbg));
+	PUSH_DO(count = lru_tree_remove_older (srv_registered, oldest));
 	if (count)
-		GRID_INFO("%u local services expired: %s", count, dbg->str);
-	g_string_free (dbg, TRUE);
+		GRID_INFO("%u local services", count);
 }
 
 static void
@@ -941,16 +899,16 @@ grid_main_configure (int argc, char **argv)
 	srv_down = lru_tree_create((GCompareFunc)g_strcmp0, g_free, NULL, LTO_NOATIME);
 	srv_known = lru_tree_create((GCompareFunc)g_strcmp0, g_free, NULL, LTO_NOATIME);
 
-	resolver = hc_resolver_create1 (oio_ext_monotonic_seconds());
+	resolver = hc_resolver_create ();
 	enum hc_resolver_flags_e f = 0;
 	if (!flag_cache_enabled)
 		f |= HC_RESOLVER_NOCACHE;
 	hc_resolver_configure (resolver, f);
 	hc_resolver_qualify (resolver, service_is_ok);
 	hc_resolver_notify (resolver, service_invalidate);
-	hc_resolver_set_ttl_csm0 (resolver, dir_high_ttl);
+	hc_resolver_set_ttl_csm0 (resolver, dir_high_ttl * G_TIME_SPAN_SECOND);
 	hc_resolver_set_max_csm0 (resolver, dir_high_max);
-	hc_resolver_set_ttl_services (resolver, dir_low_ttl);
+	hc_resolver_set_ttl_services (resolver, dir_low_ttl * G_TIME_SPAN_SECOND);
 	hc_resolver_set_max_services (resolver, dir_low_max);
 	GRID_INFO ("RESOLVER limits HIGH[%u/%u] LOW[%u/%u]",
 		dir_high_max, dir_high_ttl, dir_low_max, dir_low_ttl);

--- a/resolver/hc_resolver.h
+++ b/resolver/hc_resolver.h
@@ -46,7 +46,7 @@ struct oio_url_s;
 struct hc_resolver_s;
 
 /* Simple constructor */
-struct hc_resolver_s* hc_resolver_create1(time_t now);
+struct hc_resolver_s* hc_resolver_create(void);
 
 /* Change the internal flags of the resolver */
 void hc_resolver_configure (struct hc_resolver_s *r, enum hc_resolver_flags_e f);
@@ -68,17 +68,13 @@ void hc_resolver_destroy(struct hc_resolver_s *r);
 void hc_resolver_set_max_services(struct hc_resolver_s *r, guint d);
 
 /* @param d max cached entries from meta1 */
-void hc_resolver_set_ttl_services(struct hc_resolver_s *r, time_t d);
-
-/* @param d Timeout for services from conscience and meta0 */
-void hc_resolver_set_ttl_csm0(struct hc_resolver_s *r, time_t d);
+void hc_resolver_set_ttl_services(struct hc_resolver_s *r, gint64 d);
 
 /* @param d max cached services from conscience and meta0 */
 void hc_resolver_set_max_csm0(struct hc_resolver_s *r, guint d);
 
-/* Set the internal clock of the resolver. This has to be done in order
- * to manage expirations. */
-void hc_resolver_set_now(struct hc_resolver_s *r, time_t now);
+/* @param d Timeout for services from conscience and meta0 */
+void hc_resolver_set_ttl_csm0(struct hc_resolver_s *r, gint64 d);
 
 /* Applies time-based cache policies. */
 guint hc_resolver_expire(struct hc_resolver_s *r);
@@ -117,8 +113,6 @@ void hc_decache_reference(struct hc_resolver_s *r, struct oio_url_s *url);
 
 struct hc_resolver_stats_s
 {
-	time_t clock;
-
 	struct {
 		gint64 count;
 		guint max;

--- a/resolver/hc_resolver_internals.h
+++ b/resolver/hc_resolver_internals.h
@@ -44,7 +44,6 @@ struct lru_tree_s;
 
 struct cached_element_s
 {
-	time_t use;
 	guint32 count_elements;
 	gchar s[]; /* Must be the last! */
 };
@@ -52,7 +51,7 @@ struct cached_element_s
 struct lru_ext_s
 {
 	struct lru_tree_s *cache;
-	time_t ttl;
+	gint64 ttl;
 	guint max;
 };
 
@@ -61,7 +60,6 @@ struct hc_resolver_s
 	GMutex lock;
 	struct lru_ext_s services;
 	struct lru_ext_s csm0;
-	time_t bogonow;
 	enum hc_resolver_flags_e flags;
 
 	/* called with the IP:PORT string */

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -37,7 +37,6 @@ License along with this library.
 
 #define EVENTLOG_SIZE 16
 #define STATUS_FINAL(e) ((e) >= STEP_LOST)
-#define OLDEST(now,delay) (now > delay ? now - delay : 0)
 
 typedef guint req_id_t;
 

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -281,7 +281,7 @@ _init_configless_structures(struct sqlx_service_s *ss)
 			|| !(ss->dispatcher = transport_gridd_build_empty_dispatcher())
 			|| !(ss->clients_pool = gridd_client_pool_create())
 			|| !(ss->clients_factory = gridd_client_factory_create())
-			|| !(ss->resolver = hc_resolver_create1(oio_ext_monotonic_time() / G_TIME_SPAN_SECOND))
+			|| !(ss->resolver = hc_resolver_create())
 			|| !(ss->gtq_admin = grid_task_queue_create("admin"))
 			|| !(ss->gtq_reload = grid_task_queue_create("reload"))) {
 		GRID_WARN("SERVICE init error: memory allocation failure");
@@ -788,7 +788,6 @@ _task_expire_resolver(gpointer p)
 	if (!grid_main_is_running ())
 		return;
 
-	hc_resolver_set_now(PSRV(p)->resolver, oio_ext_monotonic_time () / G_TIME_SPAN_SECOND);
 	guint count = hc_resolver_expire(PSRV(p)->resolver);
 	if (count)
 		GRID_DEBUG("Expired %u entries from the resolver cache", count);

--- a/tests/unit/test_lrutree.c
+++ b/tests/unit/test_lrutree.c
@@ -38,11 +38,12 @@ main(int argc, char **argv)
 	lru_tree_get(lt, "plop");
 	lru_tree_get(lt, "plop");
 
-	gpointer k, v;
-	while (lru_tree_steal_first(lt, &k, &v)) {
+	gboolean _func (gpointer k, gpointer v, gpointer i) {
+		(void) i;
 		GRID_DEBUG("K %s %p", (gchar*)k, v);
-		g_free(k);
+		return FALSE;
 	}
+	lru_tree_foreach(lt, _func, NULL);
 
 	lru_tree_destroy(lt);
 	return 0;

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -250,7 +250,7 @@ _repo_wraper(const gchar *ns, gint64 maxvers, repo_test_f fr)
 
 	glp = _init_lb(ns);
 
-	resolver = hc_resolver_create1(oio_ext_monotonic_time() / G_TIME_SPAN_SECOND);
+	resolver = hc_resolver_create();
 	g_assert(resolver != NULL);
 
 	cfg.flags = SQLX_REPO_DELETEON;
@@ -292,7 +292,7 @@ _repo_failure(const gchar *ns)
 
 	glp = _init_lb(ns);
 
-	resolver = hc_resolver_create1(oio_ext_monotonic_time() / G_TIME_SPAN_SECOND);
+	resolver = hc_resolver_create();
 	g_assert(resolver != NULL);
 
 	cfg.flags = SQLX_REPO_DELETEON;


### PR DESCRIPTION
Prior to this set of commits, the LRU cache only managed random accesses in O(log(n)) via a balanced tree, and O(1) to the oldest and earliest items.

There was no "last access time" on items, and such notion has to be managed externally. This was done nearly for every use of the LRU.

So this has been integrated for the sake of simplicity.
