### PR TITLE
core,m1: fix 'user_is_a_service' option handling (2)

### DIFF
--- a/core/lb.c
+++ b/core/lb.c
@@ -485,6 +485,9 @@ _local_target__is_satisfied(struct oio_lb_pool_LOCAL_s *lb,
 			GRID_DEBUG ("Slot [%s] not ready", name);
 			continue;
 		}
+		if (_slot_needs_rehash(slot)) {
+			_slot_rehash(slot);
+		}
 		oio_location_t *known = ctx->next_polled;
 		do {
 			guint pos = _search_first_at_location(slot->items,

--- a/etc/bootstrap-3COPIES-11RAWX.yml
+++ b/etc/bootstrap-3COPIES-11RAWX.yml
@@ -1,5 +1,7 @@
 storage_policy: "THREECOPIES"
 chunk_size: 1048576
 redis: true
+rdir:
+  count: 2
 rawx:
   count: 11

--- a/etc/bootstrap-EC.yml
+++ b/etc/bootstrap-EC.yml
@@ -1,5 +1,7 @@
 storage_policy: "EC"
 chunk_size: 1048576
 redis: true
+rdir:
+  count: 2
 rawx:
   count: 12

--- a/etc/bootstrap-SINGLE.yml
+++ b/etc/bootstrap-SINGLE.yml
@@ -3,3 +3,5 @@ chunk_size: 1048576
 redis: true
 rawx:
   count: 3
+rdir:
+  count: 2

--- a/etc/bootstrap-SLAVE.yml
+++ b/etc/bootstrap-SLAVE.yml
@@ -3,5 +3,7 @@ state: "slave"
 storage_policy: "THREECOPIES"
 chunk_size: 1048576
 redis: true
+rdir:
+  count: 2
 rawx:
   count: 3

--- a/etc/bootstrap-WORM.yml
+++ b/etc/bootstrap-WORM.yml
@@ -3,5 +3,7 @@ worm: true
 storage_policy: "THREECOPIES"
 chunk_size: 1048576
 redis: true
+rdir:
+  count: 2
 rawx:
   count: 3

--- a/metautils/lib/lb.c
+++ b/metautils/lib/lb.c
@@ -159,9 +159,18 @@ oio_lb_pool__from_service_policy(struct oio_lb_world_s *lbw,
 	GString *targets = g_string_sized_new(64);
 	g_string_append_printf(targets, "%s", srvtype);
 
+	gchar *user_is_service = service_update_get_tag_value(
+			pols, srvtype, NAME_TAGNAME_USER_IS_SERVICE);
 	guint howmany = service_howmany_replicas(pols, srvtype);
-	GRID_DEBUG("pool [%s] will target [%s] %u times",
-			srvtype, targets->str, howmany);
+	if (user_is_service) {
+		oio_lb_world__add_pool_target(pool, user_is_service);
+		GRID_INFO("pool [%s] will target [%s] 1 time and [%s] %u times",
+				srvtype, user_is_service, targets->str, howmany);
+		g_free(user_is_service);
+	} else {
+		GRID_INFO("pool [%s] will target [%s] %u times",
+				srvtype, targets->str, howmany);
+	}
 	for (; howmany > 0; howmany--)
 		oio_lb_world__add_pool_target(pool, targets->str);
 

--- a/metautils/lib/lrutree.c
+++ b/metautils/lib/lrutree.c
@@ -285,7 +285,7 @@ lru_tree_remove_older (struct lru_tree_s *lt, gint64 oldest)
 {
 	EXTRA_ASSERT(lt != NULL);
 	guint removed = 0;
-	while (lt->last && lt->first->atime < oldest) {
+	while (lt->last && lt->last->atime < oldest) {
 		_remove_last (lt);
 		++ removed;
 	}

--- a/metautils/lib/metautils_svc_policy.h
+++ b/metautils/lib/metautils_svc_policy.h
@@ -46,6 +46,10 @@ gboolean service_update_tagfilter2(struct service_update_policies_s *pol,
 gboolean service_update_tagfilter(struct service_update_policies_s *pol,
 		const gchar *type, gchar **pname, gchar **pvalue);
 
+/** Get the value associated with the tag defined for the policy (or NULL). */
+gchar * service_update_get_tag_value(struct service_update_policies_s *pol,
+		const gchar *type, gchar *tag_key);
+
 enum service_update_policy_e service_howto_update(
 		struct service_update_policies_s *pol,
 		const gchar *type);

--- a/metautils/lib/utils_svc_policy.c
+++ b/metautils/lib/utils_svc_policy.c
@@ -447,6 +447,24 @@ service_howmany_distance(struct service_update_policies_s *pol,
 	return service_howmany_distance2(pol, htype);
 }
 
+gchar *
+service_update_get_tag_value(struct service_update_policies_s *pol,
+		const gchar *type, gchar *tag_key)
+{
+	struct element_s *el;
+	struct hashstr_s *htype;
+	gchar *tag_val = NULL;
+	HASHSTR_ALLOCA(htype, type);
+	g_mutex_lock(&pol->lock);
+	if ((el = g_tree_lookup(pol->tree_elements, htype))) {
+		if (el->tagname && !g_strcmp0(el->tagname, tag_key)) {
+			tag_val = g_strdup(el->tagvalue);
+		}
+	}
+	g_mutex_unlock(&pol->lock);
+	return tag_val;
+}
+
 gboolean
 service_update_tagfilter2(struct service_update_policies_s *pol,
 		const struct hashstr_s *htype, gchar **pname, gchar **pvalue)

--- a/oio/api/directory.py
+++ b/oio/api/directory.py
@@ -31,16 +31,17 @@ class DirectoryAPI(API):
         uri = "%s/%s" % (self.namespace, action)
         return uri
 
-    def _make_params(self, account, ref, srv_type=None):
+    def _make_params(self, account, ref, service_type=None):
         params = {'acct': account,
                   'ref': ref}
-        if srv_type:
-            params.update({'type': srv_type})
+        if service_type:
+            params.update({'type': service_type})
         return params
 
-    def get(self, account, reference, headers=None):
+    def get(self, account, reference, headers=None, service_type=None):
         uri = self._make_uri('reference/show')
-        params = self._make_params(account, reference)
+        params = self._make_params(account, reference,
+                                   service_type=service_type)
         resp, resp_body = self._request(
             'GET', uri, params=params, headers=headers)
         return resp_body
@@ -65,12 +66,17 @@ class DirectoryAPI(API):
         resp, resp_body = self._request(
             'POST', uri, params=params, headers=headers)
 
-    def link(self, account, reference, service_type, headers=None):
+    def link(self, account, reference, service_type, headers=None,
+             autocreate=False):
         """
         Poll and associate a new service to the reference.
         """
         uri = self._make_uri('reference/link')
         params = self._make_params(account, reference, service_type)
+        if autocreate:
+            if not headers:
+                headers = dict()
+            headers["X-oio-action-mode"] = "autocreate"
         resp, resp_body = self._request(
             'POST', uri, params=params, headers=headers)
         return resp_body

--- a/oio/directory/client.py
+++ b/oio/directory/client.py
@@ -4,6 +4,8 @@ from oio.common.utils import json
 
 
 class DirectoryClient(Client):
+    """Deprecated. Use oio.api.directory."""
+
     def __init__(self, conf, **kwargs):
         super(DirectoryClient, self).__init__(conf, **kwargs)
 

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -403,7 +403,7 @@ param_option.meta2.events-buffer-delay=5
 param_option.state=${STATE}
 param_option.worm=${WORM}
 
-param_option.service_update_policy=meta2=KEEP|${M2_REPLICAS}|${M2_DISTANCE};sqlx=KEEP|${SQLX_REPLICAS}|${SQLX_DISTANCE}|;rdir=KEEP|1|1|user_is_a_service=1
+param_option.service_update_policy=meta2=KEEP|${M2_REPLICAS}|${M2_DISTANCE};sqlx=KEEP|${SQLX_REPLICAS}|${SQLX_DISTANCE}|;rdir=KEEP|1|1|user_is_a_service=rawx
 
 param_option.meta2_max_versions=${VERSIONING}
 param_option.meta2_keep_deleted_delay=86400
@@ -502,8 +502,8 @@ template_service_pools = """
 [pool:meta2]
 targets=${M2_REPLICAS},meta2
 
-[pool:rdir]
-targets=1,rdir
+#[pool:rdir]
+#targets=1,rawx;1,rdir
 
 [pool:account]
 targets=1,account
@@ -1249,7 +1249,9 @@ def generate(options):
     # rdir
     nb_rdir = getint(options['rdir'].get(SVC_NB), 1)
     for num in range(nb_rdir):
-        env = subenv({'SRVTYPE': 'rdir', 'SRVNUM': num, 'PORT': next_port()})
+        env = subenv({'SRVTYPE': 'rdir',
+                      'SRVNUM': num + 1,
+                      'PORT': next_port()})
         add_service(env)
         with open(gridinit(env), 'a+') as f:
             tpl = Template(template_rdir_gridinit)

--- a/tools/oio-rdir-harass.py
+++ b/tools/oio-rdir-harass.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python2
+
+import sys
+import time
+import random
+from oio.event.consumer import EventTypes
+from oio.conscience.client import ConscienceClient
+from oio.rdir.client import RdirClient
+
+
+CHUNK_EVENTS = [EventTypes.CHUNK_DELETED, EventTypes.CHUNK_NEW]
+
+
+class Harasser(object):
+    def __init__(self, ns, max_containers=256, max_contents=256):
+        conf = {'namespace': ns}
+        self.cs = ConscienceClient(conf)
+        self.rdir = RdirClient(conf)
+        self.rawx_list = [x['addr'] for x in self.cs.all_services('rawx')]
+        self.sent = set()
+        self.max_containers = max_containers
+        self.max_contents = max_contents
+
+    def harass_put(self, loops=None):
+        if loops is None:
+            loops = random.randint(1000, 2000)
+        print "Pushing %d fake chunks" % loops
+        loop = loops
+        count_start_container = random.randrange(2**20)
+        count_start_content = random.randrange(2**20)
+        start = time.time()
+        nb_rawx = len(self.rawx_list)
+        while loop > 0:
+            args = {'mtime': int(start)}
+            # vol_id = random.choice(self.rawx_list)
+            # container_id = "%064X" % (random.randrange(self.max_containers))
+            # content_id = "%032X" % (random.randrange(self.max_contents))
+            vol_id = self.rawx_list[loop % nb_rawx]
+            container_id = "%064X" % (loop + count_start_container)
+            content_id = "%032X" % (loop + count_start_content)
+            chunk_id = "http://%s/%064X" \
+                % (vol_id, random.randrange(2**128))
+            self.rdir.chunk_push(
+                vol_id, container_id, content_id, chunk_id, **args)
+            self.sent.add((vol_id, container_id, content_id, chunk_id))
+            loop -= 1
+        end = time.time()
+        print "%d pushed in %.3fs, %d req/s" \
+            % (loops, end-start, loops/(end-start))
+
+    def harass_del(self, min_loops=0):
+        min_loops = min(min_loops, len(self.sent))
+        loops = random.randint(min_loops, len(self.sent))
+        print "Removing %d fake chunks" % loops
+        loop = loops
+        start = time.time()
+        while loop > 0:
+            args = self.sent.pop()
+            self.rdir.chunk_delete(*args)
+            loop -= 1
+        end = time.time()
+        print "%d removed in %.3fs, %d req/s" \
+            % (loops, end-start, loops/(end-start))
+
+    def __call__(self):
+        try:
+            while True:
+                self.harass_put()
+                self.harass_del()
+        except KeyboardInterrupt:
+            print "Cleaning..."
+            self.harass_del(len(self.sent))
+
+if __name__ == '__main__':
+    if len(sys.argv) > 3:
+        HARASS = Harasser(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]))
+    elif len(sys.argv) > 2:
+        HARASS = Harasser(sys.argv[1], int(sys.argv[2]))
+    elif len(sys.argv) > 1:
+        HARASS = Harasser(sys.argv[1])
+    else:
+        print "usage: %s NS [NB_CONTAINERS [NB_CONTENTS]]" % sys.argv[0]
+        sys.exit(1)
+    HARASS()


### PR DESCRIPTION
There was a problem with the location of the service for which
the load-balancer was queried.

This requires conscience configuration modifications:
* `rdir` pool must require a rawx (`targets=1,rawx;1,rdir`, or just don't define the pool, it will be autoconfigured);
* `service_update_policy` for rdir must be `rdir=KEEP|1|1|user_is_a_service=rawx`.