### PR TITLE
core: exposes the metachunks boundaries

### DIFF
--- a/core/http_internals.h
+++ b/core/http_internals.h
@@ -122,7 +122,7 @@ GError * oio_proxy_call_container_set_properties (CURL *h,
 /* Get the list of chunks of a content (as JSON),
  * and optionnally the list of response header keys/values. */
 GError * oio_proxy_call_content_show (CURL *h, struct oio_url_s *u,
-		GString *out, char ***hout);
+		GString *out, gchar ***hout);
 
 GError * oio_proxy_call_content_delete (CURL *h, struct oio_url_s *u);
 

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -21,7 +21,7 @@ License along with this library.
 
 /* Version started to be defined in June, 2016. Version prior to 20160600
  * have no ABI incompatibilities. */
-#define OIO_SDS_VERSION 20160600
+#define OIO_SDS_VERSION 20160601
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +42,21 @@ enum oio_sds_config_e
 	/* expects an <int> used for its boolean value */
 	OIOSDS_CFG_FLAG_SYNCATDOWNLOAD,
 };
+
+/* How properties are reported.
+ * @param key the name of the property
+ * @param value its value ... suprising isn't it? */
+typedef void (*oio_sds_property_reporter_f) (void *cb_data,
+		const char *key, const char *value);
+
+/* How hints on the internal chunking are reported.
+ * @param seq the sequence number
+ * @param offset the offset of the metachunk in the whole content
+ * @param length the size of the metachunk */
+typedef void (*oio_sds_metachunk_reporter_f) (void *cb_data,
+		unsigned int seq, size_t offset, size_t length);
+
+
 
 /* API-global --------------------------------------------------------------- */
 
@@ -85,6 +100,8 @@ char ** oio_sds_get_compile_options (void);
 unsigned int oio_sds_version (void);
 #endif /* defined OIO_SDS_VERSION */
 
+
+
 /* Error management --------------------------------------------------------- */
 
 void oio_error_free (struct oio_error_s *e);
@@ -94,6 +111,8 @@ void oio_error_pfree (struct oio_error_s **pe);
 int oio_error_code (const struct oio_error_s *e);
 
 const char * oio_error_message (const struct oio_error_s *e);
+
+
 
 /* Client-related features -------------------------------------------------- */
 
@@ -110,6 +129,8 @@ void oio_sds_pfree (struct oio_sds_s **psds);
 int oio_sds_configure (struct oio_sds_s *sds, enum oio_sds_config_e what,
 		void *pv, unsigned int vlen);
 
+
+
 /* Create / destroy --------------------------------------------------------- */
 
 /* Links the meta2 then triggers container creation */
