### PR TITLE
Various fixes required (or not) by oiofs

### DIFF
--- a/core/oiourl.h
+++ b/core/oiourl.h
@@ -111,7 +111,9 @@ const char * oio_url_get(struct oio_url_s *u, enum oio_url_field_e f);
 
 int oio_url_has(const struct oio_url_s *u, enum oio_url_field_e f);
 
-/* <id> must be oio_url_get_id_size() bytes long */
+/** Set the container id from its binary representation.
+ * Use oio_url_set(u, OIOURL_CONTENTID, id) to set it with an hexadecimal str.
+ * <id> must be oio_url_get_id_size() bytes long */
 void oio_url_set_id(struct oio_url_s *u, const void *id);
 
 /* the returned value points to an array of oio_url_get_id_size() bytes long. */

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -515,6 +515,8 @@ _create_container_init_phase(struct sqlx_sqlite3_s *sq3,
 	}
 	if (!err) {
 		m2db_set_ctime (sq3, oio_ext_real_time());
+		m2db_set_size(sq3, 0);
+		m2db_set_obj_count(sq3, 0);
 		sqlx_admin_init_i64(sq3, META2_INIT_FLAG, 1);
 	}
 	if (!err && params->properties) {


### PR DESCRIPTION
- improve `fmemopen()` binary mode workaround
- set size and object count database entries at container creation
- improve some error messages
- add comment on `oio_url_set_id()`