### PR TITLE
oio/core: adding master / slave state and admin requests

### DIFF
--- a/cluster/lib/gridcluster.c
+++ b/cluster/lib/gridcluster.c
@@ -46,6 +46,7 @@ License along with this library.
 #define NS_CONTAINER_MAX_SIZE_NAME "container_max_size"
 #define NS_STORAGE_POLICY_NAME "storage_policy"
 #define NS_CHUNK_SIZE_NAME "chunk_size"
+#define NS_STATE_NAME "state"
 #define NS_WORM_OPT_VALUE_ON "on"
 #define NS_COMPRESS_OPT_NAME "compression"
 #define NS_COMPRESS_OPT_VALUE_ON "on"
@@ -317,6 +318,13 @@ namespace_in_worm_mode(namespace_info_t* ns_info)
 {
 	GByteArray *val = namespace_param_gba(ns_info, NULL, NS_WORM_OPT_NAME);
 	return _gba_to_bool(val, FALSE);
+}
+
+gchar *
+namespace_get_state(namespace_info_t* ns_info)
+{
+	return gridcluster_get_nsinfo_strvalue(ns_info, NS_STATE_NAME,
+					       NS_STATE_VALUE_STAND_ALONE);
 }
 
 gint64

--- a/cluster/lib/gridcluster.h
+++ b/cluster/lib/gridcluster.h
@@ -46,6 +46,8 @@ GError* register_namespace_service (const struct service_info_s *si);
 
 gboolean namespace_in_worm_mode(namespace_info_t* ns_info);
 
+gchar * namespace_get_state(namespace_info_t* ns_info);
+	
 gint64 namespace_container_max_size(namespace_info_t* ns_info);
 
 gint64 namespace_chunk_size(const namespace_info_t* ns_info, const char *ns_name);

--- a/core/ext.c
+++ b/core/ext.c
@@ -170,6 +170,7 @@ oio_ext_extract_json (struct json_object *obj,
 struct oio_ext_local_s {
 	gchar *reqid;
 	GRand *prng;
+	gboolean is_admin;
 };
 
 static void
@@ -255,6 +256,21 @@ oio_ext_set_random_reqid (void)
 	oio_str_bin2hex((guint8*)&bulk, sizeof(bulk), hex, sizeof(hex));
 	oio_ext_set_reqid(hex);
 }
+
+gboolean
+oio_ext_is_admin (void)
+{
+	const struct oio_ext_local_s *l = _local_ensure ();
+	return l->is_admin;
+}
+
+void
+oio_ext_set_admin (const gboolean admin)
+{
+	struct oio_ext_local_s *l = _local_ensure ();
+	l->is_admin = admin;
+}
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/core/headers.c
+++ b/core/headers.c
@@ -30,6 +30,7 @@ oio_headers_common (struct oio_headers_s *h)
 {
 	oio_headers_add (h, "Expect", "");
 	oio_headers_add (h, PROXYD_HEADER_REQID, oio_ext_get_reqid());
+	oio_headers_add (h, PROXYD_HEADER_ADMIN, oio_ext_is_admin()?"1":"0");
 }
 
 void

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -41,6 +41,9 @@ enum oio_sds_config_e
 
 	/* expects an <int> used for its boolean value */
 	OIOSDS_CFG_FLAG_SYNCATDOWNLOAD,
+
+	/* expects an <int> used for its boolean value */
+	OIOSDS_CFG_FLAG_ADMIN,
 };
 
 enum oio_sds_content_key_e

