### PR TITLE
Fix the concurrent auto-creation of a container

### DIFF
--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1712,8 +1712,14 @@ retry:
 			GRID_DEBUG("Resource not found, autocreation");
 			autocreate = FALSE;
 			g_clear_error (&err);
-			if (!(err = _m2_container_create_with_properties (args, NULL)))
+			err = _m2_container_create_with_properties (args, NULL);
+			if (!err)
 				goto retry;
+			if (err->code == CODE_CONTAINER_EXISTS
+					|| err->code == CODE_USER_EXISTS) {
+				g_clear_error(&err);
+				goto retry;
+			}
 		}
 	}
 	return _reply_m2_error (args, err);

--- a/proxy/path_parser.c
+++ b/proxy/path_parser.c
@@ -227,14 +227,14 @@ static gchar *
 _stat_name (const char *prefix, const char *tail, gchar *d, gsize dlen)
 {
 	if (g_str_has_prefix(tail, P))
-		dlen = g_snprintf (d, dlen, "%s.%s", prefix, tail+sizeof(P)-1);
+		g_snprintf (d, dlen, "%s.%s", prefix, tail+sizeof(P)-1);
 	else if (g_str_has_prefix(tail, PROXYD_PREFIX))
-		dlen = g_snprintf (d, dlen, "%s.%s", prefix, tail+sizeof(PROXYD_PREFIX)-1);
+		g_snprintf (d, dlen, "%s.%s", prefix, tail+sizeof(PROXYD_PREFIX)-1);
 	else
-		dlen = g_snprintf (d, dlen, "%s.%s", prefix, tail);
+		g_snprintf (d, dlen, "%s.%s", prefix, tail);
 
 	/* replace ugly characters by '_' */
-	for (int i=strlen (prefix)+1; d[i] ;++i) {
+	for (size_t i=strlen (prefix)+1; d[i] ;++i) {
 		if (!g_ascii_isalnum (d[i]))
 			d[i]='_';
 	}


### PR DESCRIPTION
The ALREADY_EXISTS erorr while auto-creating a container (during a content creation) is not considered as an error.