### PR TITLE
oio-reset.sh: zookeeper untouched when not concerned

### DIFF
--- a/etc/bootstrap-17COPIES.yml
+++ b/etc/bootstrap-17COPIES.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "17COPIES"
 chunk_size: 1048576
 redis: true

--- a/etc/bootstrap-3COPIES-11RAWX.yml
+++ b/etc/bootstrap-3COPIES-11RAWX.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "THREECOPIES"
 chunk_size: 1048576
 redis: true

--- a/etc/bootstrap-3COPIES-3RAWX.yml
+++ b/etc/bootstrap-3COPIES-3RAWX.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "THREECOPIES"
 chunk_size: 1048576
 redis: true

--- a/etc/bootstrap-BACKBLAZE.yml
+++ b/etc/bootstrap-BACKBLAZE.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "BACKBLAZE"
 chunk_size: 1048576
 redis: true

--- a/etc/bootstrap-EC.yml
+++ b/etc/bootstrap-EC.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "EC"
 chunk_size: 1048576
 redis: true

--- a/etc/bootstrap-SINGLE.yml
+++ b/etc/bootstrap-SINGLE.yml
@@ -1,4 +1,3 @@
-zookeeper: false
 storage_policy: "SINGLE"
 chunk_size: 1048576
 redis: true

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -1287,7 +1287,7 @@ def main():
 
     options = parser.parse_args()
     opts = {}
-    opts[ZOOKEEPER] = True
+    opts[ZOOKEEPER] = False
     opts['conscience'] = {SVC_NB: None}
     opts['meta0'] = {SVC_NB: None}
     opts['meta1'] = {SVC_NB: None}


### PR DESCRIPTION
When zookeeper is set to 'false', it overrides any zookeeper config from
any other file specified before on the CLI. To avoid giving to much
importance to the order of configs, let's leave zookeeper untouched when
not concerned.