### PR TITLE
UDP preferred for DB_USE requests

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -320,6 +320,8 @@ extern "C" {
 # define OIO_CFG_SWIFT        "swift"
 # define OIO_CFG_ECD          "ecd"
 
+# define OIO_CFG_UDP_ALLOWED  "udp_allowed"
+
 # define gridcluster_get_eventagent(ns) oio_cfg_get_value((ns), OIO_CFG_ACCOUNTAGENT)
 # define oio_cfg_get_proxy(ns)          oio_cfg_get_value((ns), OIO_CFG_PROXY)
 # define oio_cfg_get_proxylocal(ns)     oio_cfg_get_value((ns), OIO_CFG_PROXYLOCAL)

--- a/etc/bootstrap-udp.yml
+++ b/etc/bootstrap-udp.yml
@@ -1,0 +1,1 @@
+udp_allowed: true

--- a/server/internals.h
+++ b/server/internals.h
@@ -39,6 +39,7 @@ struct endpoint_s
 {
 	unsigned int magic;
 	int fd;
+	int fd_udp;
 	int port_real;
 	int port_cfg;
 	guint32 flags;
@@ -53,9 +54,11 @@ struct network_server_s
 
 	struct network_client_s *first;
 
-	GThread *thread_events;
+	GThread *thread_udp;
+	GThread *thread_tcp;
 	GThreadPool *pool_stats;
-	GThreadPool *pool_workers;
+	GThreadPool *pool_tcp;
+	GThreadPool *pool_udp;
 
 	GAsyncQueue *queue_monitor; /* from the workers to the events_thread */
 
@@ -89,6 +92,7 @@ struct network_server_s
 	int epollfd;
 	volatile gboolean flag_continue;
 	gboolean abort_allowed;
+	gboolean udp_allowed;
 };
 
 enum

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -264,11 +264,13 @@ network_server_init(void)
 	return result;
 }
 
