### PR TITLE
Fix memory leaks (meta0, metautils)

### DIFF
--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -754,7 +754,7 @@ _client_fail(struct gridd_client_s *client, GError *why)
 {
 	EXTRA_ASSERT(client != NULL);
 	EXTRA_ASSERT(client->abstract.vtable == &VTABLE_CLIENT);
-	_client_replace_error(client, NEWERROR(why->code, "%s", why->message));
+	_client_replace_error(client, why);
 }
 
 static void

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -95,6 +95,7 @@ struct gridd_client_vtable_s
 	// as failed.
 	gboolean (*expire) (struct gridd_client_s *c, gint64 now);
 
+	// Gives the ownership of `why` to the gridd_client_s `self`
 	void (*fail) (struct gridd_client_s *c, GError *why);
 };
 
@@ -121,6 +122,8 @@ gboolean gridd_client_finished (struct gridd_client_s *self);
 gboolean gridd_client_start (struct gridd_client_s *self);
 gboolean gridd_client_expire (struct gridd_client_s *self, gint64 now);
 void gridd_client_react (struct gridd_client_s *self);
+
+/* Gives the ownership of `why` to the gridd_client_s `self` */
 void gridd_client_fail (struct gridd_client_s *self, GError *why);
 
 /* Instanciate a client with the default VTABLE */

--- a/metautils/lib/gridd_client_ext.c
+++ b/metautils/lib/gridd_client_ext.c
@@ -227,9 +227,7 @@ retry:
 		GError *err = socket_get_error(pfd.fd);
 		g_prefix_error(&err, "%s: ", gridd_client_url(client));
 		gridd_client_fail(client, err);
-		g_clear_error(&err);
-	}
-	else if (pfd.revents & (POLLIN|POLLOUT)) {
+	} else if (pfd.revents & (POLLIN|POLLOUT)) {
 		gridd_client_react(client);
 	}
 	return NULL;
@@ -292,10 +290,9 @@ retry:
 			GError *err = socket_get_error(pfd[i].fd);
 			g_prefix_error(&err, "%s: ", gridd_client_url(last));
 			gridd_client_fail(last, err);
-			g_clear_error(&err);
-		}
-		else
+		} else {
 			gridd_client_react(last);
+		}
 	}
 
 	/* Now check for expired clients */


### PR DESCRIPTION
The metautils leak specially affects all the sqliterepo-based services.
It happens under heavy loads, when replication RPC generate timeouts on the client side (e.g. "queued for too long").