### PR TITLE
Improve robustness of election FSM

### DIFF
--- a/proxy/cache_actions.c
+++ b/proxy/cache_actions.c
@@ -116,10 +116,11 @@ action_forward (struct req_args_s *args)
 
 	if (!g_ascii_strcasecmp (action, "version")) {
 		args->rp->no_access();
-		MESSAGE req = metautils_message_create_named("REQ_VERSION");
-		GByteArray *encoded = message_marshall_gba_and_clean (req);
+		GByteArray *encoded = message_marshall_gba_and_clean (
+				metautils_message_create_named("REQ_VERSION"));
 		gchar *packed = NULL;
-		err = gridd_client_exec_and_concat_string (id, COMMON_CLIENT_TIMEOUT, encoded, &packed);
+		err = gridd_client_exec_and_concat_string (id, COMMON_CLIENT_TIMEOUT,
+				encoded, &packed);
 		if (err) {
 			g_free0 (packed);
 			return _reply_common_error (args, err);
@@ -135,10 +136,31 @@ action_forward (struct req_args_s *args)
 
 	if (!g_ascii_strcasecmp (action, "handlers")) {
 		args->rp->no_access();
-		MESSAGE req = metautils_message_create_named("REQ_HANDLERS");
-		GByteArray *encoded = message_marshall_gba_and_clean (req);
+		GByteArray *encoded = message_marshall_gba_and_clean (
+				metautils_message_create_named("REQ_HANDLERS"));
 		gchar *packed = NULL;
-		err = gridd_client_exec_and_concat_string (id, COMMON_CLIENT_TIMEOUT, encoded, &packed);
+		err = gridd_client_exec_and_concat_string (id, COMMON_CLIENT_TIMEOUT,
+				encoded, &packed);
+		if (err) {
+			g_free0 (packed);
+			return _reply_common_error (args, err);
+		}
+
+		/* TODO(jfs): quite duplicated from _reply_json() but the original
+		   was not suitable. */
+		args->rp->set_status (200, "OK");
+		args->rp->set_body_bytes (g_bytes_new_take((guint8*)packed, strlen(packed)));
+		args->rp->finalize ();
+		return HTTPRC_DONE;
+	}
+
+	if (!g_ascii_strcasecmp (action, "info")) {
+		args->rp->no_access();
+		GByteArray *encoded = message_marshall_gba_and_clean (
+				metautils_message_create_named(NAME_MSGNAME_SQLX_INFO));
+		gchar *packed = NULL;
+		err = gridd_client_exec_and_concat_string(id, COMMON_CLIENT_TIMEOUT,
+				encoded, &packed);
 		if (err) {
 			g_free0 (packed);
 			return _reply_common_error (args, err);

--- a/resolver/hc_resolver_internals.h
+++ b/resolver/hc_resolver_internals.h
@@ -24,11 +24,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # include <glib.h>
 
 #ifndef  HC_RESOLVER_DEFAULT_MAX_SERVICES
-# define HC_RESOLVER_DEFAULT_MAX_SERVICES 200000
+# define HC_RESOLVER_DEFAULT_MAX_SERVICES 1048576
 #endif
 
 #ifndef  HC_RESOLVER_DEFAULT_TTL_SERVICES
-# define HC_RESOLVER_DEFAULT_TTL_SERVICES 1 * G_TIME_SPAN_DAY
+# define HC_RESOLVER_DEFAULT_TTL_SERVICES 0
 #endif
 
 // No expiration and no max for content of META0 & Conscience

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -89,7 +89,7 @@ License along with this library.
 # endif
 
 # ifndef  SQLX_DELAY_EXPIRE_FINAL
-#  define SQLX_DELAY_EXPIRE_FINAL 5 * G_TIME_SPAN_MINUTE
+#  define SQLX_DELAY_EXPIRE_FINAL 0
 # endif
 
 # ifndef  SQLX_DELAY_EXPIRE_NONE

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -45,7 +45,7 @@ License along with this library.
  * "Hard" maximum number of bases that can be held by the cache.
  */
 # ifndef  SQLX_MAX_BASES
-#  define SQLX_MAX_BASES 8192
+#  define SQLX_MAX_BASES 32768
 # endif
 
 # ifndef  SQLX_GRACE_DELAY_COOL

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -108,6 +108,27 @@ void sqlx_sync_set_prefix(struct sqlx_sync_s *ss, const gchar *prefix);
 
 void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
 
+static inline const char * zoo_state2str(int state) {
+#define ON_STATE(N) do { if (state == ZOO_##N##_STATE) return #N; } while (0)
+	ON_STATE(EXPIRED_SESSION);
+	ON_STATE(AUTH_FAILED);
+	ON_STATE(CONNECTING);
+	ON_STATE(ASSOCIATING);
+	ON_STATE(CONNECTED);
+	return "STATE?";
+}
+
+static inline const char * zoo_zevt2str(int zevt) {
+#define ON_ZEVT(N) do { if (zevt == ZOO_##N##_EVENT) return #N; } while (0)
+	ON_ZEVT(CREATED);
+	ON_ZEVT(DELETED);
+	ON_ZEVT(CHANGED);
+	ON_ZEVT(CHILD);
+	ON_ZEVT(SESSION);
+	ON_ZEVT(NOTWATCHING);
+	return "EVENT?";
+}
+
 /* -------------------------------------------------------------------------- */
 
 struct sqlx_name_s;

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -482,6 +482,7 @@ test_single (void)
 	g_assert_nonnull (peering);
 
 	g_assert_no_error (election_manager_create (&config, &manager));
+	manager->synchronous_completions = TRUE;
 	g_assert_nonnull (manager);
 	election_manager_set_sync (manager, sync);
 	election_manager_set_peering (manager, peering);
@@ -589,6 +590,7 @@ test_sets (void)
 	g_assert_nonnull (peering);
 
 	g_assert_no_error (election_manager_create (&config, &manager));
+	manager->synchronous_completions = TRUE;
 	g_assert_nonnull (manager);
 	election_manager_set_sync (manager, sync);
 	election_manager_set_peering (manager, peering);
@@ -675,6 +677,7 @@ test_election_init(void)
 	err = election_manager_create(&cfg, &m);
 	g_assert_no_error(err);
 	g_assert_nonnull (m);
+	m->synchronous_completions = TRUE;
 	election_manager_set_sync (m, sync);
 	election_manager_set_peering (m, peering);
 
@@ -726,6 +729,7 @@ test_sequence (void)
 
 	g_assert_no_error (election_manager_create (&config, &manager));
 	g_assert_nonnull (manager);
+	manager->synchronous_completions = TRUE;
 	election_manager_set_sync (manager, sync);
 	election_manager_set_peering (manager, peering);
 

--- a/tools/oio-tool.c
+++ b/tools/oio-tool.c
@@ -156,6 +156,27 @@ _ping(gchar *dest, gchar *to)
 	}
 }
 
+static int
+_info(const char *dest)
+{
+	GByteArray *out = NULL;
+	GByteArray *encoded = message_marshall_gba_and_clean (
+			metautils_message_create_named(NAME_MSGNAME_SQLX_INFO));
+	gint64 start = oio_ext_monotonic_time();
+	GError *err = gridd_client_exec_and_concat(dest, 10.0, encoded, &out);
+	gint64 end = oio_ext_monotonic_time();
+	if (err) {
+		g_print("KO (%d) %s\n", err->code, err->message);
+		g_clear_error(&err);
+		return 1;
+	} else {
+		g_print("OK %lfs\n", (end - start) / (gdouble)G_TIME_SPAN_SECOND);
+		g_print("%.*s\n", (int)out->len, (gchar*)out->data);
+		return 0;
+	}
+	if (out) g_byte_array_free(out, TRUE);
+}
+
 static void
 _print_loc(const char *dotted_loc)
 {
@@ -199,6 +220,8 @@ main (int argc, char **argv)
 		}
 		_same_hash (argv[2], argc==4 ? argv[3] : "");
 		return 0;
+	} else if (!strcmp("info", argv[1])) {
+		return _info(argv[2]);
 	} else if (!strcmp("ping", argv[1])) {
 		if (argc > 3)
 			return _ping(argv[2], argv[3]);


### PR DESCRIPTION
* better management of complete disconnections
* asynchronous management of Zookeeper completion hooks
* enlarged default numbers: bases kept open in cache, timeout for elections retrial, service urls in cache
* new `/forward/info` oio-proxy route