### PR TITLE
proxy: expose the relink of a directory entry

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -133,21 +133,20 @@ gsize oio_ext_array_partition (gpointer *array, gsize len,
 
 GError *oio_ext_extract_json (struct json_object *obj,
 		struct oio_ext_json_mapping_s *tab) {
-	EXTRA_ASSERT (obj != NULL);
 	EXTRA_ASSERT (tab != NULL);
 	for (struct oio_ext_json_mapping_s *p=tab; p->out ;p++)
 		*(p->out) = NULL;
-	if (!json_object_is_type(obj, json_type_object))
-		return NEWERROR(400, "Not an object");
+	if (!obj || !json_object_is_type(obj, json_type_object))
+		return BADREQ("Not an object");
 	for (struct oio_ext_json_mapping_s *p=tab; p->out ;p++) {
 		struct json_object *o = NULL;
 		if (!json_object_object_get_ex(obj, p->name, &o) || !o) {
 			if (!p->mandatory)
 				continue;
-			return NEWERROR(400, "Missing field [%s]", p->name);
+			return BADREQ("Missing field [%s]", p->name);
 		}
 		if (!json_object_is_type(o, p->type))
-			return NEWERROR(400, "Invalid type for field [%s]", p->name);
+			return BADREQ("Invalid type for field [%s]", p->name);
 		*(p->out) = o;
 	}
 	return NULL;

--- a/meta1v2/meta1_backend.h
+++ b/meta1v2/meta1_backend.h
@@ -135,6 +135,19 @@ GError* meta1_backend_services_set(struct meta1_backend_s *m1,
 		struct oio_url_s *url, const gchar *packedurl,
 		gboolean autocreate, gboolean force);
 
+/* Find replacements for some services linked to a reference.
+ *
+ * @param url URLs of the reference whose services must be replaced
+ * @param kept Packed list of service URLs that must be kept
+ * @param replaced Packed list of service URLs that must be replaced
+ * @param dryrun If true, find replacement services but do not save them
+ *
+ * @note
+ * The elements of `kept` and `replaced` must have the same sequence number.
+ *
+ * @note
+ * The union of `kept` and `replaced` must match exactly the list of services
+ * already known by the meta1 for the same sequence number. */
 GError* meta1_backend_services_relink(struct meta1_backend_s *m1,
 		struct oio_url_s *url, const char *kept, const char *replaced,
 		gboolean dryrun, gchar ***out);

--- a/meta1v2/meta1_backend_services.c
+++ b/meta1v2/meta1_backend_services.c
@@ -66,7 +66,7 @@ urlv_get_max_seq(struct meta1_service_url_s **uv)
 {
 	gint seq = G_MININT;
 	if (uv) {
-		for (; *uv ;++uv) {
+		for (; *uv; ++uv) {
 			if (seq < (*uv)->seq)
 				seq = (*uv)->seq;
 		}
@@ -78,7 +78,7 @@ static gchar **
 pack_urlv(struct meta1_service_url_s **uv)
 {
 	GPtrArray *tmp = g_ptr_array_new();
-	for (; uv && *uv ;uv++)
+	for (; uv && *uv; uv++)
 		g_ptr_array_add(tmp, meta1_pack_url(*uv));
 	g_ptr_array_add(tmp, NULL);
 	return (gchar**)g_ptr_array_free(tmp, FALSE);
@@ -96,7 +96,7 @@ expand_url(struct meta1_service_url_s *u)
 	tmp = g_ptr_array_new();
 
 	split = g_strsplit(u->host, ",", -1);
-	for (p=split; p && *p ;p++) {
+	for (p=split; p && *p; p++) {
 		struct meta1_service_url_s *newurl;
 
 		newurl = meta1_url_dup(u);
@@ -118,10 +118,10 @@ expand_urlv(struct meta1_service_url_s **uv)
 
 	tmp = g_ptr_array_new();
 	if (uv) {
-		for (; *uv ;++uv) {
+		for (; *uv; ++uv) {
 			struct meta1_service_url_s **p, **utmp;
 			if (NULL != (utmp = expand_url(*uv))) {
-				for (p=utmp; *p ;++p)
+				for (p=utmp; *p; ++p)
 					g_ptr_array_add(tmp, *p);
 				g_free(utmp);
 			}
@@ -239,7 +239,7 @@ __del_container_services(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 	if (!urlv || !*urlv)
 		err = __del_container_all_services(sq3, url, srvtype);
 	else {
-		for (; !err && *urlv ;urlv++,line++) {
+		for (; !err && *urlv; urlv++,line++) {
 			gchar *end = NULL;
 
 			errno = 0;
@@ -733,7 +733,8 @@ _idem (struct meta1_service_url_s *u0, struct meta1_service_url_s *u1)
 	return u0->seq == u1->seq && !strcmp(u0->srvtype, u1->srvtype);
 }
 
-/* check if two arrays of urls contains the same items. */
+/* Check if `all` array contains exactly the same items as the union
+ * of `kept` and `replaced` arrays (order does not matter). */
 static gboolean
 __match_urlv (struct meta1_service_url_s **all, struct meta1_service_url_s **kept,
 		struct meta1_service_url_s **replaced)
@@ -745,7 +746,7 @@ __match_urlv (struct meta1_service_url_s **all, struct meta1_service_url_s **kep
 	GPtrArray *gpa_told = g_ptr_array_new ();
 
 	/* build two arrays of URL we can safely sort */
-	for (; *all ;++all) {
+	for (; *all; ++all) {
 		if ((*all)->seq == ref->seq)
 			g_ptr_array_add (gpa_inplace, *all);
 	}
@@ -761,7 +762,7 @@ __match_urlv (struct meta1_service_url_s **all, struct meta1_service_url_s **kep
 	g_ptr_array_sort (gpa_told, (GCompareFunc)_sorter);
 
 	/* identical sorted arrays have equal items at each position */
-	for (guint i=0; i<gpa_told->len ;++i) {
+	for (guint i=0; i<gpa_told->len; ++i) {
 		if (0 != strcmp(M1U(gpa_told->pdata[i])->host, M1U(gpa_inplace->pdata[i])->host))
 			goto out;
 	}
@@ -1124,14 +1125,14 @@ meta1_backend_services_relink(struct meta1_backend_s *m1,
 	if (NULL != (err = compound_type_parse(&ct, ref->srvtype)))
 		goto out;
 
-	/* Sanity check : all the services must have the same <seq,type> */
-	for (struct meta1_service_url_s **p = ukept; p && *p ;++p) {
+	/* Sanity check: all the services must have the same <seq,type> */
+	for (struct meta1_service_url_s **p = ukept; p && *p; ++p) {
 		if (!_idem(*p, ref)) {
 			err = BADREQ("Mismatch in URL set (%s)", "kept");
 			goto out;
 		}
 	}
-	for (struct meta1_service_url_s **p = urepl; p && *p ;++p) {
+	for (struct meta1_service_url_s **p = urepl; p && *p; ++p) {
 		if (!_idem(*p, ref)) {
 			err = BADREQ("Mismatch in URL set (%s)", "replaced");
 			goto out;
@@ -1139,7 +1140,7 @@ meta1_backend_services_relink(struct meta1_backend_s *m1,
 	}
 	/* Sanity check: all the kept/replaced services must have the type of
 	 * the oio_url */
-	for (struct meta1_service_url_s **p = urepl; p && *p ;++p) {
+	for (struct meta1_service_url_s **p = urepl; p && *p; ++p) {
 		if (0 != strcmp((*p)->srvtype, ct.fulltype)) {
 			err = BADREQ("Service type mismatch (URL vs. kept/replaced)");
 			goto out;

--- a/meta1v2/meta1_backend_services.c
+++ b/meta1v2/meta1_backend_services.c
@@ -720,10 +720,10 @@ __parse_and_expand (const char *packed)
 static gint
 _sorter (struct meta1_service_url_s **p0, struct meta1_service_url_s **p1)
 {
-	gint64 s0 = (*p0)->seq, s1 = (*p1)->seq;
+	const gint64 s0 = (*p0)->seq, s1 = (*p1)->seq;
 	if (s0 == s1)
 		return strcmp ((*p0)->host, (*p1)->host);
-	int one = s0 > s1;
+	const int one = s0 > s1;
 	return one ? one : -(s0 < s1);
 }
 

--- a/proxy/dir_actions.c
+++ b/proxy/dir_actions.c
@@ -251,6 +251,32 @@ action_dir_srv_renew (struct req_args_s *args, struct json_object *jargs)
 	return _reply_success_json (args, _pack_and_freev_m1url_list (NULL, urlv));
 }
 
+/**
+ * Find replacements for some services linked to a reference.
+ *
+ * Expects a JSON object like:
+ *
+ *  {
+ *    "kept": {
+ *      "seq": 1,
+ *      "type": "meta2",
+ *      "host": "192.168.56.1:6005,192.168.56.2:6005",
+ *      "args": ""
+ *    },
+ *    "replaced": {
+ *      "seq": 1,
+ *      "type": "meta2",
+ *      "host": "192.168.56.3:6005",
+ *      "args": ""
+ *    }
+ *  }
+ *
+ * "kept" is the description of services that must be kept.
+ * "replaced" is the description of services that must be replaced.
+ * Note that the meta1 expects that the union of "kept" and "replaced"
+ * matches exactly the list of services it knows for the specified
+ * sequence number.
+ */
 static enum http_rc_e
 action_dir_srv_relink (struct req_args_s *args, struct json_object *jargs)
 {

--- a/proxy/dir_actions.c
+++ b/proxy/dir_actions.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS proxy
 Copyright (C) 2014 Worldine, original work as part of Redcurrant
-Copyright (C) 2015 OpenIO, modified as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, modified as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -271,12 +271,16 @@ action_dir_srv_relink (struct req_args_s *args, struct json_object *jargs)
 		{NULL, NULL, 0, 0}
 	};
 	err = oio_ext_extract_json (jargs, mapping);
-	if (!err && jkept && json_object_is_type(jkept, json_type_object)) {
-		if (NULL != (err = meta1_service_url_load_json_object (jkept, &m1u_kept)))
+	if (!err && !jkept && !jrepl)
+		err = BADREQ("Missing [kept] and [replaced]");
+	if (!err && jkept) {
+		err = meta1_service_url_load_json_object (jkept, &m1u_kept);
+		if (err)
 			g_prefix_error (&err, "invalid service in [%s]: ", "kept");
 	}
-	if (!err && jrepl && json_object_is_type(jrepl, json_type_object)) {
-		if (NULL != (err = meta1_service_url_load_json_object (jrepl, &m1u_repl)))
+	if (!err && jrepl) {
+		err = meta1_service_url_load_json_object (jrepl, &m1u_repl);
+		if (err)
 			g_prefix_error (&err, "invalid service in [%s]: ", "replaced");
 	}
 
@@ -285,7 +289,8 @@ action_dir_srv_relink (struct req_args_s *args, struct json_object *jargs)
 		GError *hook (const gchar * m1) {
 			if (newset)
 				g_strfreev (newset);
-			return meta1v2_remote_relink_service (m1, args->url, kept, repl, dryrun, &newset);
+			return meta1v2_remote_relink_service (
+					m1, args->url, kept, repl, dryrun, &newset);
 		}
 		kept = meta1_pack_url (m1u_kept);
 		repl = m1u_repl ? meta1_pack_url (m1u_repl) : NULL;

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -852,6 +852,7 @@ configure_request_handlers (void)
 	SET("/$NS/reference/set_properties/#POST", action_ref_prop_set);
 	SET("/$NS/reference/del_properties/#POST", action_ref_prop_del);
 	SET("/$NS/reference/link/#POST", action_ref_link);
+	SET("/$NS/reference/relink/#POST", action_ref_relink);
 	SET("/$NS/reference/unlink/#POST", action_ref_unlink);
 	SET("/$NS/reference/force/#POST", action_ref_force);
 	SET("/$NS/reference/renew/#POST", action_ref_renew);


### PR DESCRIPTION
Prior to this pull request, the relinking of a directory entry was broken in both the proxy and the meta1.

