### PR TITLE
Improve the management of cnx errors while requesting RAWX.

### DIFF
--- a/core/http_put.c
+++ b/core/http_put.c
@@ -537,7 +537,7 @@ GError *
 http_put_step (struct http_put_s *p)
 {
 	int rc;
-	guint count_dests = 0, count_up = 0, count_waiting_for_data = 0;
+	guint count_up = 0, count_waiting_for_data = 0;
 
 	EXTRA_ASSERT (p != NULL);
 
@@ -551,7 +551,7 @@ http_put_step (struct http_put_s *p)
 		return NULL;
 	}
 
-	count_dests = g_slist_length(p->dests);
+	register guint count_dests = g_slist_length(p->dests);
 	GRID_TRACE("%s STEP on %u destinations", __FUNCTION__, count_dests);
 
 	/* consume the CURL notifications for terminated actions */
@@ -579,7 +579,7 @@ http_put_step (struct http_put_s *p)
 	}
 
 	if (p->state == HTTP_WHOLE_BEGIN) {
-		GRID_TRACE("%s Starting %u uploads", __FUNCTION__, count_dests);
+		GRID_DEBUG("%s Starting %u uploads", __FUNCTION__, count_dests);
 		_start_upload(p);
 		p->state = HTTP_WHOLE_READY;
 	}

--- a/core/sds.c
+++ b/core/sds.c
@@ -148,8 +148,9 @@ struct chunk_s
 {
 	struct chunk_position_s position;
 	gsize size;
-	gchar hexhash[STRLEN_CHUNKHASH];
 	guint32 score;
+	gchar hexhash[STRLEN_CHUNKHASH];
+	guint8 flag_success : 1;
 	gchar url[1];
 };
 
@@ -1386,6 +1387,31 @@ oio_sds_upload_feed (struct oio_sds_ul_s *ul,
 	return NULL;
 }
 
+static void
+_finish_metachunk_upload(struct oio_sds_ul_s *ul)
+{
+	EXTRA_ASSERT(ul != NULL);
+	EXTRA_ASSERT(ul->mc != NULL);
+
+	ul->mc->size = ul->local_done;
+
+	for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+		struct chunk_s *c = l->data;
+		EXTRA_ASSERT (c->position.meta == ul->mc->meta);
+		c->size = ul->mc->size;
+		c->flag_success = http_put_get_http_code(ul->put, c);
+	}
+
+	if (ul->checksum_chunk) {
+		const char *h = g_checksum_get_string (ul->checksum_chunk);
+		for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+			struct chunk_s *c = l->data;
+			g_strlcpy (c->hexhash, h, sizeof(c->hexhash));
+			oio_str_upper (c->hexhash);
+		}
+	}
+}
+
 static GError *
 _sds_upload_finish (struct oio_sds_ul_s *ul)
 {
@@ -1400,29 +1426,19 @@ _sds_upload_finish (struct oio_sds_ul_s *ul)
 	if (failures >= total) {
 		err = ERRPTF("No upload succeeded");
 	} else {
-		/* patch the chunk sizes and positions */
-		ul->mc->size = ul->local_done;
-		for (GSList *l=ul->mc->chunks; l ;l=l->next) {
-			struct chunk_s *c = l->data;
-			c->size = ul->mc->size;
-			EXTRA_ASSERT (c->position.meta == ul->mc->meta);
-		}
+		_finish_metachunk_upload(ul);
 
-		if (ul->checksum_chunk) {
-			const char *h = g_checksum_get_string (ul->checksum_chunk);
-			for (GSList *l=ul->mc->chunks; l ;l=l->next) {
-				struct chunk_s *c = l->data;
-				g_strlcpy (c->hexhash, h, sizeof(c->hexhash));
-				oio_str_upper (c->hexhash);
-			}
-		}
 		/* TODO: in case of EC, we may wanna read response headers */
 
 		/* store the structure in holders for further commit/abort */
-		ul->chunks_done = g_slist_concat (ul->chunks_done, ul->chunks);
-		GRID_TRACE("%s > chunks +%u -> %u", __FUNCTION__,
-				g_slist_length(ul->chunks),
-				g_slist_length(ul->chunks_done));
+		for (GSList *l = ul->chunks; l ;l=l->next) {
+			struct chunk_s *chunk = l->data;
+			if (chunk->flag_success) {
+				ul->chunks_done = g_slist_prepend (ul->chunks_done, chunk);
+			} else {
+				ul->chunks_failed = g_slist_prepend (ul->chunks_failed, chunk);
+			}
+		}
 
 		ul->metachunk_done = g_list_append (ul->metachunk_done, ul->mc);
 		GRID_TRACE("%s > metachunks +1 -> %u (%"G_GSIZE_FORMAT")", __FUNCTION__,

--- a/core/sds.c
+++ b/core/sds.c
@@ -1405,7 +1405,7 @@ _finish_metachunk_upload(struct oio_sds_ul_s *ul)
 		struct chunk_s *c = l->data;
 		EXTRA_ASSERT (c->position.meta == ul->mc->meta);
 		c->size = ul->mc->size;
-		c->flag_success = http_put_get_http_code(ul->put, c);
+		c->flag_success = 2 == (http_put_get_http_code(ul->put, c) / 100);
 	}
 
 	if (ul->checksum_chunk) {


### PR DESCRIPTION
When #919 fixes things in the python API, the current PR fixes them in the C SDK.

Only the chunks that succeeded are now saved in the container.
And it is up to the container to trigger a rebuild action on the content to make it comply with the storage policy.