@@ -118,6 +139,7 @@ struct oio_error_s* oio_sds_create (struct oio_sds_s *sds,
 
 struct oio_error_s* oio_sds_delete_container(struct oio_sds_s *sds,
 					     struct oio_url_s *url);
+
 
 
 /* Download ----------------------------------------------------------------- */
@@ -184,9 +206,21 @@ struct oio_error_s* oio_sds_download (struct oio_sds_s *sds,
 struct oio_error_s* oio_sds_download_to_file (struct oio_sds_s *sds,
 		struct oio_url_s *u, const char *local);
 
-/* --------------------------------------------------------------------------
- * Upload
- * -------------------------------------------------------------------------- */
+/* Tells how is the ccontent internally split.
+ * Helps applications to paginate the downloads, with pages aligned on chunks
+ * boundaries.
+ *
+ * @param cb_data not even checked, implementation-dependant
+ * @param cb_metachunks ignored if NULL
+ * @param cb_props ignoed if NULL */
+struct oio_error_s* oio_sds_show_content (struct oio_sds_s *sds,
+		struct oio_url_s *u, void *cb_data,
+		oio_sds_metachunk_reporter_f cb_metachunks,
+		oio_sds_property_reporter_f cb_props);
+
+
+
+/* Upload ------------------------------------------------------------------- */
 
 struct oio_sds_ul_dst_s
 {
@@ -283,6 +317,7 @@ struct oio_error_s* oio_sds_upload_from_buffer (struct oio_sds_s *sds,
 		struct oio_sds_ul_dst_s *dst, void *base, size_t len);
 
 
+
 /* List --------------------------------------------------------------------- */
 
 struct oio_sds_list_param_s
@@ -342,6 +377,8 @@ struct oio_sds_usage_s
 struct oio_error_s* oio_sds_get_usage (struct oio_sds_s *sds,
 		struct oio_url_s *u, struct oio_sds_usage_s *out);
 
+
+
 /* Misc. -------------------------------------------------------------------- */
 
 /* works with fully qualified urls (content) */
@@ -382,7 +419,6 @@ struct oio_error_s* oio_sds_link (struct oio_sds_s *sds, struct oio_url_s *url,
 struct oio_error_s* oio_sds_link_or_upload (struct oio_sds_s *sds,
 		struct oio_sds_ul_src_s *src, struct oio_sds_ul_dst_s *dst);
 
-/* DEPRECATED --------------------------------------------------------------- */
 
 #ifdef __cplusplus
 }

--- a/core/proxy.c
+++ b/core/proxy.c
@@ -1,4 +1,3 @@
-
 /*
 OpenIO SDS core library
 Copyright (C) 2015 OpenIO, original work as part of OpenIO Software Defined Storage
@@ -496,7 +495,7 @@ oio_proxy_call_content_set_properties (CURL *h, struct oio_url_s *u,
 
 GError *
 oio_proxy_call_content_show (CURL *h, struct oio_url_s *u, GString *out,
-		char ***hout)
+		gchar ***hout)
 {
 	GString *http_url = _curl_content_url (u, "show");
 	if (!http_url) return BADNS();

--- a/core/sds.c
+++ b/core/sds.c
@@ -924,7 +924,9 @@ _download_to_buffer (struct oio_sds_s *sds, struct oio_sds_dl_src_s *src,
 			total += (*p)->size;
 		if (total > dst->data.buffer.length)
 			return (struct oio_error_s*) NEWERROR (CODE_BAD_REQUEST,
-					"Buffer too small for the specified ranges");
+					"Buffer too small (%"G_GSIZE_FORMAT") "
+					"for the specified ranges (%"G_GSIZE_FORMAT")",
+					dst->data.buffer.length, total);
 	} else {
 		/* No range specified: we need more information to fake a range, e.g.
 		 * the first 'dst->data.buffer.length' of the content. */

--- a/core/tool_roundtrip.c
+++ b/core/tool_roundtrip.c
@@ -139,16 +139,18 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	GRID_INFO("The original file and its copy match");
 
 	/* Get it an other way in a buffer. */
-	guint8 buf[1024];
-	struct oio_sds_dl_dst_s dl_dst = {
-		.type = OIO_DL_DST_BUFFER,
-		.data = {.buffer = {.ptr = buf, .length=1024}}
-	};
-	struct oio_sds_dl_src_s dl_src = {
-		.url = url,
-		.ranges = NULL,
-	};
-	err = oio_sds_download (client, &dl_src, &dl_dst);
+	do {
+		guint8 buf[1024];
+		struct oio_sds_dl_dst_s dl_dst = {
+			.type = OIO_DL_DST_BUFFER,
+			.data = {.buffer = {.ptr = buf, .length=1024}}
+		};
+		struct oio_sds_dl_src_s dl_src = {
+			.url = url,
+			.ranges = NULL,
+		};
+		err = oio_sds_download (client, &dl_src, &dl_dst);
+	} while (0);
 	MAYBERETURN(err, "Download error");
 	GRID_INFO("Content downloaded to a buffer");
 
@@ -192,9 +194,13 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	g_strfreev(elts);
 
 	/* get details on the content */
+	gsize max_offset = 0;
+	gsize max_size = 0;
 	void _on_metachunk (void *i UNUSED, guint seq, gsize offt, gsize len) {
 		GRID_INFO("metachunk: %u, %"G_GSIZE_FORMAT" %"G_GSIZE_FORMAT,
 				seq, offt, len);
+		max_offset = MAX(max_offset, offt);
+		max_size = MAX(max_size, offt+len);
 	}
 	void _on_property (void *i UNUSED, const char *k, const char *v) {
 		GRID_INFO("property: '%s' -> '%s'", k, v);
@@ -202,12 +208,58 @@ _roundtrip_common (struct oio_sds_s *client, struct oio_url_s *url,
 	err = oio_sds_show_content (client, url, NULL, _on_metachunk, _on_property);
 	MAYBERETURN(err, "Show error");
 
+	/* if there is more than one metachunk, voluntarily ask a range crossing
+	 * the borders of a metachunk */
+	if (max_offset > 0 && max_size > 0 && max_offset != max_size) {
+		GRID_DEBUG("max_offset=%"G_GSIZE_FORMAT" max_size=%"G_GSIZE_FORMAT,
+				max_offset, max_size);
+		struct oio_sds_dl_range_s range = {
+			.offset = max_offset - 1,
+			.size = 2,
+		};
+		struct oio_sds_dl_range_s *rangev[] = { &range, NULL };
+		struct oio_sds_dl_src_s dl_src = { .url = url, .ranges = rangev, };
+
+		/* first attempt with a buffer voluntarily too small */
+		guint8 buf[2];
+		struct oio_sds_dl_dst_s dl_dst = {
+			.type = OIO_DL_DST_BUFFER,
+			.data = {.buffer = {.ptr = buf, .length=1}}
+		};
+		err = oio_sds_download (client, &dl_src, &dl_dst);
+		if (!err)
+			return (struct oio_error_s*)SYSERR("Unexpected success: DL of a range in a buffer too small");
+		g_clear_error ((GError**)&err);
+
+		/* second attempt with a buffer exactly the expected size */
+		dl_dst.data.buffer.length = 2;
+		err = oio_sds_download (client, &dl_src, &dl_dst);
+		MAYBERETURN(err, "Download error");
+		GRID_INFO("Content downloaded to a buffer");
+
+		/* try to download the end of a metachunk */
+		dl_dst.data.buffer.length = 2;
+		range.offset = max_offset - 1;
+		range.size = 1;
+		err = oio_sds_download (client, &dl_src, &dl_dst);
+		MAYBERETURN(err, "Download error");
+		GRID_INFO("Content downloaded to a buffer");
+
+		/* try to download the start of a metachunk */
+		dl_dst.data.buffer.length = 2;
+		range.offset = max_offset;
+		range.size = 1;
+		err = oio_sds_download (client, &dl_src, &dl_dst);
+		MAYBERETURN(err, "Download error");
+		GRID_INFO("Content downloaded to a buffer");
+	}
+
 	/* Remove the content from the content */
 	err = oio_sds_delete (client, url);
 	MAYBERETURN(err, "Delete error");
 	GRID_INFO("Content removed");
 
-	/* Check the content is not preset anymore */
+	/* Check the content is not present anymore */
 	has = 0;
 	err = oio_sds_has (client, url, &has);
 	if (!err && has) err = (struct oio_error_s*) NEWERROR(0, "content still present");


### PR DESCRIPTION
Allows a client application to know the about how the content has been split. Useful to align ranges on metachunks borders.