### PR TITLE
Adds bugs, and makes the clients slower

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions(-DHAVE_EXTRA_DEBUG=1)
 endif()
 
+option(ENBUG "Introduces intentional bugs" OFF)
+if (ENBUG)
+	MESSAGE(WARNING "ENBUGED MODE : NOT FOR PRODUCTION USE")
+	add_definitions(-DHAVE_ENBUG=1)
+endif()
+
 if (DEFINED STACK_PROTECTOR)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
 endif()

--- a/core/oiolog.h
+++ b/core/oiolog.h
@@ -69,8 +69,10 @@ extern "C" {
 #  define GRID_TRACE2(FMT,...)
 #  define GRID_TRACE(FMT,...)
 # endif
-# define GRID_LOG(LEVEL,FMT,...)   g_log(G_LOG_DOMAIN, LEVEL << G_LOG_LEVEL_USER_SHIFT, FMT, ##__VA_ARGS__)
-# define GRID_DEBUG(FMT,...)   g_log(G_LOG_DOMAIN, GRID_LOGLVL_DEBUG, FMT, ##__VA_ARGS__)
+# define GRID_DEBUG(FMT,...)   do { \
+	if (GRID_DEBUG_ENABLED()) \
+		g_log(G_LOG_DOMAIN, GRID_LOGLVL_DEBUG, FMT, ##__VA_ARGS__); \
+} while (0)
 # define GRID_INFO(FMT,...)    g_log(G_LOG_DOMAIN, GRID_LOGLVL_INFO, FMT, ##__VA_ARGS__)
 # define GRID_NOTICE(FMT,...)  g_log(G_LOG_DOMAIN, GRID_LOGLVL_NOTICE, FMT, ##__VA_ARGS__)
 # define GRID_WARN(FMT,...)    g_log(G_LOG_DOMAIN, GRID_LOGLVL_WARN, FMT, ##__VA_ARGS__)
@@ -89,9 +91,6 @@ extern "C" {
 # define NOTICE(FMT,...)  g_log(G_LOG_DOMAIN, GRID_LOGLVL_NOTICE, FMT, ##__VA_ARGS__)
 # define WARN(FMT,...)    g_log(G_LOG_DOMAIN, GRID_LOGLVL_WARN, FMT, ##__VA_ARGS__)
 # define ERROR(FMT,...)   g_log(G_LOG_DOMAIN, GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define FATAL(FMT,...)   g_log(G_LOG_DOMAIN, GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define CRIT(FMT,...)    g_log(G_LOG_DOMAIN, GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define ALERT(FMT,...)   g_log(G_LOG_DOMAIN, GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
 
 /* domain macros */
 # ifdef HAVE_EXTRA_DEBUG
@@ -106,9 +105,6 @@ extern "C" {
 # define NOTICE_DOMAIN(D,FMT,...)  g_log((D), GRID_LOGLVL_NOTICE, FMT, ##__VA_ARGS__)
 # define WARN_DOMAIN(D,FMT,...)    g_log((D), GRID_LOGLVL_WARN, FMT, ##__VA_ARGS__)
 # define ERROR_DOMAIN(D,FMT,...)   g_log((D), GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define FATAL_DOMAIN(D,FMT,...)   g_log((D), GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define CRIT_DOMAIN(D,FMT,...)    g_log((D), GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
-# define ALERT_DOMAIN(D,FMT,...)   g_log((D), GRID_LOGLVL_ERROR, FMT, ##__VA_ARGS__)
 
 #define LOG_FLAG_TRIM_DOMAIN 0x01
 #define LOG_FLAG_PURIFY 0x02

--- a/gridd/main/srvalert.c
+++ b/gridd/main/srvalert.c
@@ -33,7 +33,7 @@ static int
 srv_dumy_alert_handler(void *user_data, const char *id, const char *criticity, const char *msg)
 {
 	(void)user_data;
-	ALERT_DOMAIN((id ? id : "alert"), "%s:%s", criticity, msg);
+	ERROR_DOMAIN((id ? id : "alert"), "%s:%s", criticity, msg);
 	return 1;
 }
 

--- a/metautils/lib/comm_converter.c
+++ b/metautils/lib/comm_converter.c
@@ -539,7 +539,7 @@ service_info_marshall_1(service_info_t *si, GError **err)
 	}
 
 	if (!service_info_API2ASN(si, &asn))
-		ALERT("Conversion error");
+		GRID_ERROR("Conversion error");
 
 	gba = g_byte_array_sized_new(64);
 	encRet = der_encode(&asn_DEF_ServiceInfo, &asn, metautils_asn1c_write_gba, gba);

--- a/metautils/lib/utils_addr_info.c
+++ b/metautils/lib/utils_addr_info.c
@@ -139,7 +139,6 @@ addr_info_equal(gconstpointer a, gconstpointer b)
 	case TADDR_V6:
 		return 0 == memcmp(&(addrA.addr), &(addrB.addr), sizeof(addrA.addr.v6)) ? TRUE : FALSE;
 	default:
-		FATAL("Invalid address type");
 		return FALSE;
 	}
 }

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -308,4 +308,21 @@ GError * conscience_remote_push_services(const char *cs, GSList *ls);
 GError* conscience_remote_remove_services(const char *cs, const char *type,
 		GSList *ls);
 
+/* -------------------------------------------------------------------------- */
+
+#ifdef HAVE_ENBUG
+/* each time a request to a replicated service is issued, we allow that
+ * 'oio_proxy_request_failure_threshold_* / 100' chance the request fails
+ * without any attempt ... */
+
+/* only applied to the first request when there is only one */
+extern gint32 oio_proxy_request_failure_threshold_alone;
+/* only applied to the first request */
+extern gint32 oio_proxy_request_failure_threshold_first;
+/* only applied to the last request */
+extern gint32 oio_proxy_request_failure_threshold_last;
+/* only applied to all but the first and the last requests */
+extern gint32 oio_proxy_request_failure_threshold_middle;
+#endif
+
 #endif /*OIO_SDS__proxy__common_h*/


### PR DESCRIPTION
For once in this project's lifetime, this happens intentionally.
* The enbugging is used to prove the `oio-proxy` can manage the bugs.
* We slow the client operations down when a redirection loop is detected, to let a legit election reach a final state.