### PR TITLE
oio: Fix the behavior upon rawx errors.

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -98,6 +98,13 @@ class WriteHandler(object):
         self.read_timeout = read_timeout or CLIENT_TIMEOUT
 
     def stream(self):
+        """
+        Uploads a stream of data.
+        :returns: a tuple of 3 which contains:
+           * the list of chunks to be saved in the container
+           * the number of bytes transfered
+           * the actual checksum of the data that went through the stream.
+        """
         raise NotImplementedError()
 
 

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -736,9 +736,8 @@ class ObjectStorageAPI(API):
         h[object_headers['mime_type']] = sysmeta['mime_type']
         h[object_headers['chunk_method']] = sysmeta['chunk_method']
 
-        success_chunks = [x for x in final_chunks if x['hash'] is not None]
         m, body = self._content_create(
-            account, container, obj_name, success_chunks, metadata=metadata,
+            account, container, obj_name, final_chunks, metadata=metadata,
             headers=h)
         return final_chunks, bytes_transferred, content_checksum
 

--- a/oio/api/replication.py
+++ b/oio/api/replication.py
@@ -159,7 +159,7 @@ class ReplicatedChunkWriteHandler(object):
             chunk["size"] = bytes_transferred
             chunk["hash"] = meta_checksum
 
-        return bytes_transferred, meta_checksum, success_chunks + failed_chunks
+        return bytes_transferred, meta_checksum, success_chunks
 
     def _connect_put(self, chunk):
         """

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -80,13 +80,15 @@ class TestReplication(unittest.TestCase):
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
             bytes_transferred, checksum, chunks = handler.stream(source, size)
 
-            self.assertEqual(len(chunks), len(meta_chunk))
+            self.assertEqual(len(chunks), len(meta_chunk)-1)
 
             for i in range(quorum_size):
                 self.assertEqual(chunks[i].get('error'), None)
 
-            for i in xrange(quorum_size, len(meta_chunk)):
-                self.assertEqual(chunks[i].get('error'), 'HTTP 500')
+            # # JFS: starting at branche 3.x, it has been preferred to save
+            # #      only the chunks that succeeded.
+            # for i in xrange(quorum_size, len(meta_chunk)):
+            #     self.assertEqual(chunks[i].get('error'), 'HTTP 500')
 
             self.assertEqual(bytes_transferred, 0)
             self.assertEqual(checksum, EMPTY_CHECKSUM)
@@ -116,12 +118,15 @@ class TestReplication(unittest.TestCase):
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
             bytes_transferred, checksum, chunks = handler.stream(source, size)
 
-        self.assertEqual(len(chunks), len(meta_chunk))
+        self.assertEqual(len(chunks), len(meta_chunk)-1)
 
         for i in range(len(meta_chunk) - 1):
             self.assertEqual(chunks[i].get('error'), None)
-        self.assertEqual(
-            chunks[len(meta_chunk) - 1].get('error'), '1.0 second')
+
+        # # JFS: starting at branche 3.x, it has been preferred to save only
+        # #      the chunks that succeeded.
+        # self.assertEqual(
+        #     chunks[len(meta_chunk) - 1].get('error'), '1.0 second')
 
         self.assertEqual(bytes_transferred, 0)
         self.assertEqual(checksum, EMPTY_CHECKSUM)
@@ -138,10 +143,12 @@ class TestReplication(unittest.TestCase):
             handler = ReplicatedChunkWriteHandler(
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
             bytes_transferred, checksum, chunks = handler.stream(source, size)
-        self.assertEqual(len(chunks), len(meta_chunk))
+        self.assertEqual(len(chunks), len(meta_chunk)-1)
         for i in range(len(meta_chunk) - 1):
             self.assertEqual(chunks[i].get('error'), None)
-        self.assertEqual(chunks[len(meta_chunk) - 1].get('error'), 'failure')
+        # # JFS: starting at branche 3.x, it has been preferred to save only
+        # #      the chunks that succeeded.
+        # self.assertEqual(chunks[len(meta_chunk) - 1].get('error'), 'failure')
 
         self.assertEqual(bytes_transferred, 0)
         self.assertEqual(checksum, EMPTY_CHECKSUM)


### PR DESCRIPTION
Starting now, only the chunks to be saved should be returned by the WriteHandler implementation, and this might depend on the implementation.

Prior to this fix, the filtering of failed chunks was performed whatever the implementation. We now do it in each subclass where it is necessary.