--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -70,6 +70,10 @@ extern "C" {
 #  define PROXYD_HEADER_REQID PROXYD_HEADER_PREFIX "req-id"
 # endif
 
+# ifndef PROXYD_HEADER_ADMIN
+# define PROXYD_HEADER_ADMIN PROXYD_HEADER_PREFIX "admin"
+# endif
+
 # ifndef PROXYD_HEADER_NOEMPTY
 #  define PROXYD_HEADER_NOEMPTY PROXYD_HEADER_PREFIX "no-empty-list"
 # endif

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -103,6 +103,10 @@ gint32 oio_ext_rand_int_range (gint32 low, gint32 up);
 /** Get a request-id stored in the thread-local, or NULL if not set */
 const char * oio_ext_get_reqid (void);
 
+gboolean oio_ext_is_admin(void);
+
+void oio_ext_set_admin(const gboolean admin);
+
 gint64 oio_ext_real_time (void);
 
 gint64 oio_ext_monotonic_time (void);

--- a/etc/bootstrap-SLAVE.yml
+++ b/etc/bootstrap-SLAVE.yml
@@ -1,0 +1,7 @@
+zookeeper: false
+state: "slave"
+storage_policy: "THREECOPIES"
+chunk_size: 1048576
+redis: true
+rawx:
+  count: 3

--- a/etc/bootstrap-WORM.yml
+++ b/etc/bootstrap-WORM.yml
@@ -1,0 +1,7 @@
+zookeeper: false
+worm: true
+storage_policy: "THREECOPIES"
+chunk_size: 1048576
+redis: true
+rawx:
+  count: 3

--- a/meta2v2/meta2_filters.h
+++ b/meta2v2/meta2_filters.h
@@ -70,6 +70,7 @@ M2V2_DECLARE_FILTER(meta2_filter_extract_header_append);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_string_size);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_optional_overwrite);
 M2V2_DECLARE_FILTER(meta2_filter_extract_list_params);
+M2V2_DECLARE_FILTER(meta2_filter_extract_admin);
 
 M2V2_DECLARE_FILTER(meta2_filter_fill_subject);
 M2V2_DECLARE_FILTER(meta2_filter_reply_success);

--- a/meta2v2/meta2_filters_extract.c
+++ b/meta2v2/meta2_filters_extract.c
@@ -283,6 +283,17 @@ meta2_filter_extract_header_optional_overwrite(struct gridd_filter_ctx_s *ctx,
 }
 
 int
