### PR TITLE
Add an option to create many containers in on go

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -272,7 +272,8 @@ class ObjectStorageAPI(API):
         :keyword headers: extra headers to send to the proxy
         :type headers: `dict`
         """
-        params = self._make_params(account)
+        uri = self._make_uri('container/create_many')
+        params = self._make_params(account, None)
         headers = headers or {}
         headers['x-oio-action-mode'] = 'autocreate'
         headers.update(kwargs.get('headers') or {})
@@ -282,7 +283,7 @@ class ObjectStorageAPI(API):
                                      'properties': properties or {},
                                      'system': kwargs.get('system', {})})
         data = json.dumps({"containers": unformatted_data})
-        resp, body = self._request('POST', '/create_many', params=params,
+        resp, body = self._request('POST', uri, params=params,
                                    data=data, headers=headers)
         results = []
         for container in json.loads(resp.content)["containers"]:

--- a/oio/cli/storage/container.py
+++ b/oio/cli/storage/container.py
@@ -57,13 +57,21 @@ class CreateContainer(SetPropertyCommandMixin, lister.Lister):
 
         results = []
         account = self.app.client_manager.get_account()
-        for container in parsed_args.containers:
-            success = self.app.client_manager.storage.container_create(
+        if len(parsed_args.containers) > 1:
+            results = self.app.client_manager.storage.container_create_many(
                 account,
-                container,
+                parsed_args.containers,
                 properties=properties,
                 system=system)
-            results.append((container, success))
+            return results
+        else:
+            for container in parsed_args.containers:
+                success = self.app.client_manager.storage.container_create(
+                    account,
+                    container,
+                    properties=properties,
+                    system=system)
+                results.append((container, success))
 
         columns = ('Name', 'Created')
         res_gen = (r for r in results)

--- a/oio/cli/storage/container.py
+++ b/oio/cli/storage/container.py
@@ -63,7 +63,7 @@ class CreateContainer(SetPropertyCommandMixin, lister.Lister):
                 parsed_args.containers,
                 properties=properties,
                 system=system)
-            return results
+
         else:
             for container in parsed_args.containers:
                 success = self.app.client_manager.storage.container_create(

--- a/proxy/actions.h
+++ b/proxy/actions.h
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OIO_SDS__proxy__actions_h
 # define OIO_SDS__proxy__actions_h 1
 
+#define OIO_CONTAINER_CREATE_MANY_NB_MAX_REQ 100
+
 struct req_args_s;
 
 enum http_rc_e action_forward (struct req_args_s *args);
@@ -60,6 +62,7 @@ enum http_rc_e action_ref_unlink (struct req_args_s *args);
 enum http_rc_e action_ref_force (struct req_args_s *args);
 enum http_rc_e action_ref_renew (struct req_args_s *args);
 
+enum http_rc_e action_container_create_many (struct req_args_s *args);
 enum http_rc_e action_container_create (struct req_args_s *args);
 enum http_rc_e action_container_destroy (struct req_args_s *args);
 enum http_rc_e action_container_show (struct req_args_s *args);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1190,20 +1190,20 @@ _m2_container_create_many (struct req_args_s *args, struct json_object *jbody)
 {
 	guint max_request = OIO_CONTAINER_CREATE_MANY_NB_MAX_REQ;
 	guint nb_err = 0;
-	GString *gresponse = g_string_sized_new(2048);
-	g_string_append(gresponse, "{\"containers\":[");
 	GError *err = NULL;
 	const char *url_user = oio_url_get(args->url, OIOURL_USER);
 	json_object *jarray = NULL;
 	if (!oio_url_get(args->url, OIOURL_ACCOUNT)
-		|| !oio_url_get(args->url, OIOURL_NS))
+			|| !oio_url_get(args->url, OIOURL_NS))
 		return _reply_format_error(args,
 				BADREQ("Missing account or namespace"));
 	if (!json_object_object_get_ex(jbody, "containers", &jarray)
-		|| !json_object_is_type(jarray, json_type_array))
+			|| !json_object_is_type(jarray, json_type_array))
 		return _reply_format_error(args,
 				BADREQ("Invalid array of containers"));
-	unsigned jarray_len = json_object_array_length(jarray);
+	GString *gresponse = g_string_sized_new(2048);
+	g_string_append(gresponse, "{\"containers\":[");
+	guint jarray_len = json_object_array_length(jarray);
 	if (jarray_len > max_request)
 		return _reply_format_error(args,
 			BADREQ("More than %u requested",
@@ -1213,48 +1213,50 @@ _m2_container_create_many (struct req_args_s *args, struct json_object *jbody)
 		struct json_object * jname = NULL;
 		gchar **properties = NULL;
 		const gchar *name = NULL;
-		jcontainer = json_object_array_get_idx (jarray, i);
-		g_string_append (gresponse, "{\"name\":");
-		if(!json_object_object_get_ex(jcontainer, "name", &jname)){
-			return _reply_format_error(args,
-				BADREQ("No \"name\" field"));
-		}
-		if(!json_object_is_type(jname, json_type_string))
-			return _reply_format_error(args,
-				BADREQ("Bad \"name\" field"));
-		name = json_object_get_string(jname);
-		err = KV_read_usersys_properties(jcontainer, &properties);
-		EXTRA_ASSERT((err != NULL) ^ (properties != NULL));
-		if (err) {
-			_append_status(gresponse, err->code, err->message);
+		jcontainer = json_object_array_get_idx(jarray, i);
+		g_string_append(gresponse, "{\"name\":");
+		if (!json_object_object_get_ex(jcontainer, "name", &jname)
+				|| !json_object_is_type(jname, json_type_string)) {
 			nb_err++;
-			g_clear_error(&err);
+			g_string_append(gresponse, "\"(null)\",");
+			_append_status(gresponse, CODE_BAD_REQUEST,
+				"Bad \"name\" field");
 		} else {
-			oio_url_set(args->url, OIOURL_USER, name);
-			g_string_append_printf(gresponse, "\"%s\",", name);
-			/* The simple create function has the name of the container
-			 on the url */
-			err = _m2_container_create_with_properties(args, properties);
-			g_strfreev (properties);
-			if (!err) {
-				/* No error means we actually created it. */
-				_append_status(gresponse, 201, "Created");
-			} else {
+			name = json_object_get_string(jname);
+			err = KV_read_usersys_properties(jcontainer, &properties);
+			EXTRA_ASSERT((err != NULL) ^ (properties != NULL));
+			if (err) {
 				_append_status(gresponse, err->code, err->message);
 				nb_err++;
 				g_clear_error(&err);
+			} else {
+				/* The simple create function takes the name of the container
+				   on the url */
+				oio_url_set(args->url, OIOURL_USER, name);
+				g_string_append_printf(gresponse, "\"%s\",", name);
+				err = _m2_container_create_with_properties(args, properties);
+				g_strfreev(properties);
+				if (!err) {
+					/* No error means we actually created it. */
+					_append_status(gresponse, HTTP_CODE_CREATED, "Created");
+				} else {
+					_append_status(gresponse, err->code, err->message);
+					if (err->code != CODE_CONTAINER_EXISTS)
+						nb_err++;
+					g_clear_error(&err);
+				}
 			}
 		}
-		g_string_append_c (gresponse, '}');
+		g_string_append_c(gresponse, '}');
 		if (i < jarray_len - 1)
-			g_string_append_c (gresponse, ',');
+			g_string_append_c(gresponse, ',');
 	}
 	oio_url_set(args->url, OIOURL_USER, url_user);
 	if (err)
-		g_error_free (err);
-	g_string_append (gresponse, "]}");
-	if( nb_err == jarray_len)
-		return _reply_json(args, 400, "Error on all requests",
+		g_error_free(err);
+	g_string_append(gresponse, "]}");
+	if (nb_err == jarray_len)
+		return _reply_json(args, CODE_BAD_REQUEST, "Error on all requests",
 					 gresponse);
 	return _reply_success_json(args, gresponse);
 }

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -837,7 +837,6 @@ configure_request_handlers (void)
 
 	// Directory
 	SET("/$NS/reference/create/#POST", action_ref_create);
-	SET("/$NS/container/create_many/#POST", action_container_create_many);
 	SET("/$NS/reference/destroy/#POST", action_ref_destroy);
 	SET("/$NS/reference/show/#GET", action_ref_show);
 	SET("/$NS/reference/get_properties/#POST", action_ref_prop_get);
@@ -851,6 +850,7 @@ configure_request_handlers (void)
 	// Meta2
 	// Container
 	SET("/$NS/container/create/#POST", action_container_create);
+	SET("/$NS/container/create_many/#POST", action_container_create_many);
 	SET("/$NS/container/destroy/#POST", action_container_destroy);
 	SET("/$NS/container/show/#GET", action_container_show);
 	SET("/$NS/container/list/#GET", action_container_list);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -836,8 +836,8 @@ configure_request_handlers (void)
 	SET("/$NS/conscience/unlock/#POST", action_conscience_unlock);
 
 	// Directory
-	SET("/$NS/container/create_many/#POST", action_container_create_many);
 	SET("/$NS/reference/create/#POST", action_ref_create);
+	SET("/$NS/container/create_many/#POST", action_container_create_many);
 	SET("/$NS/reference/destroy/#POST", action_ref_destroy);
 	SET("/$NS/reference/show/#GET", action_ref_show);
 	SET("/$NS/reference/get_properties/#POST", action_ref_prop_get);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -836,6 +836,7 @@ configure_request_handlers (void)
 	SET("/$NS/conscience/unlock/#POST", action_conscience_unlock);
 
 	// Directory
+	SET("/$NS/container/create_many/#POST", action_container_create_many);
 	SET("/$NS/reference/create/#POST", action_ref_create);
 	SET("/$NS/reference/destroy/#POST", action_ref_destroy);
 	SET("/$NS/reference/show/#GET", action_ref_show);


### PR DESCRIPTION
The command "openio container create <container>" used to send a request for every
container in the list to create it.
Now the command check the number of containers and use a specific request to ask for the
creation of all the containers.