### PR TITLE
oio/cli: add oio-cluster command into openio client

### DIFF
--- a/cluster/tools/gridcluster.c
+++ b/cluster/tools/gridcluster.c
@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static void
 usage(void)
 {
-	g_printerr("Usage: gridcluster [OPTION]... <NAMESPACE>...\n\n");
+	g_printerr("Usage: oio-cluster [OPTION]... <NAMESPACE>...\n\n");
 	g_printerr("  %-20s\t%s\n", "--clear-services SERVICE    ", "Clear all local RAWX reference in cluster.");
 	g_printerr("  %-20s\t%s\n", "--full,                     ", "Show full services.");
 	g_printerr("  %-20s\t%s\n", "--lb-config,                ", "Prints to stdout the namespace LB configuration ");

--- a/oio/cli/admin/client.py
+++ b/oio/cli/admin/client.py
@@ -49,8 +49,17 @@ class AdminClient(object):
     def cluster_list(self, srv_type):
         return self.cluster.all_services(srv_type)
 
+    def cluster_local_list(self):
+        return self.cluster.local_services()
+
     def cluster_info(self):
         return self.cluster.info()
+
+    def cluster_flush(self, srv_type):
+        return self.cluster.flush(srv_type)
+
+    def cluster_unlock_score(self, srv_type):
+        return self.cluster.unlock_score(srv_type)
 
     def volume_admin_show(self, volume):
         return self.volume.admin_show(volume)

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -2,10 +2,13 @@ import logging
 
 from cliff import lister
 from cliff import show
+from cliff import command
+
+from oio.common.utils import load_namespace_conf
 
 
 class ClusterShow(show.ShowOne):
-    """Cluster show"""
+    """Show information of all services in the cluster"""
 
     log = logging.getLogger(__name__ + '.ClusterInfo')
 
@@ -28,9 +31,9 @@ class ClusterShow(show.ShowOne):
 
 
 class ClusterList(lister.Lister):
-    """Cluster List"""
+    """Cluster list"""
 
-    log = logging.getLogger(__name__ + '.ClusterInfo')
+    log = logging.getLogger(__name__ + '.ClusterList')
 
     def get_parser(self, prog_name):
         parser = super(ClusterList, self).get_parser(prog_name)
@@ -43,7 +46,6 @@ class ClusterList(lister.Lister):
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-
         results = []
         for srv_type in parsed_args.srv_types:
             data = self.app.client_manager.admin.cluster_list(
@@ -61,3 +63,129 @@ class ClusterList(lister.Lister):
         columns = ('Type', 'Id', 'Volume', 'Location', 'Slots', 'Up', 'Score')
         result_gen = (r for r in results)
         return columns, result_gen
+
+
+class ClusterLocalList(lister.Lister):
+    """List local services"""
+
+    log = logging.getLogger(__name__ + '.ClusterLocalList')
+
+    def get_parser(self, prog_name):
+        parser = super(ClusterLocalList, self).get_parser(prog_name)
+        parser.add_argument(
+            'srv_types',
+            metavar='<srv_types>',
+            nargs='*',
+            help='Service Type(s)')
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug('take_action(%s)', parsed_args)
+        results = []
+        srv_types = parsed_args.srv_types
+        data = self.app.client_manager.admin.cluster_local_list()
+        for srv in data:
+            tags = srv['tags']
+            location = tags.get('tag.loc', 'n/a')
+            slots = tags.get('tag.slots', 'n/a')
+            volume = tags.get('tag.vol', 'n/a')
+            addr = srv['addr']
+            up = tags.get('tag.up', 'n/a')
+            score = srv['score']
+            srv_type = srv['type']
+            if not srv_types or srv_type in srv_types:
+                results.append((srv_type, addr, volume, location,
+                                slots, up, score))
+            columns = ('Type', 'Id', 'Volume', 'Location',
+                       'Slots', 'Up', 'Score')
+            result_gen = (r for r in results)
+        return columns, result_gen
+
+
+class ClusterUnlockService(command.Command):
+    """Unlock score"""
+
+    log = logging.getLogger(__name__ + '.ClusterUnlock')
+
+    def get_parser(self, prog_name):
+        parser = super(ClusterUnlockService, self).get_parser(prog_name)
+        parser.add_argument(
+            'srv_type',
+            metavar='<srv_type>',
+            help='Service Type')
+        parser.add_argument(
+            'srv_addr',
+            metavar='<srv_addr>',
+            help='addr of the service'
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug('take_action(%s)', parsed_args)
+        addr = parsed_args.srv_addr
+        srv_type = parsed_args.srv_type
+        namespace = self.app.client_manager.admin.conf['namespace']
+        service_desc = "[%s|%s|%s]" % (namespace,
+                                       srv_type,
+                                       addr)
+        data = self.app.client_manager.admin.cluster_list(
+            srv_type)
+        for srv in data:
+            service_info = {'type': srv_type,
+                            'addr': srv['addr'],
+                            'score': -1}
+            if addr == service_info['addr']:
+                try:
+                    self.app.client_manager.admin.cluster_unlock_score(
+                        service_info)
+                    self.log.warn("Service " + service_desc +
+                                  " has been successfully unlocked")
+                    return
+                except Exception as e:
+                    raise Exception('service unlock error: ' + str(e))
+        self.log.error('Failed to set score of service ' +
+                       service_desc + ': Invalid Service Description')
+
+
+class ClusterFlush(command.Command):
+    """flush all services in the cluster"""
+
+    log = logging.getLogger(__name__ + '.ClusterInfo')
+
+    def get_parser(self, prog_name):
+        parser = super(ClusterFlush, self).get_parser(prog_name)
+        parser.add_argument(
+            'srv_types',
+            metavar='<srv_types>',
+            nargs='+',
+            help='Service Type(s)')
+        return parser
+
+    def take_action(self, parsed_args):
+        for srv_type in parsed_args.srv_types:
+            try:
+                self.app.client_manager.admin.cluster_flush(srv_type)
+                self.log.warn('services %s flushed' % (srv_type))
+            except Exception as e:
+                raise Exception('Error while flushing service %s: %s' %
+                                (srv_type, str(e)))
+
+
+class LocalNSConf(show.ShowOne):
+    """show namespace configuration values locally configured"""
+
+    log = logging.getLogger(__name__ + '.LocalNSConf')
+
+    def get_parser(self, prog_name):
+        parser = super(LocalNSConf, self).get_parser(prog_name)
+        return parser
+
+    def take_action(self, parsed_args):
+
+        self.log.debug('take_action(%s)', parsed_args)
+        namespace = self.app.client_manager.admin.conf['namespace']
+        sds_conf = load_namespace_conf(namespace)
+        output = list()
+        for k in sds_conf:
+            output.append(("%s/%s" % (namespace, k), sds_conf[k]))
+        return zip(*output)

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -43,6 +43,15 @@ class ConscienceClient(Client):
             raise OioException("ERROR while getting list of %s services"
                                % type_)
 
+    def local_services(self):
+        uri = self._make_uri("local/list")
+        resp, body = self._request('GET', uri)
+        if resp.status_code == 200:
+            return body
+        else:
+            # FIXME: add resp error message
+            raise OioException("ERROR while getting list of %s services")
+
     def register(self, pool, service_definition):
         uri = self._make_uri('conscience/register')
         data = json.dumps(service_definition)
@@ -52,3 +61,12 @@ class ConscienceClient(Client):
         uri = self._make_uri("conscience/info")
         resp, body = self._request("GET", uri)
         return body
+
+    def unlock_score(self, infos_srv):
+        uri = self._make_uri("conscience/unlock")
+        resp, body = self._request('POST', uri, data=json.dumps(infos_srv))
+
+    def flush(self, srv_type):
+        type_dic = {'type': srv_type}
+        uri = self._make_uri('conscience/flush')
+        resp, body = self._request('POST', uri, params=type_dic)

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,10 @@ openio.admin =
     events_stats = oio.cli.admin.events:StatsEvents
     cluster_show = oio.cli.admin.cluster:ClusterShow
     cluster_list = oio.cli.admin.cluster:ClusterList
+    cluster_local_list = oio.cli.admin.cluster:ClusterLocalList
+    cluster_unlock = oio.cli.admin.cluster:ClusterUnlockService
+    cluster_flush = oio.cli.admin.cluster:ClusterFlush
+    cluster_local_conf = oio.cli.admin.cluster:LocalNSConf
 
 oio.conscience.checker =
     http = oio.conscience.checker.http:HttpChecker


### PR DESCRIPTION
New commands : 
openio cluster list --local -> show all local services of cluster 
openio cluster unlock <service> <addr> (--score <score>) -> unlock the service given in the command with the score <score> 
openio cluster local conf -> print to stdout the namespace configuration values locally configured
openio clear flush <service> -> flush all services of the service type