### PR TITLE
Rdir and blob-rebuilder improvements (fix #855)

### DIFF
--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -35,6 +35,8 @@ def make_arg_parser():
                         help="Max chunks per second (30)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
+    parser.add_argument('--allow-same-rawx', action='store_true',
+                        help="Allow rebuilding a chunk on the original rawx")
 
     return parser
 
@@ -61,6 +63,7 @@ if __name__ == '__main__':
     if args.chunks_per_second is not None:
         conf['chunks_per_second'] = args.chunks_per_second
     conf['namespace'] = args.namespace
+    conf['allow_same_rawx'] = args.allow_same_rawx
 
     logger = get_logger(conf, None, not args.quiet)
 

--- a/oio/blob/rebuilder.py
+++ b/oio/blob/rebuilder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 OpenIO, original work as part of
+# Copyright (C) 2015-2017 OpenIO, original work as part of
 # OpenIO Software Defined Storage
 #
 # This library is free software; you can redistribute it and/or
@@ -49,6 +49,8 @@ class BlobRebuilderWorker(object):
             conf.get('bytes_per_second'), 10000000)
         self.rdir_fetch_limit = int_value(
             conf.get('rdir_fetch_limit'), 100)
+        self.allow_same_rawx = true_value(
+            conf.get('allow_same_rawx'))
         self.rdir_client = RdirClient(conf)
         self.content_factory = ContentFactory(conf)
 
@@ -157,7 +159,7 @@ class BlobRebuilderWorker(object):
             raise OrphanChunk("Chunk not found in content")
         chunk_size = chunk.size
 
-        content.rebuild_chunk(chunk_id)
+        content.rebuild_chunk(chunk_id, allow_same_rawx=self.allow_same_rawx)
 
         self.rdir_client.chunk_push(self.volume, container_id, content_id,
                                     chunk_id, rtime=int(time.time()))

--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 OpenIO, original work as part of
+# Copyright (C) 2015-2017 OpenIO, original work as part of
 # OpenIO Software Defined Storage
 #
 # This library is free software; you can redistribute it and/or
@@ -85,7 +85,7 @@ class Content(object):
             version=self.version, chunk_method=self.chunk_method,
             mime_type=self.mime_type, data=self.chunks.raw())
 
-    def rebuild_chunk(self, chunk_id):
+    def rebuild_chunk(self, chunk_id, allow_same_rawx=False):
         raise NotImplementedError()
 
     def create(self, stream):

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 OpenIO, original work as part of
+# Copyright (C) 2015-2017 OpenIO, original work as part of
 # OpenIO Software Defined Storage
 #
 # This library is free software; you can redistribute it and/or
@@ -22,7 +22,7 @@ from oio.common.utils import GeneratorReader
 
 
 class ECContent(Content):
-    def rebuild_chunk(self, chunk_id):
+    def rebuild_chunk(self, chunk_id, allow_same_rawx=False):
         current_chunk = self.chunks.filter(id=chunk_id).one()
 
         if current_chunk is None:
@@ -31,7 +31,10 @@ class ECContent(Content):
         chunks = self.chunks.filter(metapos=current_chunk.metapos)\
             .exclude(id=chunk_id)
 
-        spare_url = self._get_spare_chunk(chunks.all(), [current_chunk])
+        broken_list = list()
+        if not allow_same_rawx:
+            broken_list.append(current_chunk)
+        spare_url = self._get_spare_chunk(chunks.all(), broken_list)
 
         handler = ECRebuildHandler(
             chunks.raw(), current_chunk.subpos, self.storage_method)

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 OpenIO, original work as part of
+# Copyright (C) 2015-2017 OpenIO, original work as part of
 # OpenIO Software Defined Storage
 #
 # This library is free software; you can redistribute it and/or
@@ -74,7 +74,7 @@ class PlainContent(Content):
         self._create_object()
         return final_chunks, bytes_transferred, content_checksum
 
