### PR TITLE
core: add OIO_USE_OLD_FMEMOPEN to choose fmemopen implementation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -211,3 +211,7 @@ Used by `gcc`
 | COMMON_CNX_TIMEOUT | 2 * G_TIME_SPAN_SECOND | In monotonic clock's precision |
 | COMMON_CLIENT_TIMEOUT | 30.0 | In monotonic clock's precision |
 | COMMON_STAT_TIMEOUT | 5.0 | <double> value telling the default timeout for /stat requests outgoing the proxy, in seconds. |
+
+| Macro | Default | Description |
+| ----- | ------- | ----------- |
+|OIO_USE_OLD_FMEMOPEN|_undefined_|Use the old implementation of glibc's `fmemopen`. Starting from glibc 2.22 the new implementation lacks the binary mode which made things work.|

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,8 @@ dir2macro("SERVER_DEFAULT_CNX_INACTIVE")
 dir2macro("DAEMON_DEFAULT_TIMEOUT_READ")
 dir2macro("DAEMON_DEFAULT_TIMEOUT_ACCEPT")
 
+dir2macro("OIO_USE_OLD_FMEMOPEN")
+
 ###-------------------------------------------------------------------------###
 
 if (NOT DEFINED CMAKE_INSTALL_PREFIX)

--- a/core/sds.c
+++ b/core/sds.c
@@ -65,8 +65,10 @@ unsigned int oio_sds_version (void) { return OIO_SDS_VERSION; }
 
 /* glibc 2.22 removed binary mode of fmemopen.
  * With this statement, we ask the compiler to link to the old version. */
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 22
+#ifdef OIO_USE_OLD_FMEMOPEN
+# if __GLIBC_PREREQ(2, 22)
 asm (".symver fmemopen, fmemopen@GLIBC_2.2.5");
+# endif
 #endif
 
 char **


### PR DESCRIPTION
Add -DOIO_USE_OLD_FMEMOPEN=1 on cmake commandline to use old fmemopen implementation. This will workaround a bug with glibc >= 2.22, but unfortunately won't compile with stripped glibc.