### PR TITLE
CLI: `openio cluster` completed

### DIFF
--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -146,16 +146,15 @@ class ClusterUnlockAll(lister.Lister):
     def get_parser(self, prog_name):
         parser = super(ClusterUnlockAll, self).get_parser(prog_name)
         parser.add_argument(
-            '-t', '--type',
-            action='append',
-            metavar='<type>',
-            type=str,
-            help='service type to unlock')
+            'types',
+            metavar='<types>',
+            nargs='*',
+            help='Service Type(s) to unlock (or all if unset)')
         return parser
 
     def _unlock_all(self, parsed_args):
-        types = parsed_args.type
-        if not parsed_args.type:
+        types = parsed_args.types
+        if not parsed_args.types:
             types = self.app.client_manager.admin.cluster_list_types()
         for type_ in types:
             all_descr = self.app.client_manager.admin.cluster_list(type_)
@@ -180,27 +179,25 @@ class ClusterWait(lister.Lister):
     def get_parser(self, prog_name):
         parser = super(ClusterWait, self).get_parser(prog_name)
         parser.add_argument(
-            '-t', '--type',
-            action='append',
-            metavar='<type>',
-            type=str,
-            help='service type to wait for')
+            'types',
+            metavar='<types>',
+            nargs='*',
+            help='Service Type(s) to wait for (or all if unset)')
         parser.add_argument(
             '-d', '--delay',
             metavar='<delay>',
-            type=str,
+            type=float,
+            default=15.0,
             help='How long to wait for a score')
         return parser
 
     def _wait(self, parsed_args):
 
-        types = parsed_args.type
-        if not parsed_args.type:
+        types = parsed_args.types
+        if not parsed_args.types:
             types = self.app.client_manager.admin.cluster_list_types()
 
-        delay = 15.0
-        if parsed_args.delay:
-            delay = float(parsed_args.delay)
+        delay = float(parsed_args.delay)
         deadline = now() + delay
 
         while True:
@@ -220,7 +217,8 @@ class ClusterWait(lister.Lister):
                 if now() > deadline:
                     raise Exception(
                             "Timeout ({0}s) while waiting ".format(delay) +
-                            "for the services to get a score")
+                            "for the services to get a score, still " +
+                            "{0} are zeroed".format(ko))
                 else:
                     sleep(1.0)
 

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -3,6 +3,7 @@ import logging
 from cliff import lister
 from cliff import show
 from cliff import command
+from time import time as now, sleep
 
 from oio.common.utils import load_namespace_conf
 
@@ -140,13 +141,22 @@ class ClusterUnlock(lister.Lister):
 class ClusterUnlockAll(lister.Lister):
     """Unlock all services of the cluster"""
 
-    log = logging.getLogger(__name__ + '.ClusterUnlock')
+    log = logging.getLogger(__name__ + '.ClusterUnlockAll')
 
     def get_parser(self, prog_name):
-        return super(ClusterUnlockAll, self).get_parser(prog_name)
+        parser = super(ClusterUnlockAll, self).get_parser(prog_name)
+        parser.add_argument(
+            '-t', '--type',
+            action='append',
+            metavar='<type>',
+            type=str,
+            help='service type to unlock')
+        return parser
 
-    def _unlock_all(self):
-        types = self.app.client_manager.admin.cluster_list_types()
+    def _unlock_all(self, parsed_args):
+        types = parsed_args.type
+        if not parsed_args.type:
+            types = self.app.client_manager.admin.cluster_list_types()
         for type_ in types:
             all_descr = self.app.client_manager.admin.cluster_list(type_)
             for descr in all_descr:
@@ -157,9 +167,64 @@ class ClusterUnlockAll(lister.Lister):
                 except Exception as exc:
                     yield type_, descr['addr'], str(exc)
 
-    def take_action(self, _parsed_args):
+    def take_action(self, parsed_args):
         columns = ('Type', 'Service', 'Result')
-        return columns, self._unlock_all()
+        return columns, self._unlock_all(parsed_args)
+
+
+class ClusterWait(lister.Lister):
+    """Wait for the services to get a score"""
+
+    log = logging.getLogger(__name__ + '.ClusterWait')
+
+    def get_parser(self, prog_name):
+        parser = super(ClusterWait, self).get_parser(prog_name)
+        parser.add_argument(
+            '-t', '--type',
+            action='append',
+            metavar='<type>',
+            type=str,
+            help='service type to wait for')
+        parser.add_argument(
+            '-d', '--delay',
+            metavar='<delay>',
+            type=str,
+            help='How long to wait for a score')
+        return parser
+
+    def _wait(self, parsed_args):
+
+        types = parsed_args.type
+        if not parsed_args.type:
+            types = self.app.client_manager.admin.cluster_list_types()
+
+        delay = 15.0
+        if parsed_args.delay:
+            delay = float(parsed_args.delay)
+        deadline = now() + delay
+
+        while True:
+            all_descr = []
+            for type_ in types:
+                tmp = self.app.client_manager.admin.cluster_list(type_)
+                for s in tmp:
+                    s['type'] = type_
+                all_descr += tmp
+            ko = len([s['score'] for s in tmp if s['score'] <= 0])
+            if ko <= 0:
+                for descr in all_descr:
+                    yield descr['type'], descr['addr'], descr['score']
+                return
+            else:
+                self.log.debug("Still %d services down", ko)
+                if now() > deadline:
+                    return
+                else:
+                    sleep(1.0)
+
+    def take_action(self, parsed_args):
+        columns = ('Type', 'Service', 'Score')
+        return columns, self._wait(parsed_args)
 
 
 class ClusterLock(ClusterUnlock):

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -218,7 +218,9 @@ class ClusterWait(lister.Lister):
             else:
                 self.log.debug("Still %d services down", ko)
                 if now() > deadline:
-                    return
+                    raise Exception(
+                            "Timeout ({0}s) while waiting ".format(delay) +
+                            "for the services to get a score")
                 else:
                     sleep(1.0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ openio.admin =
     cluster_unlock = oio.cli.admin.cluster:ClusterUnlock
     cluster_lock = oio.cli.admin.cluster:ClusterLock
     cluster_flush = oio.cli.admin.cluster:ClusterFlush
+    cluster_wait = oio.cli.admin.cluster:ClusterWait
     cluster_local_conf = oio.cli.admin.cluster:LocalNSConf
 
 oio.conscience.checker =


### PR DESCRIPTION
Now able to wait services to be scored, and to unlock services with given type.
Fixes #690 

    (oio)me@home 70 # OIO_NS=OPENIO openio cluster wait -t meta2
    +-------+----------------+-------+
    | Type  | Service        | Score |
    +-------+----------------+-------+
    | meta2 | 127.0.0.1:6008 |    86 |
    | meta2 | 127.0.0.1:6009 |    86 |
    | meta2 | 127.0.0.1:6010 |    86 |
    +-------+----------------+-------+
