### PR TITLE
conscience: option to unlock scores by default (fix #612)

### DIFF
--- a/cluster/conscience/conscience_srvtype.c
+++ b/cluster/conscience/conscience_srvtype.c
@@ -51,7 +51,8 @@ destroy_gba(gpointer p)
 struct conscience_srvtype_s *
 conscience_srvtype_create(struct conscience_s *conscience, const char *type)
 {
-	struct conscience_srvtype_s *srvtype = g_malloc0(sizeof(struct conscience_srvtype_s));
+	struct conscience_srvtype_s *srvtype =
+			g_malloc0(sizeof(struct conscience_srvtype_s));
 
 	/*sets a default expression that always fits*/
 	if (!conscience_srvtype_set_type_expression(srvtype, NULL, "100")) {
@@ -76,8 +77,10 @@ conscience_srvtype_create(struct conscience_s *conscience, const char *type)
 		g_strlcpy(srvtype->type_name, type, sizeof(srvtype->type_name));
 	srvtype->alert_frequency_limit = 0;
 	srvtype->score_variation_bound = 0;
+	srvtype->lock_at_first_register = TRUE;
 	srvtype->conscience = conscience;
-	srvtype->services_ring.next = srvtype->services_ring.prev = &(srvtype->services_ring);
+	srvtype->services_ring.next = &(srvtype->services_ring);
+	srvtype->services_ring.prev = &(srvtype->services_ring);
 	return srvtype;
 }
 
@@ -362,7 +365,7 @@ conscience_srvtype_refresh(struct conscience_srvtype_s *srvtype, struct service_
 
 	p_srv->score.timestamp = oio_ext_monotonic_seconds ();
 	if (si->score.value == SCORE_UNSET || si->score.value == SCORE_UNLOCK) {
-		if (really_first) {
+		if (really_first && srvtype->lock_at_first_register) {
 			GRID_TRACE2("SRV first [%s]", p_srv->description);
 			p_srv->score.value = 0;
 			p_srv->locked = TRUE;

--- a/cluster/conscience/conscience_srvtype.h
+++ b/cluster/conscience/conscience_srvtype.h
@@ -42,6 +42,7 @@ struct conscience_srvtype_s
 	gint32 score_variation_bound; /**<absolute upper bound to a score increase.*/
 	gchar *score_expr_str;	      /**<String form of the expression*/
 	struct expr_s *score_expr;/**<Preparsed expression*/
+	gboolean lock_at_first_register;
 
 	GHashTable *config_ht;	 /**<Maps (gchar*) to (GByteArray*)*/
 	GByteArray *config_serialized;	/**<Preserialized configuration sent to the agents*/

--- a/cluster/module/module.c
+++ b/cluster/module/module.c
@@ -1016,7 +1016,7 @@ module_configure_srvtype(struct conscience_s *cs, GError ** err,
 	struct conscience_srvtype_s *srvtype;
 
 	if (!what || !value) {
-		GSETERROR(err, "Invalid Key/Value pair : %s/%s", what, value);
+		GSETERROR(err, "Invalid Key/Value pair: %s/%s", what, value);
 		return FALSE;
 	}
 
@@ -1026,29 +1026,39 @@ module_configure_srvtype(struct conscience_s *cs, GError ** err,
 	else
 		srvtype = conscience_get_srvtype(cs, err, type, MODE_AUTOCREATE);
 	if (!srvtype) {
-		GSETERROR(err, "Failled to init a ServiceType");
+		GSETERROR(err, "Failed to init a ServiceType");
 		return FALSE;
 	}
 
 	/*adjust the parameter */
 	if (0 == g_ascii_strcasecmp(what, KEY_SCORE_TIMEOUT)) {
 		srvtype->score_expiration = g_ascii_strtoll(value, NULL, 10);
-		INFO("[NS=%s][SRVTYPE=%s] score expiration interval set to [%ld] seconds", cs->ns_info.name,
-		    srvtype->type_name, srvtype->score_expiration);
+		INFO("[NS=%s][SRVTYPE=%s] score expiration set to [%ld] seconds",
+				cs->ns_info.name, srvtype->type_name,
+				srvtype->score_expiration);
 		return TRUE;
 	}
 	else if (0 == g_ascii_strcasecmp(what, KEY_SCORE_VARBOUND)) {
 		srvtype->score_variation_bound = g_ascii_strtoll(value, NULL, 10);
-		INFO("[NS=%s][SRVTYPE=%s] score variation bound set to [%d]", cs->ns_info.name, srvtype->type_name, srvtype->score_variation_bound);
+		INFO("[NS=%s][SRVTYPE=%s] score variation bound set to [%d]",
+				cs->ns_info.name, srvtype->type_name,
+				srvtype->score_variation_bound);
 		return TRUE;
 	}
 	else if (0 == g_ascii_strcasecmp(what, KEY_SCORE_EXPR)) {
 		if (conscience_srvtype_set_type_expression(srvtype, err, value)) {
-			INFO("[NS=%s][SRVTYPE=%s] score expression set to [%s]", cs->ns_info.name, srvtype->type_name,
-			    value);
+			INFO("[NS=%s][SRVTYPE=%s] score expression set to [%s]",
+					cs->ns_info.name, srvtype->type_name, value);
 			return TRUE;
 		}
 		return FALSE;
+	}
+	else if (0 == g_ascii_strcasecmp(what, KEY_SCORE_LOCK)) {
+		srvtype->lock_at_first_register = metautils_cfg_get_bool(value, TRUE);
+		INFO("[NS=%s][SRVTYPE=%s] lock at first register: %s",
+				cs->ns_info.name, srvtype->type_name,
+				srvtype->lock_at_first_register? "yes":"no");
+		return TRUE;
 	}
 	else if (0 == g_ascii_strcasecmp(what, KEY_ALERT_LIMIT)) {
 		srvtype->alert_frequency_limit = g_ascii_strtoll(value, NULL, 10);
@@ -1056,7 +1066,8 @@ module_configure_srvtype(struct conscience_s *cs, GError ** err,
 		    srvtype->type_name, srvtype->alert_frequency_limit);
 	}
 
-	WARN("[NS=%s][SRVTYPE=%s] parameter not recognized [%s] (ignored!)", cs->ns_info.name, srvtype->type_name, what);
+	WARN("[NS=%s][SRVTYPE=%s] parameter not recognized [%s] (ignored!)",
+			cs->ns_info.name, srvtype->type_name, what);
 	return TRUE;
 }
 

--- a/cluster/module/module.h
+++ b/cluster/module/module.h
@@ -45,6 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define KEY_SCORE_EXPR "score_expr"
 # define KEY_STG_CONF "storage_conf"
 # define KEY_SCORE_VARBOUND "score_variation_bound"
+# define KEY_SCORE_LOCK "lock_at_first_register"
 
 # define DEF_SERIALIZE_SRVINFO_CACHED FALSE
 

--- a/metautils/lib/utils_strings.c
+++ b/metautils/lib/utils_strings.c
@@ -156,8 +156,12 @@ buffer_split(const void *buf, gsize buflen, const gchar *sep, gint max_tokens)
 gboolean
 metautils_cfg_get_bool(const gchar *value, gboolean def)
 {
-	static const gchar *array_yes[] = {"yes", "true", "on", "enable", "enabled", NULL};
-	static const gchar *array_no[] = {"no", "false", "off", "disable", "disabled", NULL};
+	static const gchar *array_yes[] = {
+		"yes", "true", "on", "enable", "enabled", "1", "yeah", NULL
+	};
+	static const gchar *array_no[] = {
+		"no", "false", "off", "disable", "disabled", "0", "nope", NULL
+	};
 
 	if (!value)
 		return def;

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -384,10 +384,12 @@ param_option.storage_policy=${STGPOL}
 
 param_storage_conf=${CFGDIR}/${NS}-policies.conf
 
+param_service.meta0.lock_at_first_register=false
 param_service.meta0.score_timeout=3600
 param_service.meta0.score_variation_bound=5
 param_service.meta0.score_expr=((num stat.cpu)>0) * ((num stat.io)>0) * ((num stat.space)>1) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
 
+param_service.meta1.lock_at_first_register=false
 param_service.meta1.score_timeout=120
 param_service.meta1.score_variation_bound=5
 param_service.meta1.score_expr=((num stat.cpu)>0) * ((num stat.io)>0) * ((num stat.space)>1) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
@@ -412,6 +414,7 @@ param_service.redis.score_timeout=120
 param_service.redis.score_variation_bound=5
 param_service.redis.score_expr=(num stat.cpu)
 
+param_service.oiofs.lock_at_first_register=false
 param_service.oiofs.score_timeout=120
 param_service.oiofs.score_variation_bound=5
 param_service.oiofs.score_expr=(num stat.cpu)


### PR DESCRIPTION
The option is 'lock_at_first_register' and is on by default.
It must be specified per service type, e.g.:
  param_service.meta0.lock_at_first_register=false