### PR TITLE
sqliterepo: fix a memleak, bound the waiting time

### DIFF
--- a/sqliterepo/gridd_client_pool.c
+++ b/sqliterepo/gridd_client_pool.c
@@ -172,7 +172,7 @@ event_client_monitor(struct gridd_client_pool_s *pool, struct event_client_s *mc
 	return 1;
 }
 
-static void
+void
 event_client_free(struct event_client_s *ec)
 {
 	if (!ec)
@@ -327,7 +327,9 @@ _manage_one_event(struct gridd_client_pool_s *pool, int fd, int evt)
 		event_client_free(ec);
 	}
 	else {
+		/* TODO check here how long it took with that election */
 		gridd_client_react(ec->client);
+
 		if (gridd_client_finished(ec->client))
 			event_client_free(ec);
 		else if (!event_client_monitor(pool, ec))
@@ -379,8 +381,7 @@ _defer(struct gridd_client_pool_s *pool, struct event_client_s *ev)
 	if (pool->closed) {
 		GRID_INFO("Request dropped");
 		event_client_free(ev);
-	}
-	else {
+	} else {
 		/* eventfd requires 8-byte integer */
 		guint64 c = 1u;
 		g_async_queue_push(pool->pending_clients, ev);

--- a/sqliterepo/gridd_client_pool.h
+++ b/sqliterepo/gridd_client_pool.h
@@ -27,15 +27,21 @@ struct election_manager_s;
 
 struct event_client_s;
 
+struct gridd_client_pool_s;
+
 typedef void (*gridd_client_end_f) (struct event_client_s*);
 
+/* "abstract" structure destined to be extended by the implementor.
+ * The "client" will react to network events (with a hook passed upon its
+ * creation, and that hook is responsible to callback the upper layer of the
+ * application. */
 struct event_client_s
 {
 	struct gridd_client_s *client;
 	gridd_client_end_f on_end;
-};
 
-struct gridd_client_pool_s;
+	/* hidden abstract fields */
+};
 
 struct gridd_client_pool_vtable_s
 {
@@ -81,5 +87,9 @@ struct abstract_client_pool_s
 /* Public API -------------------------------------------------------------- */
 
 struct gridd_client_pool_s * gridd_client_pool_create(void);
+
+/* Should not be used on an event that has already been defered. Because this
+ * will be called by the gridd_client_pool. */
+void event_client_free(struct event_client_s *ec);
 
 #endif /*OIO_SDS__metautils__lib__gridd_client_pool_h*/

--- a/sqliterepo/gridd_client_pool.h
+++ b/sqliterepo/gridd_client_pool.h
@@ -40,6 +40,10 @@ struct event_client_s
 	struct gridd_client_s *client;
 	gridd_client_end_f on_end;
 
+	/* when should the command enter the queue? after that, the command result
+	 * will be an error, and there won't even be a connection for it. */
+	gint64 deadline_start;
+
 	/* hidden abstract fields */
 };
 
@@ -85,6 +89,8 @@ struct abstract_client_pool_s
 	((struct abstract_client_pool_s*)p)->vtable->set_max(p,max)
 
 /* Public API -------------------------------------------------------------- */
+
+extern gint32 oio_sqlx_request_failure_threshold;
 
 struct gridd_client_pool_s * gridd_client_pool_create(void);
 


### PR DESCRIPTION
**TL;DR** we expect here the queue to be drastically peeled in case of storms, and old RPC immediately avoided.

For invalid peers addresses, we spare computation time and abort the RPC attempt immediately, then avoiding the GError structure to be leaked.

Bounds to 4s the delay in the queue of waiting RPC. After that, there is no RPC attempt, it will be aborted.