### PR TITLE
oio: Improve the behavior of download of contents with bad chunks

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -139,15 +139,14 @@ def _sort_chunks(raw_chunks, ec_security):
             continue
         # sort by length
         bylength = byhash.values()
-        bylength.sort(lambda x, y: cmp(len(y), len(x)))
+        bylength.sort(key=len, reverse=True)
         chunks[pos] = bylength[0]
 
     # Append the 'offset' attribute
     offset = 0
     for pos in sorted(chunks.keys()):
         clist = chunks[pos]
-        clist.sort(lambda x, y: cmp(x.get("score", 0), y.get("score", 0)),
-                   reverse=True)
+        clist.sort(key=lambda x: x.get("score", 0), reverse=True)
         for element in clist:
             element['offset'] = offset
         if not ec_security and len(clist) > 1:

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -125,6 +125,24 @@ def _sort_chunks(raw_chunks, ec_security):
             chunks[position] = []
             chunks[position].append(chunk)
 
+    # for each position, remove incoherent chunks
+    for pos, local_chunks in chunks.iteritems():
+        if len(local_chunks) < 2:
+            continue
+        byhash = dict()
+        for chunk in local_chunks:
+            h = chunk.get('hash')
+            if h not in byhash:
+                byhash[h] = list()
+            byhash[h].append(chunk)
+        if len(byhash) < 2:
+            continue
+        # sort by length
+        bylength = byhash.values()
+        bylength.sort(lambda x, y: cmp(len(y), len(x)))
+        chunks[pos] = bylength[0]
+
+    # Append the 'offset' attribute
     offset = 0
     for pos in sorted(chunks.keys()):
         clist = chunks[pos]


### PR DESCRIPTION
Le's make the python API avoid chunks with dirty attributes (i.e. out of a quorum).