### PR TITLE
m2: add a cache of DB entries required for M2_PREP

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -818,7 +818,7 @@ meta2_backend_add_modified_container(struct meta2_backend_s *m2b,
 	EXTRA_ASSERT(m2b != NULL);
 	if (m2b->notifier)
 		oio_events_queue__send_overwritable(m2b->notifier,
-				g_strdup(sqlx_admin_get_str(sq3, SQLX_ADMIN_BASENAME)),
+				sqlx_admin_get_str(sq3, SQLX_ADMIN_BASENAME),
 				_container_state (sq3));
 }
 
@@ -1307,7 +1307,7 @@ _meta2_backend_force_prepare_data_unlocked(struct meta2_backend_s *m2b,
 	g_free(stgpol);
 
 	if (pdata_out)
-		memmove(pdata_out, pdata, sizeof(struct m2_prepare_data));
+		memcpy(pdata_out, pdata, sizeof(struct m2_prepare_data));
 }
 
 static void
@@ -1359,7 +1359,7 @@ _meta2_backend_get_prepare_data(struct meta2_backend_s *m2b,
 	g_rw_lock_reader_lock(&(m2b->prepare_data_lock));
 	pdata = g_hash_table_lookup(m2b->prepare_data_cache, key);
 	if (pdata)  // do this while still locked
-		memmove(pdata_out, pdata, sizeof(struct m2_prepare_data));
+		memcpy(pdata_out, pdata, sizeof(struct m2_prepare_data));
 	g_rw_lock_reader_unlock(&(m2b->prepare_data_lock));
 
 	if (!pdata) {
@@ -1372,7 +1372,7 @@ _meta2_backend_get_prepare_data(struct meta2_backend_s *m2b,
 			g_rw_lock_writer_lock(&(m2b->prepare_data_lock));
 			pdata = g_hash_table_lookup(m2b->prepare_data_cache, key);
 			if (pdata) {
-				memmove(pdata_out, pdata, sizeof(struct m2_prepare_data));
+				memcpy(pdata_out, pdata, sizeof(struct m2_prepare_data));
 			} else {
 				_meta2_backend_force_prepare_data_unlocked(m2b, key,
 						pdata_out, *sq3);

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -59,6 +59,9 @@ GError* meta2_backend_poll_service(struct meta2_backend_s *m2,
 /** Return a string which contain m2_addr: "IP:PORT" */
 const gchar* meta2_backend_get_local_addr(struct meta2_backend_s *m2);
 
+void meta2_backend_change_callback(struct sqlx_sqlite3_s *sq3,
+		struct meta2_backend_s *m2b);
+
 /* -------------------------------------------------------------------------- */
 
 GError *meta2_backend_create_container(struct meta2_backend_s *m2,

--- a/meta2v2/meta2_backend_internals.h
+++ b/meta2v2/meta2_backend_internals.h
@@ -51,6 +51,10 @@ struct meta2_backend_s
 	gboolean flag_precheck_on_generate;
 
 	gchar ns_name[LIMIT_LENGTH_NSNAME];
+
+	// Cache for admin values useful for M2_PREPARE requests
+	GHashTable *prepare_data_cache;
+	GRWLock prepare_data_lock;
 };
 
 #endif /*OIO_SDS__meta2v2__meta2_backend_internals_h*/

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -182,6 +182,10 @@ _post_config(struct sqlx_service_s *ss)
 	/* Make deleted bases exit the cache */
 	sqlx_repository_configure_close_callback(ss->repository, meta2_on_close, ss);
 
+	/* Make base replications update the cache */
+	sqlx_repository_configure_change_callback(ss->repository,
+			(sqlx_repo_change_hook)meta2_backend_change_callback, m2);
+
 	/* Register meta2 requests handlers */
 	transport_gridd_dispatcher_add_requests(ss->dispatcher,
 			meta2_gridd_get_v2_requests(), m2);

--- a/sqliterepo/replication.c
+++ b/sqliterepo/replication.c
@@ -95,6 +95,13 @@ dump_request(const gchar *func, gchar **targets,
 	g_free(tmp);
 }
 
+static gint
+_compare_rowid(gconstpointer a, gconstpointer b, gpointer unused)
+{
+	(void) unused;
+	return CMP(*(sqlite3_int64*)a, *(sqlite3_int64*)b);
+}
+
 static GTree*
 context_get_pending_table(GTree *tree, const hashstr_t *key)
 {
@@ -103,7 +110,7 @@ context_get_pending_table(GTree *tree, const hashstr_t *key)
 	if (NULL != (subtree = g_tree_lookup(tree, key)))
 		return subtree;
 
-	subtree = g_tree_new_full(hashstr_quick_cmpdata, NULL, g_free, NULL);
+	subtree = g_tree_new_full(_compare_rowid, NULL, g_free, NULL);
 	g_tree_insert(tree, hashstr_dup(key), subtree);
 	return subtree;
 }

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -165,6 +165,8 @@ _init_nsinfo(const gchar *ns, gint64 maxvers)
 	g_snprintf (str, sizeof(str), "%"G_GINT64_FORMAT, maxvers);
 	g_hash_table_insert(nsinfo->options, g_strdup("meta2_max_versions"),
 			metautils_gba_from_string(str));
+	g_hash_table_insert(nsinfo->options, g_strdup("storage_policy"),
+			metautils_gba_from_string("NONE"));
 
 	g_hash_table_insert(nsinfo->storage_policy, g_strdup("classic"),
 			metautils_gba_from_string("DUMMY:DUPONETWO:NONE"));


### PR DESCRIPTION
This prevents opening the database in most cases, and thus saves IO.