### PR TITLE
meta{0,1,2},sqlx: allow alternate ZK url in /etc/oio/sds.conf

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -320,7 +320,6 @@ extern "C" {
 # define OIO_CFG_SWIFT        "swift"
 # define OIO_CFG_ECD          "ecd"
 
-# define gridcluster_get_zookeeper(ns)  oio_cfg_get_value((ns), OIO_CFG_ZOOKEEPER)
 # define gridcluster_get_eventagent(ns) oio_cfg_get_value((ns), OIO_CFG_ACCOUNTAGENT)
 # define oio_cfg_get_proxy(ns)          oio_cfg_get_value((ns), OIO_CFG_PROXY)
 # define oio_cfg_get_proxylocal(ns)     oio_cfg_get_value((ns), OIO_CFG_PROXYLOCAL)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -679,7 +679,14 @@ template_local_header = """
 
 template_local_ns = """
 [${NS}]
+${NOZK}# ZK URL, at least used by zk-bootstrap.py
 ${NOZK}zookeeper=${IP}:2181
+${NOZK}# Alternate ZK endpoints for specific services
+${NOZK}zookeeper.meta0=${IP}:2181
+${NOZK}zookeeper.meta1=${IP}:2181
+${NOZK}zookeeper.meta2=${IP}:2181
+${NOZK}zookeeper.sqlx=${IP}:2181
+
 #proxy-local=${RUNDIR}/${NS}-proxy.sock
 proxy=${IP}:${PORT_PROXYD}
 ecd=${IP}:${PORT_ECD}


### PR DESCRIPTION
A service with the XXX service type now overrides its ZK url (found at `zookeeper` in /etc/oio/sds.conf) with an other value found at `zookeeper.XXX` in /etc/oio/sds.conf. If the specific value is not set, the main value is left untouched.

The main `zookeeper` value is still necessary for the zk-bootstrap.py script to run.