### PR TITLE
m0: speed up replication, increase oio-meta0-init timeout

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -215,7 +215,7 @@ extern "C" {
 # endif
 
 # ifndef M0V2_INIT_TIMEOUT
-#  define M0V2_INIT_TIMEOUT 30.0
+#  define M0V2_INIT_TIMEOUT 60.0
 # endif
 
 # ifndef M0V2_CLIENT_TIMEOUT

--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -399,6 +399,8 @@ _fill(struct sqlx_sqlite3_s *sq3, guint replicas, const char * const *m1urls)
 		if (err)
 			 break;
 	}
+	if (!err)
+		sqlx_transaction_notify_huge_changes(repctx);
 	return sqlx_transaction_end(repctx, err);
 }
 
@@ -725,8 +727,11 @@ meta0_backend_assign(struct meta0_backend_s *m0,
 	err = sqlx_transaction_begin(sq3, &repctx);
 	if (NULL == err) {
 		err = _assign_prefixes(sq3->db, new_assign_prefixes,init);
-		if (!err)
+		if (!err) {
 			err = _record_meta1ref(sq3->db, new_assign_meta1ref);
+			if (!err)
+				sqlx_transaction_notify_huge_changes(repctx);
+		}
 		err = sqlx_transaction_end(repctx, err);
 	}
 	_unlock_and_close(sq3);


### PR DESCRIPTION
Force the meta0 slaves to restore the whole database from the master
which is far quicker than using the standard replication mechanism
when a large part of the database has changed.