### PR TITLE
oio-blob-rebuilder: name the reported fields in the log

### DIFF
--- a/oio/blob/rebuilder.py
+++ b/oio/blob/rebuilder.py
@@ -88,15 +88,17 @@ class BlobRebuilderWorker(object):
 
             if now - self.last_reported >= self.report_interval:
                 self.logger.info(
-                    '%(start_time)s '
-                    '%(passes)d '
-                    '%(errors)d '
-                    '%(c_rate).2f '
-                    '%(b_rate).2f '
-                    '%(total).2f '
-                    '%(rebuilder_time).2f'
-                    '%(rebuilder_rate).2f' % {
-                        'start_time': time.ctime(report_time),
+                    'status=%(volume)s '
+                    'started=%(start_time)s '
+                    'passes=%(passes)d '
+                    'errors=%(errors)d '
+                    'chunk/s=%(c_rate).2f '
+                    'byte/s=%(b_rate).2f '
+                    'elapsed=%(total).2f '
+                    '(rebuilder: %(rebuilder_rate).2f%%)' % {
+                        'volume': self.volume,
+                        'start_time': time.strftime(
+                            "%Y-%m-%d_%H:%M:%S", time.localtime(report_time)),
                         'passes': self.passes,
                         'errors': self.errors,
                         'c_rate': self.passes / (now - report_time),
@@ -112,14 +114,17 @@ class BlobRebuilderWorker(object):
                 self.bytes_processed = 0
                 self.last_reported = now
             rebuilder_time += (now - loop_time)
+
         elapsed = (time.time() - start_time) or 0.000001
         self.logger.info(
-            '%(elapsed).02f '
-            '%(errors)d '
-            '%(chunk_rate).2f '
-            '%(bytes_rate).2f '
-            '%(rebuilder_time).2f '
-            '%(rebuilder_rate).2f' % {
+            'DONE=%(volume)s '
+            'elapsed=%(elapsed).02f '
+            'errors=%(errors)d '
+            'chunk/s=%(chunk_rate).2f '
+            'byte/s=%(bytes_rate).2f '
+            'elapsed=%(rebuilder_time).2f '
+            '(rebuilder: %(rebuilder_rate).2f%%)' % {
+                'volume': self.volume,
                 'elapsed': elapsed,
                 'errors': total_errors + self.errors,
                 'chunk_rate': self.total_chunks_processed / elapsed,

--- a/oio/blob/rebuilder.py
+++ b/oio/blob/rebuilder.py
@@ -15,6 +15,7 @@
 # License along with this library.
 
 import time
+from datetime import datetime
 from socket import gethostname
 
 from oio.common import exceptions as exc
@@ -97,8 +98,8 @@ class BlobRebuilderWorker(object):
                     'elapsed=%(total).2f '
                     '(rebuilder: %(rebuilder_rate).2f%%)' % {
                         'volume': self.volume,
-                        'start_time': time.strftime(
-                            "%Y-%m-%d_%H:%M:%S", time.localtime(report_time)),
+                        'start_time': datetime.fromtimestamp(
+                            int(report_time)).isoformat(),
                         'passes': self.passes,
                         'errors': self.errors,
                         'c_rate': self.passes / (now - report_time),


### PR DESCRIPTION
The periodic report now have that shape: 

> 12697 7F9500C47CD0 log INFO status=127.0.0.1:6008 started=2017-03-09_16:08:14 passes=1 errors=1 chunk/s=109.54 byte/s=0.00 elapsed=0.01 (rebuilder: 0.00%)

The final report has that shape: 
> 12697 7F9500C47CD0 log INFO DONE=127.0.0.1:6008 elapsed=0.02 errors=2 chunk/s=57.69 byte/s=0.00 elapsed=0.01 (rebuilder: 0.39%)

The date is reported in a space-less format, and the volume is now printed on each report line.

Fix #720