+meta2_filter_extract_admin(struct gridd_filter_ctx_s *ctx,
+			     struct gridd_reply_ctx_s *reply)
+{
+	GError *e = NULL;
+	gchar buf[1024];
+	TRACE_FILTER();
+	EXTRACT_OPT(NAME_MSGKEY_ADMIN_COMMAND);
+	return FILTER_OK;
+}
+
+int
 meta2_filter_extract_list_params(struct gridd_filter_ctx_s *ctx,
         struct gridd_reply_ctx_s *reply)
 {

--- a/meta2v2/meta2_gridd_dispatcher.c
+++ b/meta2v2/meta2_gridd_dispatcher.c
@@ -83,6 +83,7 @@ meta2_dispatch_all(struct gridd_reply_ctx_s *reply,
 static gridd_filter M2V2_CREATE_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -100,6 +101,7 @@ static gridd_filter M2V2_CREATE_FILTERS[] =
 static gridd_filter M2V2_DESTROY_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -141,6 +143,7 @@ static gridd_filter M2V2_HAS_FILTERS[] =
 static gridd_filter M2V2_PURGE_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -264,6 +267,7 @@ static gridd_filter M2V2_PUT_FILTERS[] =
 	meta2_filter_extract_header_copy,
 	meta2_filter_extract_header_optional_overwrite,
 	meta2_filter_extract_header_localflag,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -279,6 +283,7 @@ static gridd_filter M2V2_APPEND_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_localflag,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -308,6 +313,7 @@ static gridd_filter M2V2_DELETE_FILTERS[] =
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_localflag,
 	meta2_filter_extract_header_flags32,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -323,6 +329,7 @@ static gridd_filter M2V2_TRUNCATE_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_string_size,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -338,6 +345,7 @@ static gridd_filter M2V2_TRUNCATE_FILTERS[] =
 static gridd_filter M2V2_PROPSET_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -385,6 +393,7 @@ static gridd_filter M2V2_EXITELECTION_FILTERS[] =
 static gridd_filter M2V2_RAW_DEL_filters[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_check_url_cid,
 	meta2_filter_fill_subject,
 	meta2_filter_check_backend,
@@ -400,6 +409,7 @@ static gridd_filter M2V2_RAW_DEL_filters[] =
 static gridd_filter M2V2_RAW_ADD_filters[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,
@@ -415,6 +425,7 @@ static gridd_filter M2V2_RAW_ADD_filters[] =
 static gridd_filter M2V2_RAW_SUBST_filters[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_admin,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
 	meta2_filter_check_backend,

--- a/metautils/lib/comm_message.c
+++ b/metautils/lib/comm_message.c
@@ -122,6 +122,9 @@ message_marshall_gba(MESSAGE m, GError **err)
 		reqid = oio_ext_get_reqid ();
 		metautils_message_set_ID(m, (guint8*)reqid, strlen(reqid));
 	}
+	const gboolean admin = oio_ext_is_admin();
+	metautils_message_add_field_strint(m, NAME_MSGKEY_ADMIN_COMMAND,
+					   admin?1:0);
 
 	/*try to encode */
 	guint32 u32 = 0;

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -122,6 +122,14 @@ License along with this library.
 #define NAME_MSGKEY_VERPOLICY          "VP"
 #define NAME_MSGKEY_VERSION            "VER"
 
+#define NS_STATE_VALUE_MASTER "master"
+#define NS_STATE_VALUE_SLAVE "slave"
+#define NS_STATE_VALUE_STAND_ALONE "stand_alone"
+
+#define NAME_MSGKEY_ADMIN_COMMAND      "ADM_CMD"
+#define NAME_MSGKEY_NS_STATE      "STT"
+#define NAME_MSGKEY_WORMED      "WRM"
+
 #define NAME_MSGKEY_PREFIX_PROPERTY    "P:"
 
 enum {

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -13,6 +13,7 @@
 
 from oio.common import exceptions
 from oio.common.http import requests
+from oio.common.constants import ADMIN_HEADER
 
 
 class API(object):
@@ -26,6 +27,7 @@ class API(object):
             session = requests.Session()
         self.session = session
         self.endpoint = endpoint
+        self.admin_mode = kwargs.get('admin_mode', False)
 
     def _request(self, method, url, endpoint=None, session=None, **kwargs):
         if not endpoint:
@@ -34,7 +36,10 @@ class API(object):
         if not session:
             session = self.session
         headers = kwargs.get('headers') or {}
-        kwargs['headers'] = dict([k, str(headers[k])] for k in headers)
+        headers = dict([k, str(headers[k])] for k in headers)
+        value_admin = "1" if self.admin_mode else "0"
+        headers.update({ADMIN_HEADER: value_admin})
+        kwargs['headers'] = headers
         resp = session.request(method, url, **kwargs)
         try:
             body = resp.json()

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -137,7 +137,8 @@ class ObjectStorageAPI(API):
         self.directory = DirectoryAPI(
             namespace,
             endpoint,
-            session=self.session
+            session=self.session,
+            admin_mode=self.admin_mode
         )
         self.namespace = namespace
 

--- a/oio/cli/clientmanager.py
+++ b/oio/cli/clientmanager.py
@@ -34,6 +34,7 @@ class ClientManager(object):
         self.session = None
         self.namespace = None
         self.setup_done = False
+        self._admin_mode = False
         root_logger = logging.getLogger('')
         LOG.setLevel(root_logger.getEffectiveLevel())
 
@@ -51,6 +52,11 @@ class ClientManager(object):
             LOG.info('Using parameters %s' % self._options)
             self.session = requests.Session()
             self.setup_done = True
+            self._admin_mode = self._options.get('admin_mode')
+
+    def get_admin_mode(self):
+        self.setup()
+        return self._admin_mode
 
     def get_endpoint(self, service_type):
         self.setup()

--- a/oio/cli/shell.py
+++ b/oio/cli/shell.py
@@ -82,6 +82,11 @@ class OpenIOShell(app.App):
             default=utils.env('OIO_PROXYD_URL'),
             help='Proxyd URL (Env: OIO_PROXYD_URL)'
         )
+        parser.add_argument(
+            "--admin",
+            dest='admin_mode',
+            action='store_true',
+            help='passing commands into admin mode')
 
         return clientmanager.build_plugin_option_parser(parser)
 
@@ -101,7 +106,8 @@ class OpenIOShell(app.App):
         options = {
             'namespace': self.options.ns,
             'account_name': self.options.account_name,
-            'proxyd_url': self.options.proxyd_url
+            'proxyd_url': self.options.proxyd_url,
+            'admin_mode': self.options.admin_mode
         }
 
         self.print_help_if_requested()

--- a/oio/cli/storage/client.py
+++ b/oio/cli/storage/client.py
@@ -7,11 +7,13 @@ API_NAME = 'storage'
 
 
 def make_client(instance):
+    admin_mode = instance.get_admin_mode()
     endpoint = instance.get_endpoint('storage')
     client = ObjectStorageAPI(
         session=instance.session,
         endpoint=endpoint,
-        namespace=instance.namespace
+        namespace=instance.namespace,
+        admin_mode=admin_mode
     )
     return client
 

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -11,6 +11,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+HEADER_PREFIX = 'x-oio-'
+ADMIN_HEADER = HEADER_PREFIX + 'admin'
+
 CONTAINER_METADATA_PREFIX = "x-oio-container-meta-"
 OBJECT_METADATA_PREFIX = "x-oio-content-meta-"
 CHUNK_METADATA_PREFIX = "x-oio-chunk-meta-"

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -164,7 +164,8 @@ class ContainerClient(Client):
                        **kwargs):
         uri = self._make_uri('content/delete')
         params = self._make_params(acct, ref, path, cid=cid)
-        resp, body = self._request('POST', uri, params=params)
+        hdrs = gen_headers()
+        resp, body = self._request('POST', uri, params=params, headers=hdrs)
 
     def content_show(self, acct=None, ref=None, path=None, cid=None,
                      content=None, **kwargs):

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -216,6 +216,10 @@ handler_action (struct http_request_s *rq, struct http_reply_ctx_s *rp)
 	else
 		oio_ext_set_random_reqid();
 
+	const gchar *admin = g_tree_lookup (rq->tree_headers, PROXYD_HEADER_ADMIN);
+	gboolean is_admin;
+	is_admin = metautils_cfg_get_bool(admin, FALSE);
+	oio_ext_set_admin(is_admin);
 	// Then parse the request to find a handler
 	struct oio_url_s *url = NULL;
 	struct oio_requri_s ruri = {NULL, NULL, NULL, NULL};

--- a/tests/functional/m2_filters/test_filters.py
+++ b/tests/functional/m2_filters/test_filters.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016 OpenIO, original work as part of
+# OpenIO Software Defined Storage
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import StringIO
+
+import os
+import time
+import mock
+
+from oio.blob.client import BlobClient
+from oio.common.exceptions import ClientException
+from oio.common.utils import cid_from_name
+from oio.common.constants import ADMIN_HEADER
+from oio.container.client import ContainerClient
+from oio.content.factory import ContentFactory
+from tests.utils import BaseTestCase
+
+
+def random_data(data_size):
+    return os.urandom(data_size)
+
+
+def gen_headers_mock():
+    hdrs = {'x-oio-action-mode': 'autocreate',
+            ADMIN_HEADER: '1'}
+    return hdrs
+
+
+class TestFilters(BaseTestCase):
+
+    def setUp(self):
+        with mock.patch('oio.container.client.gen_headers',
+                        gen_headers_mock):
+            super(TestFilters, self).setUp()
+            self.account = self.conf['account']
+            self.namespace = self.conf['namespace']
+            self.chunk_size = self.conf['chunk_size']
+            self.gridconf = {'namespace': self.namespace}
+            self.content_factory = ContentFactory(self.gridconf)
+            self.container_name = 'TestFilter%f' % time.time()
+            self.blob_client = BlobClient()
+            self.container_client = ContainerClient(self.gridconf)
+            self.container_client.container_create(acct=self.account,
+                                                   ref=self.container_name)
+            self.container_id = cid_from_name(self.account,
+                                              self.container_name).upper()
+            self.stgpol = "SINGLE"
+
+    def _new_content(self, data, path):
+        old_content = self.content_factory.new(self.container_id, path,
+                                               len(data), self.stgpol)
+        old_content.create(StringIO.StringIO(data))
+        return self.content_factory.get(self.container_id,
+                                        old_content.content_id)
+
+    def test_slave_and_admin(self):
+        if not os.getenv("SLAVE"):
+            self.skipTest("must be in slave mode")
+        data = random_data(10)
+        path = 'test_slave'
+        try:
+            self._new_content(data, path)
+            self.assertTrue(None)
+        except ClientException as e:
+            print str(e)
+            self.assertTrue(str(e).find('NS slave!') != -1)
+        with mock.patch('oio.container.client.gen_headers', gen_headers_mock):
+            content = self._new_content(data, path)
+            content.delete()
+
+    def test_worm_and_admin(self):
+        if not os.getenv("WORM"):
+            self.skipTest("must be in worm mode")
+        data = random_data(10)
+        path = 'test_worm'
+        content = self._new_content(data, path)
+        try:
+            content.delete()
+            self.assertTrue(None)
+        except ClientException as e:
+            self.assertTrue(str(e).find('NS wormed!') != -1)
+        downloaded_data = ''.join(content.fetch())
+        self.assertEqual(downloaded_data, data)
+        with mock.patch('oio.container.client.gen_headers', gen_headers_mock):
+            content.delete()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,6 +17,9 @@ set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/.timestamp")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-unlock-all.sh
 		${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-unlock-all.sh
 		@ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-flush-all.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-flush-all.sh
+		@ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-wait-scored.sh
 		${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-wait-scored.sh
 		@ONLY)
@@ -53,6 +56,7 @@ install(PROGRAMS
 			zk-bootstrap.py
 			zk-reset.py
 			${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-unlock-all.sh
+			${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-flush-all.sh
 			${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-wait-scored.sh
 			${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-bootstrap.py
 			${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-test-config.py

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -377,6 +377,8 @@ param_option.meta2.events-max-pending=1000
 param_option.sqlx.events-max-pending=1000
 param_option.meta1.events-max-pending=100
 param_option.meta2.events-buffer-delay=5
+param_option.state=${STATE}
+param_option.worm=${WORM}
 
 param_option.service_update_policy=meta2=KEEP|${M2_REPLICAS}|${M2_DISTANCE};sqlx=KEEP|${SQLX_REPLICAS}|${SQLX_DISTANCE}|;rdir=KEEP|1|1|user_is_a_service=1
 
@@ -858,6 +860,11 @@ BUCKET_NAME = 'bucket_name'
 COMPRESSION = 'compression'
 APPLICATION_KEY = 'application_key'
 KEY_FILE='key_file'
+WORMED="worm"
+NS_STATE="state"
+MASTER_VALUE="master"
+SLAVE_VALUE="slave"
+STAND_ALONE_VALUE="stand_alone"
 
 defaults = {
     'NS': 'OPENIO',
@@ -952,6 +959,11 @@ def generate(options):
     backblaze_account_id = options.get('backblaze', {}).get(ACCOUNT_ID)
     backblaze_bucket_name = options.get('backblaze', {}).get(BUCKET_NAME)
     backblaze_app_key = options.get('backblaze', {}).get(APPLICATION_KEY)
+    is_wormed = options.get('worm', False)
+    worm = '1' if is_wormed else '0'
+    state = options.get("state", None)
+    if state not in [MASTER_VALUE, SLAVE_VALUE, STAND_ALONE_VALUE]:
+        state = STAND_ALONE_VALUE
     key_file = options.get(KEY_FILE, CFGDIR + '/' + 'application_keys.cfg')
     ENV = dict(IP=ip,
                NS=ns,
@@ -986,7 +998,9 @@ def generate(options):
                BACKBLAZE_BUCKET_NAME=backblaze_bucket_name,
                BACKBLAZE_APPLICATION_KEY=backblaze_app_key,
                KEY_FILE=key_file,
-               HTTPD_BINARY=HTTPD_BINARY)
+               HTTPD_BINARY=HTTPD_BINARY,
+               STATE=state,
+               WORM=worm)
 
     def merge_env(add):
         env = dict(ENV)

--- a/tools/oio-flush-all.sh
+++ b/tools/oio-flush-all.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# @EXE_PREFIX@-flush-all, a CLI tool of OpenIO
+# Copyright (C) 2016 OpenIO, original work as part of OpenIO Software Defined Storage
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+set -e
+
+PREFIX="@EXE_PREFIX@"
+NS=
+
+list () {
+    oio-test-config.py -t meta0 -t meta1 -t meta2
+}
+
+while getopts "s:n:l" opt ; do
+    case $opt in
+	n) NS="${OPTARG}" ;;
+	\?) exit 1 ;;
+    esac
+done
+
+if [ -z "$NS" ] ; then
+    echo "No namespace configured"
+    exit 1
+fi
+
+PROXY_URL=`oio-test-config.py -t proxy -1`
+
+if [ -z "$PROXY_URL" ] ; then
+    echo "No proxy configured"
+    exit 1
+fi
+
+list | while read services;
+do
+    RESPONSE=$(curl -sS -X POST "http://${PROXY_URL}/v3.0/forward/flush?id=${services}")
+done

--- a/tools/oio-reset.sh
+++ b/tools/oio-reset.sh
@@ -174,6 +174,7 @@ timestamp
 # unlock all services
 $PREFIX-unlock-all.sh -n "$NS"
 $PREFIX-wait-scored.sh -n "$NS" -t 60
+$PREFIX-flush-all.sh -n "$NS"
 
 timestamp
 find $SDS -type d | xargs chmod a+rx

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -40,10 +40,38 @@ func_tests () {
 	./core/tool_roundtrip /etc/passwd
 }
 
+test_worm () {
+    export OIO_NS="NS-${RANDOM}" OIO_ACCOUNT="ACCT-$RANDOM" OIO_USER=USER-$\
+	   RANDOM OIO_PATH=PATH-$RANDOM
+    oio-reset.sh -v -v -N $OIO_NS $@
+    echo -e "END OF RESET" | logger -t TEST
+    cd $SRCDIR
+    export WORM=1
+    tox
+    echo "test_filters: begin WORM test"
+    nosetests tests.functional.m2_filters.test_filters
+    unset WORM
+}
+
+test_slave () {
+    export OIO_NS="NS-${RANDOM}" OIO_ACCOUNT="ACCT-$RANDOM" OIO_USER=USER-$\
+	   RANDOM OIO_PATH=PATH-$RANDOM
+    oio-reset.sh -v -v -N $OIO_NS $@
+    echo -e "END OF RESET" | logger -t TEST
+    cd $SRCDIR
+    export SLAVE=1
+    tox
+    echo "test_filters: begin SLAVE test"
+    nosetests tests.functional.m2_filters.test_filters
+    unset SLAVE
+}
+
 echo -e "\n### UNIT tests\n"
 cd $WRKDIR
 make -C tests/unit test
 
+test_worm -f "${SRCDIR}/etc/bootstrap-WORM.yml"
+test_slave -f "${SRCDIR}/etc/bootstrap-SLAVE.yml"
 func_tests -f "${SRCDIR}/etc/bootstrap-SINGLE.yml"
 func_tests -f "${SRCDIR}/etc/bootstrap-3COPIES-11RAWX.yml"
 func_tests -f "${SRCDIR}/etc/bootstrap-EC.yml"


### PR DESCRIPTION
To use admin mode, two methods are available

with the python cli, you can use the --admin param to pass in admin mode
with the C SDK, you can use oio_sds_configure with the OIOSDS_CFG_FLAG_ADMIN flag

to enable worm mode, you must add worm=true inside your oio-reset config file.
to modify the state of the NS (slave or master mode), you must add state='master' or 'slave' inside the oio-reset config file
By default, the state is in stand_alone mode.

This PR add also a new script named oio-flush-all, who flush all caches of meta0, meta1 and meta2.