### PR TITLE
oio/rdir: Do not link from the simple rdir client

### DIFF
--- a/oio/cli/admin/client.py
+++ b/oio/cli/admin/client.py
@@ -1,6 +1,6 @@
 import logging
 from oio.common.utils import json
-from oio.rdir.client import RdirClient
+from oio.rdir.client import RdirClient, RdirDispatcher
 from oio.event.client import EventClient
 from oio.conscience.client import ConscienceClient
 from oio.directory.meta0 import Meta0Client
@@ -14,7 +14,8 @@ class AdminClient(object):
     def __init__(self, namespace, session=None, **kwargs):
         self.conf = {'namespace': namespace}
         self.conf.update(kwargs)
-        self._volume = None
+        self._rdir = None
+        self._rdir_lb = None
         self._event = None
         self._cluster = None
         self._meta0 = None
@@ -22,9 +23,15 @@ class AdminClient(object):
 
     @property
     def volume(self):
-        if not self._volume:
-            self._volume = RdirClient(self.conf, session=self.session)
-        return self._volume
+        if not self._rdir:
+            self._rdir = RdirClient(self.conf, session=self.session)
+        return self._rdir
+
+    @property
+    def rdir_lb(self):
+        if not self._rdir_lb:
+            self._rdir_lb = RdirDispatcher(self.conf, session=self.session)
+        return self._rdir_lb
 
     @property
     def event(self):

--- a/oio/cli/admin/directory.py
+++ b/oio/cli/admin/directory.py
@@ -57,7 +57,7 @@ class DirectoryInit(DirectoryCmd):
         if parsed_args.rdir:
             self.log.info("Assigning rdir services to rawx services...")
             time.sleep(5)  # Let meta1 fetch the list of managed bases
-            self.app.client_manager.admin.volume.assign_all_rawx()
+            self.app.client_manager.admin.rdir_lb.assign_all_rawx()
         self.log.info("Done")
 
 

--- a/oio/cli/admin/volume.py
+++ b/oio/cli/admin/volume.py
@@ -194,7 +194,7 @@ class BootstrapVolume(lister.Lister):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
 
-        all_rawx = self.app.client_manager.admin.volume.assign_all_rawx()
+        all_rawx = self.app.client_manager.admin.rdir_lb.assign_all_rawx()
 
         results = list()
         for rawx in all_rawx:

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -35,7 +35,7 @@ class RdirDispatcher(Client):
                  for x in all_rdir}
 
         if not cs:
-            raise ClientException("The conscience client is not readdy")
+            raise ClientException("The conscience client is not ready")
         if len(all_rdir) <= 0:
             raise ServiceUnavailable("No rdir service found in %s" % self.ns)
 
@@ -136,7 +136,7 @@ class RdirClient(Client):
             body[key] = value
 
         self._rdir_request(volume_id, 'POST', 'rdir/push', create=True,
-                           json=body, headers={})
+                           json=body)
 
     def chunk_delete(self, volume_id, container_id, content_id, chunk_id):
         """Unreference a chunk from the reverse directory"""

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -12,11 +12,17 @@ def _make_id(ns, type_, addr):
     return "%s|%s|%s" % (ns, type_, addr)
 
 
-class RdirClient(Client):
+def _filter_rdir_host(allsrv):
+    for srv in allsrv.get('srv', {}):
+        if srv['type'] == 'rdir':
+            return srv['host']
+    raise NotFound("No rdir service found in %s" % (allsrv, ))
+
+
+class RdirDispatcher(Client):
     def __init__(self, conf, **kwargs):
-        super(RdirClient, self).__init__(conf, **kwargs)
+        super(RdirDispatcher, self).__init__(conf, **kwargs)
         self.directory = DirectoryAPI(self.ns, self.endpoint, **kwargs)