-    def rebuild_chunk(self, chunk_id):
+    def rebuild_chunk(self, chunk_id, allow_same_rawx=False):
         current_chunk = self.chunks.filter(id=chunk_id).one()
         if current_chunk is None:
             raise exc.OrphanChunk("Chunk not found in content")
@@ -84,8 +84,11 @@ class PlainContent(Content):
         if len(duplicate_chunks) == 0:
             raise UnrecoverableContent("No copy of missing chunk")
 
+        broken_list = list()
+        if not allow_same_rawx:
+            broken_list.append(current_chunk)
         spare_urls = self._get_spare_chunk(
-            duplicate_chunks, [current_chunk])
+            duplicate_chunks, broken_list)
 
         uploaded = False
         for src in duplicate_chunks:

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -23,10 +23,15 @@ class RdirDispatcher(Client):
     def __init__(self, conf, **kwargs):
         super(RdirDispatcher, self).__init__(conf, **kwargs)
         self.directory = DirectoryAPI(self.ns, self.endpoint, **kwargs)
+        self.rdir = RdirClient(conf, **kwargs)
 
-    def assign_all_rawx(self):
+    def assign_all_rawx(self, max_per_rdir=None):
         """
         Find a rdir service for all rawx that don't have one already.
+
+        :param max_per_rdir: maximum number or rawx services that an rdir
+                             can be linked to
+        :type max_per_rdir: `int`
         """
         cs = ConscienceClient(self.conf)
         all_rawx = cs.all_services('rawx')
@@ -44,8 +49,12 @@ class RdirDispatcher(Client):
                 # Verify that there is no rdir linked
                 resp = self.directory.get(RDIR_ACCT, rawx['addr'],
                                           service_type='rdir')
-                rawx['rdir'] = by_id[_make_id(self.ns, 'rdir',
-                                              _filter_rdir_host(resp))]
+                rdir_host = _filter_rdir_host(resp)
+                try:
+                    rawx['rdir'] = by_id[_make_id(self.ns, 'rdir', rdir_host)]
+                except KeyError:
+                    self.logger.warn("rdir %s linked to rawx %s seems down",
+                                     rdir_host, rawx['addr'])
             except (NotFound, ClientException):
                 if rawx['score'] <= 0:
                     self.logger.warn("rawx %s has score %s, and thus cannot be"
@@ -53,27 +62,30 @@ class RdirDispatcher(Client):
                                      "limitation)",
                                      rawx['addr'], rawx['score'])
                     continue
-                rdir = self._smart_link_rdir(rawx['addr'], cs, all_rdir)
+                rdir = self._smart_link_rdir(rawx['addr'], cs, all_rdir,
+                                             max_per_rdir)
                 n_bases = by_id[rdir]['tags'].get("stat.opened_db_count", 0)
                 by_id[rdir]['tags']["stat.opened_db_count"] = n_bases + 1
                 rawx['rdir'] = by_id[rdir]
         return all_rawx
 
-    def _smart_link_rdir(self, volume_id, cs, all_rdir):
+    def _smart_link_rdir(self, volume_id, cs, all_rdir, max_per_rdir=None):
         """
         Force the load balancer to avoid services that already host more
-        bases than the average while selecting rdir services.
+        bases than the average (or more than `max_per_rdir`)
+        while selecting rdir services.
         """
-        avail_base_count = [x['tags']['stat.opened_db_count'] for x in all_rdir
-                            if x['score'] > 0]
-        if len(avail_base_count) <= 0:
+        opened_db = [x['tags']['stat.opened_db_count'] for x in all_rdir
+                     if x['score'] > 0]
+        if len(opened_db) <= 0:
             raise ServiceUnavailable(
                     "No valid rdir service found in %s" % self.ns)
-        mean = sum(avail_base_count) / float(len(avail_base_count))
+        if not max_per_rdir:
+            max_per_rdir = max(sum(opened_db) / float(len(opened_db)) - 1, 1)
         avoids = [_make_id(self.ns, "rdir", x['addr'])
                   for x in all_rdir
                   if x['score'] > 0 and
-                  x['tags']['stat.opened_db_count'] > mean]
+                  x['tags']['stat.opened_db_count'] >= max_per_rdir]
         known = [_make_id(self.ns, "rawx", volume_id)]
         try:
             polled = cs.poll('rdir', avoid=avoids, known=known)[0]
