### PR TITLE
Balance reads

### DIFF
--- a/cluster/lib/gridcluster.c
+++ b/cluster/lib/gridcluster.c
@@ -305,7 +305,7 @@ gchar *
 namespace_get_state(namespace_info_t* ns_info)
 {
 	return gridcluster_get_nsinfo_strvalue(ns_info, NS_STATE_NAME,
-					       NS_STATE_VALUE_STAND_ALONE);
+			NS_STATE_VALUE_STANDALONE);
 }
 
 gint64

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -44,6 +44,11 @@ enum oio_sds_config_e
 
 	/* expects an <int> used for its boolean value */
 	OIOSDS_CFG_FLAG_ADMIN,
+
+	/* Disable the shuffling of chunks before reading,
+	 * and instead sort them by score.
+	 * Expects an <int> used for its boolean value. */
+	OIOSDS_CFG_FLAG_NO_SHUFFLE,
 };
 
 enum oio_sds_content_key_e

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -100,7 +100,7 @@ License along with this library.
 
 #define NS_STATE_VALUE_MASTER "master"
 #define NS_STATE_VALUE_SLAVE "slave"
-#define NS_STATE_VALUE_STAND_ALONE "stand_alone"
+#define NS_STATE_VALUE_STANDALONE "standalone"
 
 #define NAME_MSGKEY_ADMIN_COMMAND      "ADM_CMD"
 #define NAME_MSGKEY_NS_STATE      "STT"

--- a/oio/cli/admin/client.py
+++ b/oio/cli/admin/client.py
@@ -61,6 +61,9 @@ class AdminClient(object):
     def cluster_flush(self, srv_type):
         return self.cluster.flush(srv_type)
 
+    def cluster_lock_score(self, srv_type):
+        return self.cluster.lock_score(srv_type)
+
     def cluster_unlock_score(self, srv_type):
         return self.cluster.unlock_score(srv_type)
 

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -71,6 +71,11 @@ class ConscienceClient(Client):
         resp, body = self._request("GET", uri)
         return body
 
+    def lock_score(self, infos_srv):
+        uri = self._make_uri("conscience/lock")
+        resp, body = self._request('POST', uri, data=json.dumps(infos_srv))
+        return body
+
     def unlock_score(self, infos_srv):
         uri = self._make_uri("conscience/unlock")
         resp, body = self._request('POST', uri, data=json.dumps(infos_srv))

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,7 @@ openio.admin =
     cluster_local_list = oio.cli.admin.cluster:ClusterLocalList
     cluster_unlockall = oio.cli.admin.cluster:ClusterUnlockAll
     cluster_unlock = oio.cli.admin.cluster:ClusterUnlock
+    cluster_lock = oio.cli.admin.cluster:ClusterLock
     cluster_flush = oio.cli.admin.cluster:ClusterFlush
     cluster_local_conf = oio.cli.admin.cluster:LocalNSConf
 

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -405,7 +405,6 @@ param_option.worm=${WORM}
 
 param_option.service_update_policy=meta2=KEEP|${M2_REPLICAS}|${M2_DISTANCE};sqlx=KEEP|${SQLX_REPLICAS}|${SQLX_DISTANCE}|;rdir=KEEP|1|1|user_is_a_service=1
 
-param_option.lb.rawx=WRR?shorten_ratio=1.0&standard_deviation=no&reset_delay=60
 param_option.meta2_max_versions=${VERSIONING}
 param_option.meta2_keep_deleted_delay=86400
 param_option.compression=on
@@ -888,7 +887,8 @@ WORMED="worm"
 NS_STATE="state"
 MASTER_VALUE="master"
 SLAVE_VALUE="slave"
-STAND_ALONE_VALUE="stand_alone"
+STANDALONE_VALUE="standalone"
+
 defaults = {
     'NS': 'OPENIO',
     'IP': '127.0.0.1',
@@ -985,8 +985,8 @@ def generate(options):
     is_wormed = options.get('worm', False)
     worm = '1' if is_wormed else '0'
     state = options.get("state", None)
-    if state not in [MASTER_VALUE, SLAVE_VALUE, STAND_ALONE_VALUE]:
-        state = STAND_ALONE_VALUE
+    if state not in [MASTER_VALUE, SLAVE_VALUE, STANDALONE_VALUE]:
+        state = STANDALONE_VALUE
     key_file = options.get(KEY_FILE, CFGDIR + '/' + 'application_keys.cfg')
     ENV = dict(IP=ip,
                NS=ns,


### PR DESCRIPTION
* In C API, by default, chunks are shuffled before reading disregarding the score. Now it is possible to start reading the highest scored one.
* In Python API,  when reading a replicated content, we swap the highest scored chunk with one selected by a weighted random algorithm, to avoid harassing the same rawx.
* New `openio cluster lock` command.