### PR TITLE
rawx: Allow to turn off the event source

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -342,6 +342,7 @@ extern "C" {
 # define OIO_CFG_SWIFT        "swift"
 # define OIO_CFG_ECD          "ecd"
 
+# define OIO_CFG_RAWX_EVENTS   "rawx_events"
 # define OIO_CFG_LOG_OUTGOING  "log_outgoing"
 # define OIO_CFG_UDP_ALLOWED  "udp_allowed"
 # define OIO_CFG_AVOID_BADSRV  "avoid_faulty_services"

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -358,14 +358,16 @@ rawx_hook_child_init(apr_pool_t *pchild, server_rec *s)
 
 	conf->cleanup = _cleanup_child;
 
-	gchar *event_agent_addr = oio_cfg_get_eventagent(conf->ns_name);
-	GError *err = rawx_event_init(event_agent_addr);
-	if (NULL != err) {
-		DAV_ERROR_POOL(pchild, 0, "Failed to initialize event context: (%d) %s",
-				err->code, err->message);
-		g_clear_error (&err);
+	if (oio_cfg_get_bool(conf->ns_name, OIO_CFG_RAWX_EVENTS, FALSE)) {
+		gchar *event_agent_addr = oio_cfg_get_eventagent(conf->ns_name);
+		GError *err = rawx_event_init(event_agent_addr);
+		if (NULL != err) {
+			DAV_ERROR_POOL(pchild, 0, "Failed to initialize event context: (%d) %s",
+					err->code, err->message);
+			g_clear_error (&err);
+		}
+		g_free(event_agent_addr);
 	}
-	g_free(event_agent_addr);
 
 	oio_log_to_syslog ();
 }


### PR DESCRIPTION
Controlled by the "rawx_events" in sds.conf
Disabled by default.