### PR TITLE
Allow the services to expire in the LB pools

### DIFF
--- a/core/lb.c
+++ b/core/lb.c
@@ -157,7 +157,7 @@ struct oio_lb_world_s
  * - the set of targets that must bring a service in the result set
  * - a pointer to the world to map the targets into LB slots.
  * - the bitwise mask that tells how close the service are, when the mask is
- *   applied to their lcoations.
+ *   applied to their locations.
  */
 struct oio_lb_pool_LOCAL_s
 {

--- a/core/oiolb.h
+++ b/core/oiolb.h
@@ -106,6 +106,9 @@ void oio_lb_world__feed_slot (struct oio_lb_world_s *self, const char *slot,
 struct oio_lb_pool_s * oio_lb_world__create_pool (
 		struct oio_lb_world_s *world, const char *name);
 
+void oio_lb_world__increment_generation(struct oio_lb_world_s *self);
+
+void oio_lb_world__purge_old_generations(struct oio_lb_world_s *self);
 
 /* Set a mask (hexadecimal string, 64b) to compute distance between items */
 #define OIO_LB_OPT_MASK           "mask"

--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -194,6 +194,11 @@ _post_config(struct sqlx_service_s *ss)
 		return FALSE;
 	}
 
+	/* tell the meta1 to load everything excepted the services that make
+	 * no sense */
+	g_snprintf(ss->srvtypes, sizeof(ss->srvtypes), "!%s,%s",
+			NAME_SRVTYPE_META1, NAME_SRVTYPE_META0);
+
 	transport_gridd_dispatcher_add_requests(ss->dispatcher,
 			meta1_gridd_get_requests(), m1);
 

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -46,37 +46,6 @@ _task_reconfigure_m2(gpointer p)
 	meta2_backend_configure_nsinfo(m2, PSRV(p)->nsinfo);
 }
 
-static void
-_task_reload_m2_lb(gpointer p)
-{
-	ADAPTIVE_PERIOD_DECLARE();
-	if (!PSRV(p)->nsinfo)
-		return;
-
-	if (ADAPTIVE_PERIOD_SKIP())
-		return;
-
-	oio_lb_world__reload_pools(PSRV(p)->lb_world, PSRV(p)->lb,
-			PSRV(p)->nsinfo);
-
-	/* In meta2, we are only interrested in rawx services */
-	GSList *svctypes = g_slist_prepend(NULL, NAME_SRVTYPE_RAWX);
-	GError *err = sqlx_reload_lb_service_types(PSRV(p)->lb_world, PSRV(p)->lb,
-			svctypes);
-	if (err) {
-		GRID_WARN("Failed to reload "NAME_SRVTYPE_RAWX" services: %s",
-				err->message);
-		g_clear_error(&err);
-	} else {
-		ADAPTIVE_PERIOD_ONSUCCESS(10);
-	}
-	g_slist_free(svctypes);
-
-	oio_lb_world__reload_storage_policies(PSRV(p)->lb_world,
-			PSRV(p)->lb, PSRV(p)->nsinfo);
-	oio_lb_world__debug(PSRV(p)->lb_world);
-}
-
 static gchar **
 filter_services(struct sqlx_service_s *ss,
 		gchar **s, gint64 seq, const gchar *type)
@@ -202,7 +171,10 @@ _post_config(struct sqlx_service_s *ss)
 		return FALSE;
 	}
 
-	// prepare a meta2 backend
+	/* Tell the meta2 is interested only by RAWX services */
+	g_strlcpy(ss->srvtypes, NAME_SRVTYPE_RAWX, sizeof(ss->srvtypes));
+
+	/* prepare a meta2 backend */
 	err = meta2_backend_init(&m2, ss->repository, ss->ns_name, ss->lb, ss->resolver);
 	if (NULL != err) {
 		GRID_WARN("META2 backend init failure: (%d) %s", err->code, err->message);
@@ -222,10 +194,10 @@ _post_config(struct sqlx_service_s *ss)
 			meta2_gridd_get_v2_requests(), m2);
 
 	/* Register few meta2 tasks */
+	grid_task_queue_register(ss->gtq_reload, 1,
+			(GDestroyNotify)sqlx_task_reload_lb, NULL, ss);
 	grid_task_queue_register(ss->gtq_reload, 5,
 			_task_reconfigure_m2, NULL, ss);
-	grid_task_queue_register(ss->gtq_reload, 1,
-			(GDestroyNotify)_task_reload_m2_lb, NULL, ss);
 
 	m2->notifier = ss->events_queue;
 

