### PR TITLE
Autocontainer in the "Flat NS" style

### DIFF
--- a/cluster/lib/gridcluster.c
+++ b/cluster/lib/gridcluster.c
@@ -431,19 +431,19 @@ namespace_in_compression_mode(namespace_info_t* ns_info)
 gsize
 namespace_get_autocontainer_src_offset(namespace_info_t* ns_info)
 {
-	return namespace_get_size(ns_info, "FLATNS_hash_offset", 0);
+	return namespace_get_size(ns_info, "flat_hash_offset", 0);
 }
 
 gsize
 namespace_get_autocontainer_src_size(namespace_info_t* ns_info)
 {
-	return namespace_get_size(ns_info, "FLATNS_hash_size", 0);
+	return namespace_get_size(ns_info, "flat_hash_size", 0);
 }
 
 gsize
 namespace_get_autocontainer_dst_bits(namespace_info_t* ns_info)
 {
-	return namespace_get_size(ns_info, "FLATNS_hash_bitlength", 17);
+	return namespace_get_size(ns_info, "flat_bitlength", 17);
 }
 
 gint64

--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -87,12 +87,18 @@ void oio_str_randomize(gchar *d, const gsize dlen, const char *set);
 /** Fills 'b' with 'blen' random bytes */
 void oio_buf_randomize(guint8 *b, gsize blen);
 