-void network_server_allow_udp(struct network_server_s *srv) {
+void
+network_server_allow_udp(struct network_server_s *srv)
+{
 	g_assert(srv != NULL);
 
 	for (struct endpoint_s **pe=srv->endpointv; pe && *pe ;++pe) {
-		GRID_ERROR("BUG: Can't call %s when servers are alreaddy open",
+		GRID_ERROR("BUG: Can't call %s when servers are already open",
 				__FUNCTION__);
 		g_assert((*pe)->fd < 0);
 	}
@@ -645,13 +647,17 @@ _thread_cb_events(gpointer d)
 	return d;
 }
 
-static gsize _endpoint_count_all (struct endpoint_s **pu) {
+static gsize
+_endpoint_count_all (struct endpoint_s **pu)
+{
 	gsize count = 0;
 	for (; *pu ;++pu) { count ++; }
 	return count;
 }
 
-static gsize _endpoint_count_udp (struct endpoint_s **pu) {
+static gsize
+_endpoint_count_udp (struct endpoint_s **pu)
+{
 	gsize count = 0;
 	for (; *pu ;++pu) { if ((*pu)->fd_udp > 0) { count ++; } }
 	return count;

--- a/server/network_server.h
+++ b/server/network_server.h
@@ -110,6 +110,9 @@ extern GQuark gq_time_unexpected;
 
 struct network_server_s * network_server_init(void);
 
+/* must be called PRIOR to network_server_open_servers */
+void network_server_allow_udp(struct network_server_s *srv);
+
 void network_server_set_max_workers(struct network_server_s *srv, guint max);
 
 void network_server_set_maxcnx(struct network_server_s *srv, guint max);
@@ -131,6 +134,8 @@ void network_server_bind_host_throughput(struct network_server_s *srv,
  * @return a valid (but maybe empty) array of string, NULL terminated. Free it
  *         with g_strfreev() */
 gchar** network_server_endpoints (struct network_server_s *srv);
+
+int network_server_first_udp (struct network_server_s *srv);
 
 void network_server_bind_host_lowlatency(struct network_server_s *srv,
 		const gchar *url, gpointer factory_udata,

--- a/server/slab.h
+++ b/server/slab.h
@@ -20,15 +20,6 @@ License along with this library.
 #ifndef OIO_SDS__server__slab_h
 # define OIO_SDS__server__slab_h 1
 
-/**
- * @defgroup server_slabs Data slabs
- * @ingroup server
- * @brief
- * @details
- *
- * @{
- */
-
 # include <glib.h>
 # include <string.h>
 # include <sys/types.h>
@@ -153,7 +144,5 @@ data_slab_make_static_string(const gchar *s)
 	gsize l = strlen(s);
 	return data_slab_make_buffer2((guint8*)s, FALSE, 0, l, l);
 }
-
-/** @} */
 
 #endif /*OIO_SDS__server__slab_h*/

--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -177,7 +177,6 @@ transport_gridd_factory0(struct gridd_request_dispatcher_s *dispatcher,
 {
 	EXTRA_ASSERT(dispatcher != NULL);
 	EXTRA_ASSERT(client != NULL);
-	EXTRA_ASSERT(client->fd >= 0);
 
 	struct transport_client_context_s *transport_context = g_malloc0(sizeof(*transport_context));
 	transport_context->dispatcher = dispatcher;
@@ -435,7 +434,6 @@ transport_gridd_notify_input(struct network_client_s *clt)
 	struct transport_client_context_s *ctx;
 
 	EXTRA_ASSERT(clt != NULL);
-	EXTRA_ASSERT(clt->fd >= 0);
 
 	ctx = clt->transport.client_context;
 	/* read the data */

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -175,4 +175,6 @@ struct sqlx_peering_s * sqlx_peering_factory__create_direct (
 		struct gridd_client_pool_s *clipool,
 		struct gridd_client_factory_s *clifac);
 
+void sqlx_peering_direct__set_udp (struct sqlx_peering_s *self, int fd);
+
 #endif /*OIO_SDS__sqliterepo__synchro_h*/

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -53,6 +53,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define SQLX_MAX_TIMER_PER_ROUND 100
 #endif
 
+static volatile gboolean udp_allowed = FALSE;
+
 // common_main hooks
 static struct grid_main_option_s * sqlx_service_get_options(void);
 static const char * sqlx_service_usage(void);
@@ -230,6 +232,16 @@ _configure_with_arguments(struct sqlx_service_s *ss, int argc, char **argv)
 			GRID_DEBUG("ZK [%s] (nothing at %s)", ss->zk_url, k);
 		if (str) oio_str_reuse(&ss->zk_url, str);
 	} while (0);
+
+	/* Check if UDP is allowed for servers in the /etc/oio/sds.conf files */
+	gchar *str_udp_allowed = oio_cfg_get_value (ss->ns_name, OIO_CFG_UDP_ALLOWED);
+	if (str_udp_allowed) {
+		udp_allowed = oio_str_parse_bool(str_udp_allowed, FALSE);
+		GRID_NOTICE("UDP %s", udp_allowed ? "allowed" : "forbidden");
+		g_free(str_udp_allowed);
+	} else {
+		GRID_INFO("UDP %s", "disabled by default");
+	}
 
 	return TRUE;
 }
@@ -543,9 +555,11 @@ sqlx_service_action(void)
 			return _action_report_error(err, "Failed to start the QUEUE thread");
 	}
 
-	/* SERVER/GRIDD main run loop */
+	/* open all the sockets */
 	if (!grid_main_is_running())
 		return;
+	if (udp_allowed)
+		network_server_allow_udp(SRV.server);
 	grid_daemon_bind_host(SRV.server, SRV.url->str, SRV.dispatcher);
 	err = network_server_open_servers(SRV.server);
 	if (NULL != err)
@@ -553,6 +567,13 @@ sqlx_service_action(void)
 	if (!grid_main_is_running())
 		return;
 
+	if (udp_allowed) {
+		int fd_udp = network_server_first_udp(SRV.server);
+		GRID_DEBUG("UDP socket fd=%d", fd_udp);
+		sqlx_peering_direct__set_udp(SRV.peering, fd_udp);
+	}
+
+	/* SERVER/GRIDD main run loop */
 	if (NULL != (err = network_server_run(SRV.server)))
 		return _action_report_error(err, "GRIDD run failure");
 }

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -558,8 +558,7 @@ sqlx_service_action(void)
 	/* open all the sockets */
 	if (!grid_main_is_running())
 		return;
-	if (udp_allowed)
-		network_server_allow_udp(SRV.server);
+	network_server_allow_udp(SRV.server);
 	grid_daemon_bind_host(SRV.server, SRV.url->str, SRV.dispatcher);
 	err = network_server_open_servers(SRV.server);
 	if (NULL != err)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -693,6 +693,8 @@ ecd=${IP}:${PORT_ECD}
 event-agent=beanstalk://127.0.0.1:11300
 #event-agent=ipc://${RUNDIR}/event-agent.sock
 conscience=${CS_ALL_PUB}
+
+udp_allowed=${UDP_ALLOWED}
 """
 
 template_event_agent = """
@@ -912,6 +914,7 @@ NS_STATE="state"
 MASTER_VALUE="master"
 SLAVE_VALUE="slave"
 STANDALONE_VALUE="standalone"
+UDP_ALLOWED="udp_allowed"
 
 defaults = {
     'NS': 'OPENIO',
@@ -927,7 +930,8 @@ defaults = {
     'REPLI_SQLX': 1,
     'REPLI_M2': 1,
     'REPLI_M1': 1,
-    'COMPRESSION': "off"}
+    'COMPRESSION': "off",
+    UDP_ALLOWED: "off"}
 
 # XXX When /usr/sbin/httpd is present we suspect a Redhat/Centos/Fedora
 # environment. If not, we consider being in a Ubuntu/Debian environment.
@@ -1010,6 +1014,8 @@ def generate(options):
     is_wormed = options.get('worm', False)
     worm = '1' if is_wormed else '0'
     state = options.get("state", None)
+    udp_allowed = str(options.get(UDP_ALLOWED, "off")).lower()
+
     if state not in [MASTER_VALUE, SLAVE_VALUE, STANDALONE_VALUE]:
         state = STANDALONE_VALUE
     key_file = options.get(KEY_FILE, CFGDIR + '/' + 'application_keys.cfg')
@@ -1049,7 +1055,8 @@ def generate(options):
                HTTPD_BINARY=HTTPD_BINARY,
                META_HEADER=META_HEADER,
                STATE=state,
-               WORM=worm)
+               WORM=worm,
+               UDP_ALLOWED=udp_allowed)
 
     def merge_env(add):
         env = dict(ENV)
@@ -1329,6 +1336,7 @@ def generate(options):
     final_conf["storage_policy"] = stgpol
     final_conf["account"] = 'test_account'
     final_conf["sds_path"] = SDSDIR
+    final_conf[UDP_ALLOWED] = udp_allowed
     final_conf["proxy"] = final_services['proxy'][0]['addr']
     final_conf[M2_REPLICAS] = meta2_replicas
     final_conf[M1_REPLICAS] = meta1_replicas


### PR DESCRIPTION
Only enabled when explicitely allowed in the `/etc/oio/sds.conf` files, with en entry like this in the namespace's section

    [MyNS]
    udp_allowed = true

The goal is to reduce the overall load with a simpler protocol for dummy tasks.