### PR TITLE
Enables the TCP_FASTOPEN option on sockets

### DIFF
--- a/core/http_put.c
+++ b/core/http_put.c
@@ -744,6 +744,9 @@ _curl_get_handle_proxy (void)
 {
 	CURL *h = curl_easy_init ();
 	curl_easy_setopt (h, CURLOPT_USERAGENT, OIOSDS_http_agent);
+#if (LIBCURL_VERSION_MAJOR > 7) || ((LIBCURL_VERSION_MAJOR == 7) && (LIBCURL_VERSION_MINOR >= 49))
+	curl_easy_setopt (h, CURLOPT_TCP_FASTOPEN, 1L);
+#endif
 	curl_easy_setopt (h, CURLOPT_NOPROGRESS, 1L);
 	curl_easy_setopt (h, CURLOPT_PROXY, "");
 	curl_easy_setopt (h, CURLOPT_FORBID_REUSE, 0L);

--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -213,12 +213,18 @@ struct gridd_client_vtable_s VTABLE_CLIENT =
 	_client_fail
 };
 
+/* Benefit from the maybe-present TCCP_FASTOPEN, and try to send a few bytes
+ * alongside with the initiation sequence.
+ */
 static GError*
 _client_connect(struct gridd_client_s *client)
 {
 	GError *err = NULL;
-	client->fd = sock_connect(client->url, &err);
 
+	gsize sent = client->request ? client->request->len : 0;
+	client->fd = sock_connect_and_send(client->url, &err,
+			sent && client->request ? client->request->data : NULL,
+			&sent);
 	if (client->fd < 0) {
 		EXTRA_ASSERT(err != NULL);
 		g_prefix_error(&err, "Connect error: ");
@@ -227,7 +233,12 @@ _client_connect(struct gridd_client_s *client)
 
 	EXTRA_ASSERT(err == NULL);
 	client->tv_connect = oio_ext_monotonic_time ();
-	client->step = CONNECTING;
+	client->sent_bytes = sent;
+	if (client->sent_bytes >= client->request->len) {
+		client->step = REP_READING_SIZE;
+	} else {
+		client->step = REQ_SENDING;
+	}
 	return NULL;
 }
 
@@ -379,7 +390,7 @@ _client_manage_event_in_buffer(struct gridd_client_s *client, guint8 *d, gsize d
 
 		case REQ_SENDING:
 
-			client->step = REQ_SENDING;
+			EXTRA_ASSERT(client->step == REQ_SENDING);
 
 			if (!client->request)
 				return NULL;
@@ -403,7 +414,7 @@ _client_manage_event_in_buffer(struct gridd_client_s *client, guint8 *d, gsize d
 
 		case REP_READING_SIZE:
 
-			client->step = REP_READING_SIZE;
+			EXTRA_ASSERT(client->step == REP_READING_SIZE);
 
 			if (!client->reply)
 				client->reply = g_byte_array_new();
@@ -427,10 +438,11 @@ _client_manage_event_in_buffer(struct gridd_client_s *client, guint8 *d, gsize d
 			EXTRA_ASSERT (client->reply->len == 4);
 			s32 = *((guint32*)(client->reply->data));
 			client->size = g_ntohl(s32);
+			client->step = REP_READING_DATA;
 
 		case REP_READING_DATA:
 
-			client->step = REP_READING_DATA;
+			EXTRA_ASSERT(client->step == REP_READING_DATA);
 			rc = 0;
 
 			EXTRA_ASSERT (client->reply->len <= client->size + 4);

--- a/metautils/lib/metautils_sockets.h
+++ b/metautils/lib/metautils_sockets.h
@@ -119,6 +119,8 @@ gboolean sock_set_nodelay(int fd, gboolean enabled);
 
 gboolean sock_set_cork(int fd, gboolean enabled);
 
+gboolean sock_set_fastopen(int fd);
+
 gboolean sock_set_linger(int fd, int onoff, int linger);
 
 gboolean sock_set_linger_default(int fd);
@@ -130,8 +132,14 @@ void sock_set_client_default(int fd);
  * @return the result of close() or -1 in case of error. */
 int metautils_pclose(int *pfd);
 
-/* Opens anon-blocking TCP socket then connect it to 'url' before returning
+/* Opens a non-blocking TCP socket then connect it to 'url' before returning
  * it. 'err' is optional. */
 int sock_connect (const char *url, GError **err);
+
+/* Opens a non-blocking TCP socket and attempts to benefit the TCP_FASTOPEN
+ * mechanism. The regular sock_connect() is used if that fast-open option is
+ * not supported or if there is no data to be sen. */
+int sock_connect_and_send (const char *url, GError **err,
+		const uint8_t *buf, gsize *len);
 
 #endif /*OIO_SDS__metautils__lib__metautils_sockets_h*/

--- a/metautils/lib/utils_sockets.c
+++ b/metautils/lib/utils_sockets.c
@@ -398,6 +398,20 @@ sock_set_cork(int fd, gboolean enabled)
 }
 
 gboolean
+sock_set_fastopen(int fd)
+{
+	int syndata_backlog = 16;
+	int rc = metautils_syscall_setsockopt(fd, SOL_TCP, TCP_FASTOPEN,
+			&syndata_backlog, sizeof(syndata_backlog));
+	if (!rc)
+		return TRUE;
+
+	GRID_DEBUG("fd=%i set(TCP_FASTOPEN,%d): (%d) %s",
+			fd, syndata_backlog, errno, strerror(errno));
+	return FALSE;
+}
+
+gboolean
 sock_set_linger(int fd, int onoff, int linger)
 {
 	if (VTABLE.set_linger)
@@ -424,6 +438,7 @@ sock_set_linger_default(int fd)
 void
 sock_set_client_default(int fd)
 {
+	sock_set_reuseaddr(fd, TRUE);
 	sock_set_linger_default(fd);
 	sock_set_nodelay(fd, TRUE);
 	sock_set_tcpquickack(fd, TRUE);
@@ -447,24 +462,36 @@ metautils_pclose(int *pfd)
 	return rc;
 }
 
-int
-sock_connect (const char *url, GError **err)
+static int
+sock_build_for_url(const char *url, GError **err,
+		struct sockaddr_storage *sas, size_t *sas_len)
 {
-	struct sockaddr_storage sas;
-	gsize sas_len = sizeof(sas);
+	*sas_len = sizeof(*sas);
 
-	if (!grid_string_to_sockaddr (url, (struct sockaddr*) &sas, &sas_len)) {
+	if (!grid_string_to_sockaddr (url, (struct sockaddr*) sas, sas_len)) {
 		g_error_transmit(err, NEWERROR(EINVAL, "invalid URL"));
 		return -1;
 	}
 
-	int fd = socket_nonblock(sas.ss_family, SOCK_STREAM, 0);
+	int fd = socket_nonblock(sas->ss_family, SOCK_STREAM, 0);
 	if (0 > fd) {
 		g_error_transmit(err, NEWERROR(EINVAL, "socket error: (%d) %s", errno, strerror(errno)));
 		return -1;
 	}
 
-	sock_set_reuseaddr(fd, TRUE);
+	sock_set_client_default(fd);
+	*err = NULL;
+	return fd;
+}
+
+int
+sock_connect (const char *url, GError **err)
+{
+	gsize sas_len = 0;
+	struct sockaddr_storage sas;
+	int fd = sock_build_for_url(url, err, &sas, &sas_len);
+	if (fd < 0)
+		return -1;
 
 	if (0 != metautils_syscall_connect (fd, (struct sockaddr*)&sas, sas_len)) {
 		if (errno != EINPROGRESS && errno != 0) {
@@ -474,9 +501,75 @@ sock_connect (const char *url, GError **err)
 		}
 	}
 
-	sock_set_linger_default(fd);
-	sock_set_nodelay(fd, TRUE);
-	sock_set_tcpquickack(fd, TRUE);
 	*err = NULL;
 	return fd;
+}
+
+static volatile gboolean _fastopen_supported = TRUE;
+
+int
+sock_connect_and_send (const char *url, GError **err,
+		const uint8_t *buf, gsize *len)
+{
+	gsize sas_len = 0;
+	struct sockaddr_storage sas;
+	int fd = sock_build_for_url(url, err, &sas, &sas_len);
+	if (fd < 0)
+		return -1;
+
+#if defined(MSG_FASTOPEN) && defined(TCP_FASTOPEN)
+
+	if (!buf || !len || !_fastopen_supported)
+		goto label_simple_connect;
+
+#ifdef HAVE_ENBUG
+	if (len > 1)
+		*len = *len / 2;
+#endif
+
+	ssize_t rc;
+retry:
+	rc = sendto(fd, buf, *len, MSG_FASTOPEN, (struct sockaddr*) &sas, sas_len);
+	if (rc < 0) {
+		if (errno == EINTR)
+			goto retry;
+		if (errno == ENOTSUP || errno == ENOTCONN) {
+			/* the TCP_FASTOPEN is not accepted, let's continue with a
+			 * regular connect/send sequence */
+			GRID_WARN("TCP_FASTOPEN not supported, disabling it");
+			_fastopen_supported = FALSE;
+label_simple_connect:
+#endif
+			*len = 0;
+			if (0 != metautils_syscall_connect (fd, (struct sockaddr*)&sas, sas_len)) {
+				if (errno != EINPROGRESS && errno != 0) {
+					g_error_transmit(err,
+							SYSERR("connect error: (%d) %s", errno, strerror(errno)));
+					metautils_pclose (&fd);
+					return -1;
+				}
+			}
+			*err = NULL;
+			return fd;
+#if defined(MSG_FASTOPEN) && defined(TCP_FASTOPEN)
+		} else if (errno == EINPROGRESS) {
+			/* syn-cookie not ready, so the kernel will proceed internally with
+			 * traditional connect() SYN-SYN/ACK-ACK sequence */
+			*len = 0;
+			*err = NULL;
+			return fd;
+		} else {
+			g_error_transmit(err, NEWERROR(CODE_NETWORK_ERROR,
+						"connect error: (%d) %s", errno, strerror(errno)));
+			metautils_pclose (&fd);
+			return -1;
+		}
+	} else {
+		/* syn-cookie ready, the number of bytes packed in the SYN-cookie is
+		 * returned. */
+		*len = rc;
+		*err = NULL;
+		return fd;
+	}
+#endif
 }

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -973,8 +973,8 @@ _endpoint_open(struct endpoint_s *u, gboolean udp_allowed)
 		return NEWERROR(errsave, "bind(udp,%s) = '%s'", u->url, strerror(errsave));
 	}
 
-	/* for INET sockets, get the port really used */
 	if (_endpoint_is_INET(u)) {
+		/* for INET sockets, get the port really used */
 		memset(&ss, 0, sizeof(ss));
 		ss_len = sizeof(ss);
 		getsockname(u->fd, (struct sockaddr*)&ss, &ss_len);
@@ -982,6 +982,9 @@ _endpoint_open(struct endpoint_s *u, gboolean udp_allowed)
 			u->port_real = ntohs(((struct sockaddr_in*)&ss)->sin_port);
 		else
 			u->port_real = ntohs(((struct sockaddr_in6*)&ss)->sin6_port);
+
+		/* and benefit from the TCP_FASTOPEN support */
+		sock_set_fastopen(u->fd);
 	}
 
 	if (0 > listen(u->fd, 32768))


### PR DESCRIPTION
The major benefit will be ~ 25% less network packets for small RPC, because the server will accept to the data sent with the TCP SYN packet. Currently implemented between the C SDK based clients and the services, the biggest impact will be observed between the services (DB replication), and between the proxy and the services.

Consider configuring your hosts like this:

```bash
echo 3 >> /proc/sys/net/ipv4/tcp_fastopen
```

`echo 1` would activate it for the clients, `echo 2` for the servers, their sum fort both.