--- a/metautils/lib/lb.c
+++ b/metautils/lib/lb.c
@@ -34,23 +34,13 @@ License along with this library.
 
 #include "metautils.h"
 
-#define SLOT(P) ((struct score_slot_s*)P)
-
-typedef guint32 srv_score_t;
-
-struct score_slot_s
-{
-	guint index;
-	srv_score_t score;
-	guint32 sum;
-};
-
 void
 oio_lb_world__feed_service_info_list(struct oio_lb_world_s *lbw,
 		GSList *services)
 {
-	struct oio_lb_item_s *item = g_alloca(sizeof(struct oio_lb_item_s)
-			+ LIMIT_LENGTH_SRVID);
+	struct oio_lb_item_s *item =
+		g_alloca(sizeof(struct oio_lb_item_s) + LIMIT_LENGTH_SRVID);
+
 	for (GSList *l = services; l; l = l->next) {
 		char slot_name[128] = {0};
 		struct service_info_s *srv = l->data;

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -288,7 +288,9 @@ GError * KV_read_properties (struct json_object *j, gchar ***out,
  * @see KV_read_properties() */
 GError * KV_read_usersys_properties (struct json_object *j, gchar ***out);
 
-void lb_cache_reload(void);
+/** Trigger a whole reload of the internal LB caches, exactly as it is done
+ * by the periodically scheduled internal task */
+gboolean lb_cache_reload(void);
 
 /* -------------------------------------------------------------------------- */
 

--- a/proxy/lb_actions.c
+++ b/proxy/lb_actions.c
@@ -235,7 +235,7 @@ action_lb_poll(struct req_args_s *args)
 enum http_rc_e
 action_lb_reload (struct req_args_s *args)
 {
-	lb_cache_reload();
+	(void) lb_cache_reload();
 	return _reply_success_json (args, NULL);
 }
 

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -483,20 +483,8 @@ lb_cache_reload (void)
 		GSList *srv = NULL;
 		GError *e = conscience_remote_get_services(cs, *pt, FALSE, &srv);
 		if (e) {
-			GRID_WARN("Failed to load the list of [%s] in NS=%s", ns_name, *pt);
+			GRID_WARN("Failed to load the list of [%s] in NS=%s", *pt, ns_name);
 			any_loading_error = TRUE;
-#if 0
-		} else {
-			GRID_TRACE("%s -> got %u for %s (%d/%s)", __FUNCTION__,
-					g_slist_length(srv), *pt, gerror_get_code(e),
-					gerror_get_message(e));
-			for (GSList *l=srv ;l; l=l->next) {
-				GString *gstr = g_string_sized_new(128);
-				service_info_encode_json(gstr, l->data, TRUE);
-				GRID_INFO("> %s", gstr->str);
-				g_string_free(gstr, TRUE);
-			}
-#endif
 		}
 		g_ptr_array_add(tabsrv, srv);
 		g_ptr_array_add(taberr, e);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -383,23 +383,8 @@ _encode_wanted_services (const char *type, GSList *list)
 }
 
 static void
-_reload_srvtype(const char *type)
+_reload_srvtype(const char *type, GSList *list)
 {
-	CSURL(cs);
-
-	GSList *list = NULL;
-	GError *err = conscience_remote_get_services (cs, type, FALSE, &list);
-	if (err) {
-		GRID_WARN("Services listing error for type[%s]: code=%d %s",
-				type, err->code, err->message);
-		g_clear_error(&err);
-		return;
-	}
-
-	if (GRID_TRACE_ENABLED()) {
-		GRID_TRACE ("SRV loaded %u [%s]", g_slist_length(list), type);
-	}
-
 	/* reloads the known services */
 	gulong now = oio_ext_monotonic_seconds ();
 	SRV_WRITE(for (GSList *l=list; l ;l=l->next) {
@@ -420,43 +405,117 @@ _reload_srvtype(const char *type)
 		g_bytes_unref (encoded);
 	}
 
-	/* reload the LB */
-	if (NULL != list) {
+	/* reload the LB world */
+	if (list)
 		oio_lb_world__feed_service_info_list(lb_world, list);
-
-		if (!oio_lb__has_pool(lb, type)) {
-			struct service_update_policies_s *pols =
-					service_update_policies_create();
-			gchar *pols_cfg = NULL;
-			NSINFO_READ(pols_cfg = gridcluster_get_service_update_policy(&nsinfo));
-			service_update_reconfigure(pols, pols_cfg);
-			g_free(pols_cfg);
-			GRID_DEBUG("Automatically creating pool for service type [%s]",
-					type);
-			oio_lb__force_pool(lb,
-					oio_lb_pool__from_service_policy(lb_world, type, pols));
-			service_update_policies_destroy(pols);
-		}
-
-		g_slist_free_full(list, (GDestroyNotify)service_info_clean);
-	}
 }
 
-void
+static void
+_reload_lb_service_types(
+		struct oio_lb_world_s *lbw, struct oio_lb_s *lb_,
+		struct namespace_info_s *nsi,
+		gchar **tabtypes, GPtrArray *tabsrv, GPtrArray *taberr)
+{
+	struct service_update_policies_s *pols = service_update_policies_create();
+	gchar *pols_cfg = gridcluster_get_service_update_policy(nsi);
+	service_update_reconfigure(pols, pols_cfg);
+	g_free(pols_cfg);
+
+	for (guint i=0; tabtypes[i] ;++i) {
+		const char * srvtype = tabtypes[i];
+		if (!oio_lb__has_pool(lb_, srvtype)) {
+			GRID_DEBUG("Creating pool for service type [%s]", srvtype);
+			oio_lb__force_pool(lb_,
+					oio_lb_pool__from_service_policy(lbw, srvtype, pols));
+		}
+
+		if (!taberr->pdata[i])
+			_reload_srvtype(srvtype, tabsrv->pdata[i]);
+	}
+
+	service_update_policies_destroy(pols);
+}
+
+static void
+_free_list_of_services(gpointer p)
+{
+	if (!p)
+		return;
+	g_slist_free_full((GSList*)p, (GDestroyNotify)service_info_clean);
+}
+
+static void
+_free_error(gpointer p)
+{
+	if (!p)
+		return;
+	g_error_free((GError*)p);
+}
+
+/* If you ever plan to factorize this code with the similar part in
+ * sqlx/sqlx_service.c be carefull that a lot of context is expected on both
+ * sides, and that even the function used to fetch the services cannot be the
+ * same (sqlx talks to the proxy, the proxy talks to the conscience). */
+gboolean
 lb_cache_reload (void)
 {
-	gchar **tt = NULL;
+	struct namespace_info_s *nsi = NULL;
+	gchar **tabtypes = NULL;
+	GPtrArray *tabsrv = NULL, *taberr = NULL;
+	gboolean any_loading_error = FALSE;
+
+	CSURL(cs);
 	NSINFO_READ(
-		tt = g_strdupv_inline(srvtypes);
-		oio_lb_world__reload_pools(lb_world, lb, &nsinfo);
-		oio_lb_world__reload_storage_policies(lb_world, lb, &nsinfo);
+		tabtypes = g_strdupv_inline(srvtypes);
+		nsi = namespace_info_dup(&nsinfo);
 	);
 
-	if (tt) {
-		for (gchar **t=tt; *t ;++t)
-			_reload_srvtype (*t);
-		g_free (tt);
+	if (!tabtypes || !*tabtypes) {
+		GRID_WARN("proxy not ready to reload the LB");
+		any_loading_error = TRUE;
+		goto out;
 	}
+
+	/* preload all the services */
+	tabsrv = g_ptr_array_new_full(8, _free_list_of_services);
+	taberr = g_ptr_array_new_full(8, _free_error);
+	for (char **pt=tabtypes; *pt ;++pt) {
+		GSList *srv = NULL;
+		GError *e = conscience_remote_get_services(cs, *pt, FALSE, &srv);
+		if (e) {
+			GRID_WARN("Failed to load the list of [%s] in NS=%s", ns_name, *pt);
+			any_loading_error = TRUE;
+#if 0
+		} else {
+			GRID_TRACE("%s -> got %u for %s (%d/%s)", __FUNCTION__,
+					g_slist_length(srv), *pt, gerror_get_code(e),
+					gerror_get_message(e));
+			for (GSList *l=srv ;l; l=l->next) {
+				GString *gstr = g_string_sized_new(128);
+				service_info_encode_json(gstr, l->data, TRUE);
+				GRID_INFO("> %s", gstr->str);
+				g_string_free(gstr, TRUE);
+			}
+#endif
+		}
+		g_ptr_array_add(tabsrv, srv);
+		g_ptr_array_add(taberr, e);
+	}
+
+	/* refresh the load-balancing world */
+	if (!any_loading_error)
+		oio_lb_world__increment_generation(lb_world);
+	oio_lb_world__reload_pools(lb_world, lb, nsi);
+	_reload_lb_service_types(lb_world, lb, nsi, tabtypes, tabsrv, taberr);
+	oio_lb_world__reload_storage_policies(lb_world, lb, nsi);
+	if (!any_loading_error)
+		oio_lb_world__purge_old_generations(lb_world);
+out:
+	if (tabtypes) g_free0 (tabtypes);
+	if (nsi) namespace_info_free(nsi);
+	if (tabsrv) g_ptr_array_free(tabsrv, TRUE);
+	if (taberr) g_ptr_array_free(taberr, TRUE);
+	return !any_loading_error;
 }
 
 static void
@@ -468,11 +527,9 @@ _task_reload_lb(gpointer p UNUSED)
 		return;
 
 	CSURL(cs);
-	if (!cs) return;
-
-	ADAPTIVE_PERIOD_ONSUCCESS(lb_downstream_delay);
-	lb_cache_reload();
-	oio_lb_world__debug(lb_world);
+	if (cs && lb_cache_reload()) {
+		ADAPTIVE_PERIOD_ONSUCCESS(lb_downstream_delay);
+	}
 }
 
 static void
@@ -509,7 +566,7 @@ _task_reload_nsinfo (gpointer p UNUSED)
 
 	CSURL(cs);
 	if (!cs)
-		return;
+		return; /* not ready */
 
 	if (ADAPTIVE_PERIOD_SKIP())
 		return;
@@ -670,8 +727,8 @@ grid_main_get_options (void)
 			"synchronously and no cache is kept on a GET."},
 
 		{"LocalScores", OT_BOOL, {.b = &flag_local_scores},
-			"Enables the updates of the list of local services, so that\n"
-			"their score is displayed. This gives a pretty output but\n"
+			"Enables the updates of the list of local services, so that "
+			"their score is displayed. This gives a pretty output but "
 			"requires CPU spent in critical sections."},
 
 		{"DirLowTtl", OT_UINT, {.u = &dir_low_ttl},

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -79,7 +79,7 @@ struct sqlx_service_s
 	/* if left empty, all the services from the conscience will be reloaded.
 	 * If filled, only the specified service types (coma-separated) will be
 	 * considered */
-	gchar srvtypes[1024];
+	gchar srvtypes[128];
 
 	struct replication_config_s *replication_config;
 	const struct sqlx_service_config_s *service_config;
@@ -172,9 +172,6 @@ extern int sqlite_service_main(int argc, char **argv,
 		const struct sqlx_service_config_s *cfg);
 
 void sqlx_service_set_custom_options (struct grid_main_option_s *options);
-
-GError* sqlx_reload_lb_service_types(struct oio_lb_world_s *lbw,
-		struct oio_lb_s *lb, GSList *list_srvtypes);
 
 // FIXME: this is only used in meta1
 /** Reloads the optional (oio_lb_s*). Exposed to let the

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -76,6 +76,11 @@ struct sqlx_service_s
 	gchar volume[1024];
 	gchar ns_name[LIMIT_LENGTH_NSNAME];
 
+	/* if left empty, all the services from the conscience will be reloaded.
+	 * If filled, only the specified service types (coma-separated) will be
+	 * considered */
+	gchar srvtypes[1024];
+
 	struct replication_config_s *replication_config;
 	const struct sqlx_service_config_s *service_config;
 

--- a/tests/functional/api/test_directory.py
+++ b/tests/functional/api/test_directory.py
@@ -244,6 +244,7 @@ class TestDirectoryAPI(BaseTestCase):
         Tests that rdir services linked to rawx services
         are not on the same locations
         """
+        self._reload()
         cs = ConscienceClient({'namespace': self.ns})
         rawx_list = cs.all_services('rawx')
         rdir_dict = {x['addr']: x for x in cs.all_services('rdir')}

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -1111,7 +1111,7 @@ def generate(options):
         return env
 
     ENV['CHUNK_SIZE'] = getint(options.get(CHUNK_SIZE), 1024*1024)
-    ENV['MONITOR_PERIOD'] = getint(options.get(MONITOR_PERIOD), 5)
+    ENV['MONITOR_PERIOD'] = getint(options.get(MONITOR_PERIOD), 1)
     if options.get(ZOOKEEPER):
         ENV['NOZK'] = ''
     else:


### PR DESCRIPTION
Fix #815 

* The `core/lb` feature now has a way to easily expire services that disappear from the conscience
* `meta2` now uses the same code as meta1, both use the expiration feature.
* `proxy` uses a slight variant of that code