-        self._addr_cache = dict()
 
     def assign_all_rawx(self):
         """
@@ -27,13 +33,19 @@ class RdirClient(Client):
         all_rdir = cs.all_services('rdir', True)
         by_id = {_make_id(self.ns, 'rdir', x['addr']): x
                  for x in all_rdir}
+
+        if not cs:
+            raise ClientException("The conscience client is not readdy")
+        if len(all_rdir) <= 0:
+            raise ServiceUnavailable("No rdir service found in %s" % self.ns)
+
         for rawx in all_rawx:
             try:
                 # Verify that there is no rdir linked
                 resp = self.directory.get(RDIR_ACCT, rawx['addr'],
                                           service_type='rdir')
                 rawx['rdir'] = by_id[_make_id(self.ns, 'rdir',
-                                              self._lookup_rdir_host(resp))]
+                                              _filter_rdir_host(resp))]
             except (NotFound, ClientException):
                 if rawx['score'] <= 0:
                     self.logger.warn("rawx %s has score %s, and thus cannot be"
@@ -47,18 +59,11 @@ class RdirClient(Client):
                 rawx['rdir'] = by_id[rdir]
         return all_rawx
 
-    def _smart_link_rdir(self, volume_id, cs=None, all_rdir=None):
+    def _smart_link_rdir(self, volume_id, cs, all_rdir):
         """
         Force the load balancer to avoid services that already host more
         bases than the average while selecting rdir services.
         """
-        if not cs:
-            cs = ConscienceClient(self.conf)
-        if not all_rdir:
-            all_rdir = cs.all_services('rdir', True)
-        if len(all_rdir) <= 0:
-            raise ServiceUnavailable("No rdir service found in %s" % self.ns)
-
         avail_base_count = [x['tags']['stat.opened_db_count'] for x in all_rdir
                             if x['score'] > 0]
         if len(avail_base_count) <= 0:
@@ -83,63 +88,41 @@ class RdirClient(Client):
                              forced, autocreate=True)
         return polled['id']
 
-    def _link_rdir(self, volume_id, smart=True):
-        if not smart:
-            self.directory.link(RDIR_ACCT, volume_id, 'rdir',
-                                autocreate=True)
-        else:
-            self._smart_link_rdir(volume_id)
-        return self.directory.get(RDIR_ACCT, volume_id, service_type='rdir')
 
-    def _lookup_rdir_host(self, resp):
-        host = None
-        for srv in resp.get('srv', {}):
-            if srv['type'] == 'rdir':
-                host = srv['host']
-        if not host:
-            raise ClientException("No rdir service found in %s" % resp)
-        return host
+class RdirClient(Client):
+    def __init__(self, conf, **kwargs):
+        super(RdirClient, self).__init__(conf, **kwargs)
+        self.directory = DirectoryAPI(self.ns, self.endpoint, **kwargs)
+        self._addr_cache = dict()
 
-    def _get_rdir_addr(self, volume_id, create=False, nocache=False):
-        if not nocache and volume_id in self._addr_cache:
+    def _clear_cache(self, volume_id):
+        del self._addr_cache[volume_id]
+
+    def _get_rdir_addr(self, volume_id):
+        # Initial lookup in the cache
+        if volume_id in self._addr_cache:
             return self._addr_cache[volume_id]
-        resp = {}
+        # Not cached, try a direct lookup
         try:
             resp = self.directory.get(RDIR_ACCT, volume_id,
                                       service_type='rdir')
+            host = _filter_rdir_host(resp)
+            # Add the new service to the cache
+            self._addr_cache[volume_id] = host
+            return host
         except NotFound:
-            if not create:
-                raise VolumeException('No such volume %s' % volume_id)
+            raise VolumeException('No rdir assigned to volume %s' % volume_id)
 
-        try:
-            host = self._lookup_rdir_host(resp)
-        except ClientException:
-            # Reference exists but no rdir linked
-            if not create:
-                raise
-            resp = self._link_rdir(volume_id)
-            host = self._lookup_rdir_host(resp)
-        self._addr_cache[volume_id] = host
-        return host
-
-    def _make_uri(self, action, volume_id, create=False, nocache=False):
-        rdir_host = self._get_rdir_addr(volume_id, create=create,
-                                        nocache=nocache)
-        uri = 'http://%s/v1/%s' % (rdir_host, action)
-        return uri
+    def _make_uri(self, action, volume_id):
+        rdir_host = self._get_rdir_addr(volume_id)
+        return 'http://%s/v1/%s' % (rdir_host, action)
 
     def _rdir_request(self, volume, method, action, create=False, **kwargs):
         params = {'vol': volume}
         if create:
             params['create'] = '1'
-        uri = self._make_uri(action, volume, create=create)
-        try:
-            resp, body = self._direct_request(method, uri, params=params,
-                                              **kwargs)
-        except NotFound:
-            uri = self._make_uri(action, volume, create=create, nocache=True)
-            resp, body = self._direct_request(method, uri, params=params,
-                                              **kwargs)
+        uri = self._make_uri(action, volume)
+        resp, body = self._direct_request(method, uri, params=params, **kwargs)
         return resp, body
 
     def chunk_push(self, volume_id, container_id, content_id, chunk_id,
@@ -152,10 +135,8 @@ class RdirClient(Client):
         for key, value in data.iteritems():
             body[key] = value
 
-        headers = {}
-
         self._rdir_request(volume_id, 'POST', 'rdir/push', create=True,
-                           json=body, headers=headers)
+                           json=body, headers={})
 
     def chunk_delete(self, volume_id, container_id, content_id, chunk_id):
         """Unreference a chunk from the reverse directory"""

--- a/tests/functional/api/test_directory.py
+++ b/tests/functional/api/test_directory.py
@@ -1,7 +1,7 @@
 from oio.api.directory import DirectoryAPI
 from oio.common import exceptions as exc
 from oio.conscience.client import ConscienceClient
-from oio.rdir.client import RdirClient
+from oio.rdir.client import RdirDispatcher
 from tests.utils import random_str, BaseTestCase
 
 
@@ -265,7 +265,7 @@ class TestDirectoryAPI(BaseTestCase):
             self.api.delete('_RDIR_TEST', rawx['addr'])
 
     def test_rdir_repartition(self):
-        client = RdirClient({'namespace': self.ns})
+        client = RdirDispatcher({'namespace': self.ns})
         all_rawx = client.assign_all_rawx()
         by_rdir = dict()
         total = 0


### PR DESCRIPTION
Keep this for a class whose purpose is administration and deployment.

The "link" in the directory (meta1) is supposed already donbe in a "bootstrap" step of the deployment. Only the lazy creation of the rdir DB is performed.

When then avoid any relinking to a (supposedly) rdir service, then avoiding the mistake to link a rawx service. De facto fixes #854 .