### PR TITLE
core: force usage of old fmemopen with glibc >= 2.22

### DIFF
--- a/core/sds.c
+++ b/core/sds.c
@@ -61,6 +61,12 @@ struct oio_url_s;
 
 unsigned int oio_sds_version (void) { return OIO_SDS_VERSION; }
 
+/* glibc 2.22 removed binary mode of fmemopen.
+ * With this statement, we ask the compiler to link to the old version. */
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 22
+asm (".symver fmemopen, fmemopen@GLIBC_2.2.5");
+#endif
+
 char **
 oio_sds_get_compile_options (void)
 {


### PR DESCRIPTION
Binary mode of fmemopen() has been removed in glibc 2.22.
Without binary mode, fmemopen() tries to add '\0' at the end of the
buffer, but if there is no room it fails an never flushes the writes,
leading to unpredictable behavior.