### PR TITLE
Modify log format of oio-blob-rebuilder and oio-blob-indexer (fix #880)

### DIFF
--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from random import random
 
 from oio.blob.utils import check_volume, read_chunk_metadata
@@ -46,15 +47,15 @@ class BlobIndexer(Daemon):
             )
             self.total_chunks_processed += 1
             now = time.time()
-
             if now - self.last_reported >= self.report_interval:
                 self.logger.info(
-                    '%(start_time)s '
-                    '%(passes)d '
-                    '%(errors)d '
-                    '%(c_rate).2f '
-                    '%(total).2f ' % {
-                        'start_time': time.ctime(report_time),
+                    'started=%(start_time)s '
+                    'passes=%(passes)d '
+                    'errors=%(errors)d '
+                    'c_rate=%(c_rate).2f '
+                    'total=%(total).2f ' % {
+                        'start_time': datetime.fromtimestamp(
+                            int(report_time)).isoformat(),
                         'passes': self.passes,
                         'errors': self.errors,
                         'c_rate': self.passes / (now - report_time),
@@ -66,11 +67,18 @@ class BlobIndexer(Daemon):
                 self.passes = 0
                 self.errors = 0
                 self.last_reported = now
-        elapsed = (time.time() - start_time) or 0.000001
+        end_time = time.time()
+        elapsed = (end_time - start_time) or 0.000001
         self.logger.info(
-            '%(elapsed).02f '
-            '%(errors)d '
-            '%(chunk_rate).2f ' % {
+            'started=(%start_time)s '
+            'ended=(%end_time)s '
+            'elapsed=%(elapsed).02f '
+            'errors=%(errors)d '
+            'chunk/s%(chunk_rate).2f ' % {
+                'start_time': datetime.fromtimestamp(
+                    int(start_time)).isoformat(),
+                'end_time': datetime.fromtimestamp(
+                    int(end_time)).isoformat(),
                 'elapsed': elapsed,
                 'errors': total_errors + self.errors,
                 'chunk_rate': self.total_chunks_processed / elapsed

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -52,12 +52,13 @@ class BlobIndexer(Daemon):
                     'started=%(start_time)s '
                     'passes=%(passes)d '
                     'errors=%(errors)d '
-                    'c_rate=%(c_rate).2f '
+                    'chunks=%(nb_chunks)d %(c_rate).2f/s '
                     'total=%(total).2f ' % {
                         'start_time': datetime.fromtimestamp(
                             int(report_time)).isoformat(),
                         'passes': self.passes,
                         'errors': self.errors,
+                        'nb_chunks': self.total_chunks_processed,
                         'c_rate': self.passes / (now - report_time),
                         'total': (now - start_time)
                     }
@@ -70,18 +71,19 @@ class BlobIndexer(Daemon):
         end_time = time.time()
         elapsed = (end_time - start_time) or 0.000001
         self.logger.info(
-            'started=(%start_time)s '
-            'ended=(%end_time)s '
+            'started=%(start_time)s '
+            'ended=%(end_time)s '
             'elapsed=%(elapsed).02f '
             'errors=%(errors)d '
-            'chunk/s%(chunk_rate).2f ' % {
+            'chunks=%(nb_chunks)d %(c_rate).2f/s ' % {
                 'start_time': datetime.fromtimestamp(
                     int(start_time)).isoformat(),
                 'end_time': datetime.fromtimestamp(
                     int(end_time)).isoformat(),
                 'elapsed': elapsed,
                 'errors': total_errors + self.errors,
-                'chunk_rate': self.total_chunks_processed / elapsed
+                'nb_chunks': self.total_chunks_processed,
+                'c_rate': self.total_chunks_processed / elapsed
             }
         )
         if elapsed < self.interval:

--- a/oio/blob/rebuilder.py
+++ b/oio/blob/rebuilder.py
@@ -118,10 +118,12 @@ class BlobRebuilderWorker(object):
                 self.bytes_processed = 0
                 self.last_reported = now
             rebuilder_time += (now - loop_time)
-
-        elapsed = (time.time() - start_time) or 0.000001
+        end_time = time.time()
+        elapsed = (end_time - start_time) or 0.000001
         self.logger.info(
             'DONE %(volume)s '
+            'started=%(start_time)s '
+            'ended=%(end_time)s '
             'elapsed=%(elapsed).02f '
             'errors=%(errors)d '
             'chunks=%(nb_chunks)d %(c_rate).2f/s '
@@ -129,6 +131,10 @@ class BlobRebuilderWorker(object):
             'elapsed=%(rebuilder_time).2f '
             '(rebuilder: %(rebuilder_rate).2f%%)' % {
                 'volume': self.volume,
+                'start_time': datetime.fromtimestamp(
+                    int(start_time)).isoformat(),
+                'end_time': datetime.fromtimestamp(
+                    int(end_time)).isoformat(),
                 'elapsed': elapsed,
                 'errors': total_errors + self.errors,
                 'nb_chunks': self.total_chunks_processed,


### PR DESCRIPTION
Add the date of the start and end of both command.
Add name to the value of the fields of the oio-blob-indexer logs,
like the one oio-blob-rebuilder is using.