### PR TITLE
core: modify set_properties and get_properties to respect new format

### DIFF
--- a/core/http_internals.h
+++ b/core/http_internals.h
@@ -163,6 +163,7 @@ struct oio_proxy_content_create_in_s
 	const char *chunk_method;
 	unsigned int append : 1;
 	unsigned int update : 1; // accept holes in metachunk positions
+	const char * const * properties;
 };
 
 GError * oio_proxy_call_content_create (CURL *h, struct oio_url_s *u,

--- a/core/proxy.c
+++ b/core/proxy.c
@@ -459,11 +459,14 @@ _set_properties(CURL *h, GString *http_url, const char* const *values)
 {
 	GError *err = NULL;
 	GString *json = _build_json(values);
+	GString *to_send = g_string_new(NULL);
+	g_string_printf(to_send, "{'properties': %s}", json->str);
 	struct http_ctx_s i = {
-		.body = json
+		.body = to_send
 	};
 	err = _proxy_call (h, "POST", http_url->str, &i, NULL);
 	g_string_free(i.body, TRUE);
+	g_string_free(json, TRUE);
 	return err;
 }
 
@@ -637,11 +640,24 @@ oio_proxy_call_content_create (CURL *h, struct oio_url_s *u,
 		hdrin[len] = g_strdup(PROXYD_HEADER_MODE);
 		hdrin[len+1] = g_strdup("append");
 	}
-
-	struct http_ctx_s i = { .headers = hdrin, .body = in ? in->chunks : NULL };
+	GString *body = in? in->chunks : NULL;
+        if (in && !in->update && in->properties) {
+		GString *val = g_string_new("{'properties': ");
+		GString *json_properties = _build_json(in->properties);
+		g_string_append(val, json_properties->str);
+		g_string_append(val, ", 'chunks': ");
+		g_string_append(val, in->chunks->str);
+		g_string_append_c(val, '}');
+		body = val;
+		g_string_free(json_properties, TRUE);
+  
+	}
+	struct http_ctx_s i = { .headers = hdrin, .body = body };
 	struct http_ctx_s o = { .headers = NULL, .body = out };
 	GError *err = _proxy_call (h, "POST", http_url->str, &i, &o);
 	_ptrv_free_content (i.headers);
+	if (in && !in->update && in->properties)
+		g_string_free (body, TRUE);
 	g_string_free (http_url, TRUE);
 	return err;
 }

--- a/core/sds.c
+++ b/core/sds.c
@@ -1659,6 +1659,7 @@ oio_sds_upload_commit (struct oio_sds_ul_s *ul)
 		.chunk_method = ul->chunk_method,
 		.append = BOOL(ul->dst->append),
 		.update = BOOL(ul->dst->partial),
+		.properties = ul->dst->properties
 	};
 
 	GRID_TRACE("%s (%p) Saving %s", __FUNCTION__, ul, request_body->str);
@@ -1671,9 +1672,6 @@ oio_sds_upload_commit (struct oio_sds_ul_s *ul)
 	g_string_free (reply_body, TRUE);
 	if (err)
 		return (struct oio_error_s*) err;
-	if (ul->dst->properties)
-		return (struct oio_error_s*) oio_proxy_call_content_set_properties
-			(ul->sds->h, ul->dst->url, (const char* const*)ul->dst->properties);
 	return NULL;
 }
 
@@ -2307,10 +2305,13 @@ oio_sds_get_content_properties(struct oio_sds_s *sds, struct oio_url_s *url,
 	err = (struct oio_error_s*) oio_proxy_call_content_get_properties(sds->h, url, &value);
 	if (err)
 		return err;
-
 	json_object *json = json_tokener_parse(value->str);
-	json_object_object_foreach(json,key,val) {
-		fct(ctx, key, json_object_get_string(val));
+	json_object_object_foreach(json,key,property_properties_json) {
+		EXTRA_ASSERT(g_strcmp0("properties", key) == 0);
+		json_object_object_foreach(property_properties_json,
+					   property_key, property_value)
+		        fct(ctx, property_key,
+			    json_object_get_string(property_value));
 	}
 	json_object_put(json);
 	g_string_free(value, TRUE);


### PR DESCRIPTION
core: The properties indicate in upload are set in the upload_commit step