### PR TITLE
oio/directory/meta0: correcting rebalance function

### DIFF
--- a/oio/directory/meta0.py
+++ b/oio/directory/meta0.py
@@ -242,10 +242,11 @@ class PrefixMapping(object):
                 pfxs = {x for x in random.sample(svc_pfx,
                                                  len(svc_pfx)-ideal_pfx_by_svc)
                         if x not in moved_prefixes}
-                self.decommission(svc, pfxs)
-                for pfx in pfxs:
-                    moved_prefixes.add(pfx)
-                    loops += 1
+                if len(pfxs) != 0:
+                    self.decommission(svc, pfxs)
+                    for pfx in pfxs:
+                        moved_prefixes.add(pfx)
+                        loops += 1
         if self.logger:
             self.logger.info("Rebalance moved %d prefixes",
                              len(moved_prefixes))


### PR DESCRIPTION
The bug was caused by the non-check of the length of the random prefixes, who can be zero.

When the prefix set was zero, all prefixes of the service selected were lost, causing a lost of prefixes managed by a meta1