@@ -86,6 +98,11 @@ class RdirDispatcher(Client):
                   'seq': 1, 'args': "", 'id': polled['id']}
         self.directory.force(RDIR_ACCT, volume_id, 'rdir',
                              forced, autocreate=True)
+        try:
+            self.rdir.create(volume_id)
+        except Exception as exc:
+            self.logger.warn("Failed to create database for %s on %s: %s",
+                             volume_id, polled['addr'], exc)
         return polled['id']
 
 
@@ -124,6 +141,10 @@ class RdirClient(Client):
         uri = self._make_uri(action, volume)
         resp, body = self._direct_request(method, uri, params=params, **kwargs)
         return resp, body
+
+    def create(self, volume_id):
+        """Create the database for `volume_id` on the appropriate rdir"""
+        self._rdir_request(volume_id, 'POST', 'rdir/create')
 
     def chunk_push(self, volume_id, container_id, content_id, chunk_id,
                    **data):

--- a/oio/rdir/server_db.py
+++ b/oio/rdir/server_db.py
@@ -60,15 +60,15 @@ class RdirBackend(object):
         return "%s/%s" % (self.db_path, volume_id)
 
     def create(self, volume_id):
-        db_path = self._get_db_path(volume_id)
-        DB(db_path, create_if_missing=True)
+        self._get_db(volume_id, create_if_missing=True)
 
     @handle_db_not_found
-    def _get_db(self, volume_id):
+    def _get_db(self, volume_id, create_if_missing=False):
         with self.dbLock:
             if volume_id not in self.dbs:
                 db_path = self._get_db_path(volume_id)
-                self.dbs[volume_id] = DB(db_path, create_if_missing=False)
+                self.dbs[volume_id] = DB(db_path,
+                                         create_if_missing=create_if_missing)
             db = self.dbs[volume_id]
         return db
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ openio.directory =
 
 openio.admin =
     volume_show = oio.cli.admin.volume:ShowVolume
+    volume_assignation = oio.cli.admin.volume:DisplayVolumeAssignation
     volume_admin_incident = oio.cli.admin.volume:IncidentAdminVolume
     volume_admin_lock = oio.cli.admin.volume:LockAdminVolume
     volume_admin_unlock = oio.cli.admin.volume:UnlockAdminVolume

--- a/tests/unit/rdir/test_backend.py
+++ b/tests/unit/rdir/test_backend.py
@@ -254,10 +254,9 @@ class TestRdirBackend(unittest.TestCase):
                          })
 
     def test_status(self):
-        self.assertEqual(self.rdir.status(), {'opened_db_count': 0})
-        self.rdir.chunk_push(self.volume, self.container_0, self.content_0,
-                             self.chunk_0, rtime=5555, mtime=6666)
         self.assertEqual(self.rdir.status(), {'opened_db_count': 1})
+        self.rdir.create("myvolume1")
+        self.assertEqual(self.rdir.status(), {'opened_db_count': 2})
 
     def test_multi_volume(self):
         self.rdir.create("myvolume1")

--- a/tests/unit/rdir/test_server.py
+++ b/tests/unit/rdir/test_server.py
@@ -217,4 +217,5 @@ class TestRdirServer(unittest.TestCase):
         resp = self.app.get('/status')
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data)
-        self.assertEqual(data, {'opened_db_count': 0})
+        # The base remains open after it has been created
+        self.assertEqual(data, {'opened_db_count': 1})


### PR DESCRIPTION
* Create databases just after linking to rawx
* Add `openio volume assignation` subcommand to display current rdir links
* Add option `--max-per-rdir` to `openio volume admin bootstrap` to enforce the maximum number of databases per rdir service
* Keep rdir databases open when they are created
* Allow rebuild of a chunk on the original rawx