-/** Fills 'dst' with the name of the container deduced from the given 'path'.
- * 'dst' must be at least 65 characters long. */
-const char * oio_str_autocontainer (const char *src, guint size,
+/** Fills 'dst' with the name of the container deduced from the given 'src'
+ * which is 'srclen' bytes long. If 'srclen' is 0, then src is expected to be
+ * NULL-terminated and its strlen() is considered.
+ * 'dst' must be at least '(bits-1)/4 + 2' bytes long, to hold the hexadecimal
+ * form of the 'bits' first bits of the hash of 'src'.
+ * Because a SHA256 checksum is used, the hash will always be 32 bytes longs,
+ * and any hexadecimal prefix won't ever use more than 65 bytes including the
+ * final NULL character. */
+const char * oio_str_autocontainer (const char *src, guint srclen,
 		char *dst, guint bits);
 
-/** Get the hexadecimal form of the 'dst_bits_ first bits of the input
+/** Get the hexadecimal form of the 'bits' first bits of the input
  * 'src' buffer of size 'len'. The 'dst' buffer is used to store the result
  * and a pointer to 'dst' is returned upon success. */
 const char * oio_buf_prefix (const guint8 *src, guint len,

--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -87,24 +87,21 @@ void oio_str_randomize(gchar *d, const gsize dlen, const char *set);
 /** Fills 'b' with 'blen' random bytes */
 void oio_buf_randomize(guint8 *b, gsize blen);
 
-struct oio_str_autocontainer_config_s {
-	gsize src_offset;
-	gsize src_size;
-	gsize dst_bits;
-};
-
 /** Fills 'dst' with the name of the container deduced from the given 'path'.
  * 'dst' must be at least 65 characters long. */
-const char * oio_str_autocontainer_name (const char *src, char *dst,
-		const struct oio_str_autocontainer_config_s *cfg);
+const char * oio_str_autocontainer (const char *src, guint size,
+		char *dst, guint bits);
 
-/** Fills 'dst' with the hexadecimal representation of the first bits
- * of 'src'. */
-const char * oio_str_autocontainer_hash (const guint8 *src, gsize src_len,
-		gchar *dst, const struct oio_str_autocontainer_config_s *cfg);
+/** Get the hexadecimal form of the 'dst_bits_ first bits of the input
+ * 'src' buffer of size 'len'. The 'dst' buffer is used to store the result
+ * and a pointer to 'dst' is returned upon success. */
+const char * oio_buf_prefix (const guint8 *src, guint len,
+		char *dst, guint bits);
 
+/** In place transform the input 's' string in its uppercase form */
 void oio_str_upper(register gchar *s);
 
+/** In place transform the input 's' string in its lowercase form */
 void oio_str_lower(register gchar *s);
 
 /* appends to 'base' the JSON acceptable version of 's', i.e. 's' with its

--- a/core/tool_roundtrip.c
+++ b/core/tool_roundtrip.c
@@ -616,10 +616,7 @@ _roundtrip_put_autocontainer (const char * const * properties)
 
 	/* compute the autocontainer with the SHA1, consider only the first 17 bits */
 	char tmp[65];
-	struct oio_str_autocontainer_config_s cfg = {
-		.src_offset = 0, .src_size = 0, .dst_bits = 17,
-	};
-	const char *auto_container = oio_str_autocontainer_hash (fi.h, fi.hs, tmp, &cfg);
+	const char *auto_container = oio_buf_prefix (fi.h, fi.hs, tmp, 17);
 
 	/* build a new URL with the computed container name */
 	struct oio_url_s *url_auto = oio_url_dup (url);

--- a/oio/cli/clientmanager.py
+++ b/oio/cli/clientmanager.py
@@ -4,6 +4,8 @@ import pkg_resources
 from oio.common import exceptions
 from oio.common.http import requests
 from oio.common.utils import load_namespace_conf
+from oio.common.autocontainer import HashedContainerBuilder
+from oio.conscience.client import ConscienceClient
 
 
 LOG = logging.getLogger(__name__)
@@ -34,6 +36,7 @@ class ClientManager(object):
         self.session = None
         self.namespace = None
         self.setup_done = False
+        self.info_done = False
         self._admin_mode = False
         root_logger = logging.getLogger('')
         LOG.setLevel(root_logger.getEffectiveLevel())
@@ -54,6 +57,14 @@ class ClientManager(object):
             self.setup_done = True
             self._admin_mode = self._options.get('admin_mode')
 
+    def info(self):
+        self.setup()
+        if self.info_done:
+            return
+        client = ConscienceClient({"namespace": self.namespace})
+        self.info = client.info()
+        self.info_done = True
+
     def get_admin_mode(self):
         self.setup()
         return self._admin_mode
@@ -70,6 +81,25 @@ class ClientManager(object):
             msg = 'Set an account name with --oio-account, OIO_ACCOUNT\n'
             raise exceptions.CommandError('Missing parameter: \n%s' % msg)
         return account_name
+
+    def get_flatns_manager(self):
+        self.info()
+        options = self.info['options']
+        bitlength, offset, size = None, 0, 0
+        try:
+            bitlength = int(options['flat_bitlength'])
+        except:
+            raise Exception("Namespace not configured for autocontainers")
+        try:
+            if 'flat_hash_offset' in options:
+                offset = int(options['flat_hash_offset'])
+            if 'flat_hash_size' in options:
+                size = int(options['flat_hash_size'])
+        except:
+            raise Exception("Invalid autocontainer config: offset/size")
+        return HashedContainerBuilder(offset=offset,
+                                      size=size,
+                                      bits=bitlength)
 
 
 def get_plugin_modules(group):

--- a/oio/cli/clientmanager.py
+++ b/oio/cli/clientmanager.py
@@ -5,6 +5,7 @@ from oio.common import exceptions
 from oio.common.http import requests
 from oio.common.utils import load_namespace_conf
 from oio.common.autocontainer import HashedContainerBuilder
+from oio.common.exceptions import ConfigurationException
 from oio.conscience.client import ConscienceClient
 
 
@@ -89,7 +90,8 @@ class ClientManager(object):
         try:
             bitlength = int(options['flat_bitlength'])
         except:
-            raise Exception("Namespace not configured for autocontainers")
+            raise ConfigurationException(
+                    "Namespace not configured for autocontainers")
         try:
             if 'flat_hash_offset' in options:
                 offset = int(options['flat_hash_offset'])

--- a/oio/cli/clientmanager.py
+++ b/oio/cli/clientmanager.py
@@ -84,6 +84,8 @@ class ClientManager(object):
         return account_name
 
     def get_flatns_manager(self):
+        # TODO(jfs): this is also needed in oio-swift, need to factorize in
+        #            oiopy
         self.info()
         options = self.info['options']
         bitlength, offset, size = None, 0, 0

--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -12,28 +12,6 @@ from oio.common.autocontainer import HashedContainerBuilder
 from oio.conscience.client import ConscienceClient
 
 
-def _get_flatns_manager(client_manager):
-    cfg = {"namespace": client_manager.namespace}
-    client = ConscienceClient(cfg)
-    nsinfo = client.info()
-    options = nsinfo['options']
-    bitlength, offset, size = None, 0, 0
-    try:
-        bitlength = int(options['flat_bitlength'])
-    except:
-        raise Exception("Namespace not configured for autocontainers")
-    try:
-        if 'flat_hash_offset' in options:
-            offset = int(options['flat_hash_offset'])
-        if 'flat_hash_size' in options:
-            size = int(options['flat_hash_size'])
-    except:
-        raise Exception("Invalid autocontainers configuration: offset/size")
-    return HashedContainerBuilder(offset=offset,
-                                  size=size,
-                                  bits=bitlength)
-
-
 class CreateObject(lister.Lister):
     """Upload object"""
 

--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -8,8 +8,6 @@ from cliff import show
 
 from oio.cli.utils import KeyValueAction
 from oio.common.utils import Timestamp
-from oio.common.autocontainer import HashedContainerBuilder
-from oio.conscience.client import ConscienceClient
 
 
 class CreateObject(lister.Lister):

--- a/oio/common/autocontainer.py
+++ b/oio/common/autocontainer.py
@@ -13,7 +13,7 @@
 
 
 from itertools import takewhile
-from ctypes import CDLL, c_char_p, c_uint
+from ctypes import CDLL, c_char_p, c_uint, create_string_buffer
 
 
 # Python's int() raises an exception if the string has non-digit
@@ -51,7 +51,7 @@ class HashedContainerBuilder(object):
         srclen = len(src)
         if self.size and self.size < len(src):
             srclen = self.size
-        tmp = " " * 65
+        tmp = create_string_buffer(65)
         out = self.func(src, srclen, tmp, self.bits)
         return str(out)
 

--- a/oio/common/autocontainer.py
+++ b/oio/common/autocontainer.py
@@ -36,6 +36,10 @@ class HashedContainerBuilder(object):
         self.lib = None
         self.func = None
 
+    def __str__(self):
+        return '{0}(bits={1},offset={2},size={3})'.format(
+                self.__class__.__name__, self.bits, self.offset, self.size)
+
     def __call__(self, path):
         if self.lib is None:
             self.lib = CDLL('liboiocore.so.0')

--- a/oio/common/autocontainer.py
+++ b/oio/common/autocontainer.py
@@ -13,6 +13,7 @@
 
 
 from itertools import takewhile
+from ctypes import CDLL, c_char_p, c_uint
 
 
 # Python's int() raises an exception if the string has non-digit
@@ -20,6 +21,35 @@ from itertools import takewhile
 def strtoll(val, base=10):
     """Mimics libc's strtoll function"""
     return int("".join(takewhile(str.isdigit, val)), base)
+
+
+class HashedContainerBuilder(object):
+    """
+    Build a container name from a SHA256 of the content path.
+    Only the first bits will be considered to generte the final prefix.
+    """
+
+    def __init__(self, offset=0, size=None, bits=15, **_kwargs):
+        self.offset = offset
+        self.size = size
+        self.bits = bits
+        self.lib = None
+        self.func = None
+
+    def __call__(self, path):
+        if self.lib is None:
+            self.lib = CDLL('liboiocore.so.0')
+            self.func = self.lib.oio_str_autocontainer
+            self.func.argtypes = [c_char_p, c_uint, c_char_p, c_uint]
+            self.func.restype = c_char_p
+
+        src = path[self.offset:]
+        srclen = len(src)
+        if self.size and self.size < len(src):
+            srclen = self.size
+        tmp = " " * 65
+        out = self.func(src, srclen, tmp, self.bits)
+        return str(out)
 
 
 class AutocontainerBuilder(object):

--- a/tests/unit/test_str.c
+++ b/tests/unit/test_str.c
@@ -92,10 +92,6 @@ test_bin (void)
 static void
 test_autocontainer (void)
 {
-	struct oio_str_autocontainer_config_s cfg = {
-		.src_size = 0, .src_offset = 0, .dst_bits = 17
-	};
-
 	guint64 nb0 = 0, nb8 = 0;
 	for (unsigned int i0=0; i0<256 ;i0++) {
 		for (unsigned int i1=0; i1<256 ;i1++) {
@@ -103,7 +99,7 @@ test_autocontainer (void)
 				guint8 bin[] = {i0, i1, i2, 0, 0};
 				gchar dst[65];
 
-				const char *s = oio_str_autocontainer_hash (bin, sizeof(bin), dst, &cfg);
+				const char *s = oio_buf_prefix (bin, sizeof(bin), dst, 17);
 				g_assert (s != NULL);
 				gchar last = s[strlen(s)-1];
 				g_assert (last == '0' || last == '8');

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -418,9 +418,9 @@ param_option.meta2_max_versions=${VERSIONING}
 param_option.meta2_keep_deleted_delay=86400
 param_option.compression=on
 param_option.container_max_size=50000000
-param_option.FLATNS_hash_offset=0
-param_option.FLATNS_hash_size=0
-param_option.FLATNS_hash_bitlength=17
+param_option.flat_hash_offset=0
+param_option.flat_hash_size=0
+param_option.flat_bitlength=17
 param_option.storage_policy=${STGPOL}
 
 # Storage policies definitions


### PR DESCRIPTION
* Conscience option renamed for beauty purpose: `FLATNS_*` options become `flat_*` options
* C code simplified to ease Python bindings
* NewPython "HashedcontainerBuilder" wrapping the former C code
* New CLI option "--auto" that ignores the given container and computes it with the content name