### PR TITLE
sqliterepo: Shorten the cnx timeout for USE and GETVERS requests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -210,10 +210,12 @@ Used by `gcc`
 | M2V2_CLIENT_TIMEOUT | 10.0 | <double> value telling the default timeout for meta2 requests, in seconds. |
 | M2V2_CLIENT_TIMEOUT_HUGE | 10.0 | <double> value telling the default timeout for meta2 requests, in seconds. |
 | SQLX_CLIENT_TIMEOUT | 30.0 | <double> value telling the default timeout for sqlx requests, in seconds. |
+| SQLX_CNX_TIMEOUT_GETVERS | 0.5 | <double> value telling the default timeout for DB_VERS requests, in seconds. |
+| SQLX_CNX_TIMEOUT_USE | 0.25 | <double> value telling the default timeout for DB_USE (tcp) requests, in seconds. |
 | SQLX_SYNC_TIMEOUT | 4.0 | <double> value telling the default timeout for sqlx requests, in seconds. |
 | SQLX_REPLI_TIMEOUT | 10.0 | <double> value telling the default timeout for sqlx requests, in seconds. |
 | SQLX_RESYNC_TIMEOUT | 30.0 | <double> value telling the default timeout for sqlx requests, in seconds. |
-| COMMON_CNX_TIMEOUT | 2 * G_TIME_SPAN_SECOND | In monotonic clock's precision |
+| COMMON_CNX_TIMEOUT | 2.0 | <double> value in seconds |
 | COMMON_CLIENT_TIMEOUT | 30.0 | In monotonic clock's precision |
 | COMMON_STAT_TIMEOUT | 5.0 | <double> value telling the default timeout for /stat requests outgoing the proxy, in seconds. |
 

