### PR TITLE
metautils/lb: uses the local PRNG, uniform distribution

### DIFF
--- a/metautils/lib/lb.c
+++ b/metautils/lib/lb.c
@@ -838,10 +838,9 @@ static gboolean
 __next_RAND(struct grid_lb_s *lb, struct service_info_s **si)
 {
 	struct service_info_s *result = NULL;
-	register guint idx = rand();
 
 	grid_lb_lock(lb);
-	result = _get_by_score(lb, idx);
+	result = _get_by_score(lb, oio_ext_rand_int_range(0,lb->size_max));
 	grid_lb_unlock(lb);
 
 	return _result(si, result);
@@ -874,12 +873,11 @@ __next_SRAND(struct grid_lb_s *lb, struct service_info_s **si)
 	}
 
 	struct service_info_s *result = NULL;
-	needle = rand();
 
 	grid_lb_lock(lb);
 	if (lb->gpa->len > 0) {
 		if (lb->sum_scored) {
-			needle = needle % lb->sum_scored;
+			needle = oio_ext_rand_int_range (0, lb->sum_scored);
 			ga = lb->sorted_by_score;
 			result = _get_by_score(lb, dichotomic_search(0, ga->len));
 		}


### PR DESCRIPTION
Uses the local PRNG instead of the libc's rand(), with its guarantee on
the uniform distribution over a given range.

This should lead to better random and should fix the apparent preference
for the first item.