--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS core library
-Copyright (C) 2015-2016 OpenIO, original work as part of OpenIO SDS
+Copyright (C) 2015-2017 OpenIO, original work as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -179,7 +179,7 @@ extern "C" {
 # endif
 
 # ifndef  COMMON_CNX_TIMEOUT
-#  define COMMON_CNX_TIMEOUT (2*G_TIME_SPAN_SECOND)
+#  define COMMON_CNX_TIMEOUT 2.0
 # endif
 
 # ifndef COMMON_CLIENT_TIMEOUT
@@ -192,6 +192,18 @@ extern "C" {
 
 # ifndef SQLX_CLIENT_TIMEOUT
 #  define SQLX_CLIENT_TIMEOUT 30.0
+# endif
+
+/* Timeout when connecting for DB_USE requests
+   in seconds */
+# ifndef SQLX_CNX_TIMEOUT_USE
+#  define SQLX_CNX_TIMEOUT_USE 0.25
+# endif
+
+/* Timeout when connecting for GETVERS requests
+   in seconds */
+# ifndef SQLX_CNX_TIMEOUT_GETVERS
+#  define SQLX_CNX_TIMEOUT_GETVERS 0.5
 # endif
 
 /* Timeout for synchronisation requests (USE, GETVERS)

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS metautils
 Copyright (C) 2014 Worldine, original work as part of Redcurrant
-Copyright (C) 2015 OpenIO, modified as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, modified as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -22,14 +22,6 @@ License along with this library.
 
 # include <glib.h>
 # include "metautils.h"
-
-# ifndef GRIDC_DEFAULT_TIMEOUT_STEP
-#  define GRIDC_DEFAULT_TIMEOUT_STEP 10.0
-# endif
-
-# ifndef GRIDC_DEFAULT_TIMEOUT_OVERALL
-#  define GRIDC_DEFAULT_TIMEOUT_OVERALL 30.0
-# endif
 
 struct gridd_client_s;
 struct gridd_client_factory_s;
@@ -75,9 +67,12 @@ struct gridd_client_vtable_s
 	// Tells to keep the connection open between requests.
 	void (*set_keepalive) (struct gridd_client_s *c, gboolean on);
 
-	// Force the timeout for each signel request (step), and for each request
-	// and its redirections.
+	// Force global timeout for the operation (all the request, including
+	// the redirections)
 	void (*set_timeout) (struct gridd_client_s *c, gdouble seconds);
+
+	// Force the connection timeout for each unit request
+	void (*set_timeout_cnx) (struct gridd_client_s *c, gdouble seconds);
 
 	// Returns if the client's last change is older than 'now'
 	gboolean (*expired) (struct gridd_client_s *c, gint64 now);
@@ -117,6 +112,7 @@ int gridd_client_fd (struct gridd_client_s *self);
 GError * gridd_client_set_fd(struct gridd_client_s *self, int fd);
 void gridd_client_set_keepalive(struct gridd_client_s *self, gboolean on);
 void gridd_client_set_timeout (struct gridd_client_s *self, gdouble seconds);
+void gridd_client_set_timeout_cnx (struct gridd_client_s *self, gdouble sec);
 gboolean gridd_client_expired(struct gridd_client_s *self, gint64 now);
 gboolean gridd_client_finished (struct gridd_client_s *self);
 gboolean gridd_client_start (struct gridd_client_s *self);

--- a/server/internals.h
+++ b/server/internals.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS server
 Copyright (C) 2014 Worldine, original work as part of Redcurrant
-Copyright (C) 2015 OpenIO, modified as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, modified as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -28,7 +28,7 @@ License along with this library.
 #endif
 
 #ifndef OIO_SERVER_UDP_QUEUE_MAXAGE
-#define OIO_SERVER_UDP_QUEUE_MAXAGE COMMON_CNX_TIMEOUT
+#define OIO_SERVER_UDP_QUEUE_MAXAGE (2 * G_TIME_SPAN_SECOND)
 #endif
 
 enum {

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS server
 Copyright (C) 2014 Worldine, original work as part of Redcurrant
-Copyright (C) 2015 OpenIO, modified as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, modified as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -686,8 +686,8 @@ _cb_ping(struct network_client_s *clt, struct network_server_s *srv)
 
 		const gint64 now = oio_ext_monotonic_time();
 
-		/* COMMON_CNX_TIMEOUT is arbitrary but it avoid managing pings
-		 * that have probably been retried by the emitter. */
+		/* OIO_SERVER_UDP_QUEUE_MAXAGE is arbitrary but it avoids managing
+		 * pings that have probably been retried by the emitter. */
 		if (now - clt->time.evt_in > OIO_SERVER_UDP_QUEUE_MAXAGE) {
 			GRID_DEBUG("PING %s -> %s queued for too long",
 					clt->peer_name, clt->local_name);

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS sqliterepo
 Copyright (C) 2014 Worldine, original work as part of Redcurrant
-Copyright (C) 2015 OpenIO, modified as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, modified as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -481,7 +481,10 @@ _direct_use (struct sqlx_peering_s *self,
 	} else {
 		struct event_client_s *mc = g_malloc0 (sizeof(struct event_client_s));
 		mc->client = gridd_client_factory_create_client (p->factory);
+
 		gridd_client_set_timeout(mc->client, SQLX_SYNC_TIMEOUT);
+		gridd_client_set_timeout_cnx(mc->client, SQLX_CNX_TIMEOUT_USE);
+
 		GError *err = gridd_client_connect_url (mc->client, url);
 		if (err) {
 			GRID_DEBUG("USE error: (%d) %s", err->code, err->message);
@@ -652,6 +655,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 	mc->vremote = NULL;
 
 	gridd_client_set_timeout(mc->ec.client, SQLX_SYNC_TIMEOUT);
+	gridd_client_set_timeout_cnx(mc->ec.client, SQLX_CNX_TIMEOUT_GETVERS);
 
 	GError *err = gridd_client_connect_url (mc->ec.client, url);
 	if (NULL != err) {


### PR DESCRIPTION
From a default of 2s, use now 0.5s for GETVERS and 0.25s for USE.