### PR TITLE
sqliterepo: Reduce the amount of IO ops with a smarter cache

### DIFF
--- a/core/log.c
+++ b/core/log.c
@@ -256,6 +256,7 @@ _logger_stderr(const gchar *log_domain, GLogLevelFlags log_level,
 		default:
 			g_string_append_len(gstr, "log ", 4);
 			g_string_append(gstr, glvl_to_str(log_level));
+			g_string_append_c(gstr, ' ');
 			/* print the domain */
 			if (!(oio_log_flags & LOG_FLAG_TRIM_DOMAIN))
 				g_string_append(gstr, log_domain);

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -648,8 +648,7 @@ sqlx_admin_reload(struct sqlx_sqlite3_s *sq3)
 {
 	if (sq3->admin)
 		g_tree_destroy(sq3->admin);
-	sq3->admin = g_tree_new_full(metautils_strcmp3, NULL,
-			g_free, metautils_gba_unref);
+	sq3->admin = g_tree_new_full(metautils_strcmp3, NULL, g_free, g_free);
 
 	sqlx_admin_load (sq3);
 	sqlx_admin_ensure_versions (sq3);
@@ -721,8 +720,7 @@ retry:
 	sq3->name.ns = g_strdup(args->name.ns);
 	sq3->path = g_strdup(args->realpath);
 	sq3->admin_dirty = 0;
-	sq3->admin = g_tree_new_full(metautils_strcmp3, NULL,
-			g_free, metautils_gba_unref);
+	sq3->admin = g_tree_new_full(metautils_strcmp3, NULL, g_free, g_free);
 
 	sqlx_exec(handle, "PRAGMA foreign_keys = OFF");
 	sqlx_exec(handle, "PRAGMA journal_mode = MEMORY");
@@ -877,8 +875,7 @@ _open_and_lock_base(struct open_args_s *args, enum election_status_e expected,
 			gchar *myid = g_strdup(
 					election_manager_get_local((*result)->manager));
 			peers = oio_strv_append(peers, myid);
-			gboolean modified = sqlx_admin_ensure_peers((*result), peers);
-			if (modified) {
+			if (sqlx_admin_ensure_peers((*result), peers)) {
 				sqlx_admin_save_lazy(*result);
 				GRID_DEBUG("Replications peers saved in %s", (*result)->path);
 			}

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -20,6 +20,39 @@ License along with this library.
 #include <string.h>
 
 #include "sqliterepo.h"
+#include "version.h"
+
+/** @private */
+struct _cache_entry_s {
+	/* the size of the value, without the trailing 0 */
+	guint32 len;
+	guint8 flag_deleted : 1;
+	guint8 flag_changed : 1;
+	gchar buffer[];
+};
+
+static inline gsize _buffer_length(const gsize len) { return MAX(len,32) + 1; }
+
+static inline gsize
+_cache_entry_length(struct _cache_entry_s *e)
+{
+	return _buffer_length(e->len);
+}
+
+static struct _cache_entry_s *
+_make_cache_entry(const gchar *buf, gsize len)
+{
+	/* By allocating 32 bytes for the value, we know it will ever be enough
+	 * for the value that represent the version of a table in the database.
+	 * Those entries are changed in place, later, because this is done really
+	 * often and it saves memory allocations. */
+	struct _cache_entry_s *e = g_malloc0(
+			sizeof(struct _cache_entry_s) + _buffer_length(len));
+	e->len = len;
+	if (len > 0)
+		memcpy(e->buffer, buf, len);
+	return e;
+}
 
 int
 sqlx_exec(sqlite3 *handle, const gchar *sql)
@@ -47,27 +80,30 @@ sqlx_exec(sqlite3 *handle, const gchar *sql)
 	return grc;
 }
 
-void
-sqlx_admin_set_gba_and_clean(struct sqlx_sqlite3_s *sq3, const gchar *k,
-		GByteArray *gba)
-{
-	// Avoid replacing the value if the same is already present
-	GByteArray *prev = g_tree_lookup(sq3->admin, k);
-	if (prev && gba->len == prev->len) {
-		if (!memcmp(gba->data, prev->data, prev->len)) {
-			g_byte_array_free(gba, TRUE);
-			return;
-		}
-	}
-
-	g_tree_replace(sq3->admin, g_strdup(k), gba);
-	sq3->admin_dirty = 1;
-}
-
-void
+gboolean
 sqlx_admin_set_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v)
 {
-	sqlx_admin_set_gba_and_clean(sq3, k, metautils_gba_from_string(v));
+	v = v ?: "";
+	const gsize len = strlen(v);
+
+	/* Avoid replacing the value if the same is already present */
+	struct _cache_entry_s *prev = g_tree_lookup(sq3->admin, k);
+	if (prev && len == prev->len && (!len || !memcmp(v, prev->buffer, len)))
+		return FALSE;
+
+	/* If the new value is not longer than the previous, we can even reuse
+	 * the same buffer */
+	if (prev && len < _cache_entry_length(prev)) {
+		prev->len = g_strlcpy(prev->buffer, v, _cache_entry_length(prev));
+		prev->flag_deleted = 0;
+	} else {
+		prev = _make_cache_entry(v, len);
+		g_tree_replace(sq3->admin, g_strdup(k), prev);
+	}
+
+	prev->flag_changed = 1;
+	sq3->admin_dirty = 1;
+	return TRUE;
 }
 
 gboolean
@@ -75,27 +111,32 @@ sqlx_admin_init_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v)
 {
 	if (g_tree_lookup(sq3->admin, k))
 		return FALSE;
-	sqlx_admin_set_str(sq3, k, v);
-	return TRUE;
+	return sqlx_admin_set_str(sq3, k, v);
 }
 
 void
 sqlx_admin_del(struct sqlx_sqlite3_s *sq3, const gchar *k)
 {
-	sqlx_admin_set_str (sq3, k, NULL);
+	struct _cache_entry_s *v = g_tree_lookup(sq3->admin, k);
+	if (v) {
+		v->flag_deleted = 1;
+		v->flag_changed = 0;
+		sq3->admin_dirty = TRUE;
+	}
 }
 
 void
 sqlx_admin_del_all_user(struct sqlx_sqlite3_s *sq3)
 {
-	gchar **k = gtree_string_keys(sq3->admin);
-	if (!k)
-		return;
-	for (gchar **p=k; *p ;p++) {
-		if (g_str_has_prefix(*p, SQLX_ADMIN_PREFIX_USER))
-			sqlx_admin_del (sq3, *p);
+	gboolean runner(gchar *k, struct _cache_entry_s *v, gpointer i UNUSED) {
+		if (g_str_has_prefix(k, SQLX_ADMIN_PREFIX_USER)) {
+			v->flag_deleted = 1;
+			v->flag_changed = 0;
+		}
+		return FALSE;
 	}
-	g_free (k);
+	g_tree_foreach(sq3->admin, (GTraverseFunc)runner, NULL);
+	sq3->admin_dirty = TRUE;
 }
 
 int
@@ -107,26 +148,19 @@ sqlx_admin_has(struct sqlx_sqlite3_s *sq3, const gchar *k)
 gchar*
 sqlx_admin_get_str(struct sqlx_sqlite3_s *sq3, const gchar *k)
 {
-	GByteArray *v = g_tree_lookup(sq3->admin, k);
-	return v ? g_strndup((gchar*)v->data, v->len) : NULL;
-}
-
-GByteArray*
-sqlx_admin_get_gba(struct sqlx_sqlite3_s *sq3, const gchar *k)
-{
-	GByteArray *v = g_tree_lookup(sq3->admin, k);
-	return v ? metautils_gba_dup(v) : NULL;
+	struct _cache_entry_s *v = g_tree_lookup(sq3->admin, k);
+	if (!v || v->flag_deleted)
+		return NULL;
+	return g_strndup(v->buffer, v->len);
 }
 
 gint64
 sqlx_admin_get_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 def)
 {
-	gchar *s = sqlx_admin_get_str(sq3, k);
-	if (!s)
+	struct _cache_entry_s *v = g_tree_lookup(sq3->admin, k);
+	if (!v || v->flag_deleted)
 		return def;
-	gint64 i64 = g_ascii_strtoll(s, NULL, 10);
-	g_free(s);
-	return i64;
+	return g_ascii_strtoll(v->buffer, NULL, 10);
 }
 
 void
@@ -150,50 +184,65 @@ void
 sqlx_admin_inc_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 delta)
 {
 	gchar *s = sqlx_admin_get_str(sq3, k);
-	if (!s)
+	if (!s) {
 		sqlx_admin_set_i64(sq3, k, delta);
-	else {
+	} else {
 		sqlx_admin_set_i64(sq3, k, delta + g_ascii_strtoll(s, NULL, 10));
 		g_free(s);
 	}
 }
 
+static void
+_cache_entry_increment_version(struct _cache_entry_s *entry, const int delta)
+{
+	/* Build the new version string in place, as explained the buffer
+	 * is large enough for the longest version string possible. So we can
+	 * use the strlcpy() return size as the actual length of the buffer. */
+	if (entry->flag_deleted) {
+		entry->len = g_strlcpy(entry->buffer, "1:0", _cache_entry_length(entry));
+	} else {
+		gchar *p = strchr(entry->buffer, ':');
+		if (!p) {
+			entry->len = g_strlcpy(entry->buffer, "1:0", _cache_entry_length(entry));
+		} else {
+			const gint64 v0 = g_ascii_strtoll(entry->buffer, NULL, 10);
+			const gint64 v1 = g_ascii_strtoll(p+1, NULL, 10);
+			entry->len = g_snprintf(entry->buffer, _cache_entry_length(entry),
+					"%"G_GINT64_FORMAT":%"G_GINT64_FORMAT, v0 + delta, v1);
+		}
+	}
+
+	entry->flag_changed = 1;
+	entry->flag_deleted = 0;
+}
+
 void
 sqlx_admin_inc_version(struct sqlx_sqlite3_s *sq3, const gchar *k, const int delta)
 {
-	gchar buf[128], *p, *prev;
-
-	if (!(prev = sqlx_admin_get_str(sq3, k)))
-		return;
-	if (!(p = strchr(prev, ':')))
-		return;
-
-	*(p++) = '\0';
-	g_snprintf(buf, sizeof(buf), "%"G_GINT64_FORMAT":%"G_GINT64_FORMAT,
-			g_ascii_strtoll(prev, NULL, 10) + delta,
-			g_ascii_strtoll(p, NULL, 10));
-	g_free(prev);
-	sqlx_admin_set_str(sq3, k, buf);
+	struct _cache_entry_s *prev = g_tree_lookup(sq3->admin, k);
+	if (prev) {
+		_cache_entry_increment_version(prev, delta);
+		sq3->admin_dirty = TRUE;
+	}
 }
 
-gboolean
+void
 sqlx_admin_ensure_versions (struct sqlx_sqlite3_s *sq3)
 {
-	int rc, any_added = FALSE;
+	int rc;
 	sqlite3_stmt *stmt = NULL;
 	sqlite3_prepare_debug(rc, sq3->db, "SELECT name FROM sqlite_master"
 			" WHERE type = 'table'", -1, &stmt, NULL);
 	if (rc == SQLITE_OK) {
 		EXTRA_ASSERT(stmt != NULL);
 		while (SQLITE_ROW == (rc = sqlite3_step(stmt))) {
-			const gchar *name = (const gchar*)sqlite3_column_text(stmt, 0);
-			gchar *k = g_strdup_printf("version:main.%s", name);
-			any_added |= sqlx_admin_init_str (sq3, k, "1:0");
-			g_free(k);
+			gchar k[512];
+			g_snprintf(k, sizeof(k), "version:main.%s",
+					sqlite3_column_text(stmt, 0));
+			sqlx_admin_init_str (sq3, k, "1:0");
 		}
 		sqlite3_finalize(stmt);
 	}
-	return BOOL(any_added);
 }
 
 gboolean
@@ -201,46 +250,26 @@ sqlx_admin_ensure_peers(struct sqlx_sqlite3_s *sq3, gchar **peers)
 {
 	EXTRA_ASSERT(peers != NULL);
 	gboolean modified = FALSE;
-	gchar *packed_peers = sqlx_admin_get_str(sq3, SQLX_ADMIN_PEERS);
-	if (!oio_str_is_set(packed_peers)) {
-		g_free(packed_peers);  // in case it was allocated but empty
-		packed_peers = g_strjoinv(",", peers);
-		sqlx_admin_set_str(sq3, SQLX_ADMIN_PEERS, packed_peers);
-		modified = TRUE;
+	if (!sqlx_admin_has(sq3, SQLX_ADMIN_PEERS)) {
+		gchar *packed_peers = g_strjoinv(",", peers);
+		modified = sqlx_admin_set_str(sq3, SQLX_ADMIN_PEERS, packed_peers);
+		g_free(packed_peers);
 	}
-	g_free(packed_peers);
 	return modified;
 }
 
 void
 sqlx_admin_inc_all_versions(struct sqlx_sqlite3_s *sq3, const int delta)
 {
-	gboolean runner(gchar *k0, GByteArray *v, gpointer ignored) {
-		(void) ignored;
+	gboolean runner(gchar *k0, struct _cache_entry_s *v, gpointer i UNUSED) {
 		if (!g_str_has_prefix(k0, "version:"))
 			return FALSE;
-
-		gchar *prev = g_alloca(v->len+8);
-		memset(prev, 0, v->len+8);
-		memcpy(prev, v->data, v->len);
-
-		/* Build the new version string */
-		gchar *p = strchr(prev, ':');
-		if (!p)
-			return FALSE;
-		*(p++) = '\0';
-		gint64 v0 = g_ascii_strtoll(prev, NULL, 10) + delta;
-		gint64 v1 = g_ascii_strtoll(p, NULL, 10);
-		g_snprintf(prev, v->len+8, "%"G_GINT64_FORMAT":%"G_GINT64_FORMAT, v0, v1);
-
-		/* Change in place and mark for a later save in the DB */
-		g_byte_array_set_size(v, 0);
-		g_byte_array_append(v, (guint8*)prev, strlen(prev));
-		sq3->admin_dirty = 1;
+		_cache_entry_increment_version(v, delta);
 		return FALSE;
 	}
 
 	g_tree_foreach(sq3->admin, (GTraverseFunc)runner, NULL);
+	sq3->admin_dirty = TRUE;
 }
 
 void
@@ -259,8 +288,7 @@ sqlx_admin_get_status(struct sqlx_sqlite3_s *sq3)
 gchar**
 sqlx_admin_get_keys(struct sqlx_sqlite3_s *sq3)
 {
-	gboolean runner(gchar *k, GByteArray *v, GPtrArray *tmp) {
-		(void) v;
+	gboolean runner(gchar *k, gpointer v UNUSED, GPtrArray *tmp) {
 		g_ptr_array_add (tmp, g_strdup(k));
 		return FALSE;
 	}
@@ -273,13 +301,12 @@ sqlx_admin_get_keys(struct sqlx_sqlite3_s *sq3)
 gchar**
 sqlx_admin_get_keyvalues (struct sqlx_sqlite3_s *sq3)
 {
-	gboolean runner(gchar *k, GByteArray *v, GPtrArray *tmp) {
-		(void) v;
+	gboolean runner(gchar *k, struct _cache_entry_s *v, GPtrArray *tmp) {
 		g_ptr_array_add (tmp, g_strdup(k));
-		if (!v->len || !v->data)
+		if (!v->buffer)
 			g_ptr_array_add (tmp, g_strdup(""));
 		else
-			g_ptr_array_add (tmp, g_strndup((gchar*)v->data, v->len));
+			g_ptr_array_add (tmp, g_strndup((gchar*)v->buffer, v->len));
 		return FALSE;
 	}
 
@@ -288,7 +315,7 @@ sqlx_admin_get_keyvalues (struct sqlx_sqlite3_s *sq3)
 	return (gchar**) metautils_gpa_to_array (tmp, TRUE);
 }
 
-guint
+static guint
 sqlx_admin_save (struct sqlx_sqlite3_s *sq3)
 {
 	int rc;
@@ -304,16 +331,20 @@ sqlx_admin_save (struct sqlx_sqlite3_s *sq3)
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)
 		err = SYSERR("DB error: (%d) %s", rc, sqlite3_errmsg(sq3->db));
 	else {
-		gboolean _save (gchar *k, GByteArray *v, gpointer i) {
-			if (!v || !v->len || !v->data) {
-				run_to_delete = TRUE;
+		gboolean _save (gchar *k, struct _cache_entry_s *v, gpointer i UNUSED) {
+
+			run_to_delete |= BOOL(v->flag_deleted);
+			if (v->flag_deleted || !v->flag_changed)
 				return FALSE;
-			}
-			(void) i;
+
 			sqlite3_reset (stmt);
 			sqlite3_clear_bindings (stmt);
 			sqlite3_bind_text (stmt, 1, k, -1, NULL);
-			sqlite3_bind_blob (stmt, 2, v->data, v->len, NULL);
+			if (!v->len) {
+				sqlite3_bind_null (stmt, 2);
+			} else {
+				sqlite3_bind_blob (stmt, 2, (guint8*)v->buffer, v->len, NULL);
+			}
 			sqlite3_step_debug_until_end (rc, stmt);
 			if (rc != SQLITE_OK && rc != SQLITE_DONE)
 				err = SYSERR("DB error: (%d) %s", rc, sqlite3_errmsg(sq3->db));
@@ -324,17 +355,16 @@ sqlx_admin_save (struct sqlx_sqlite3_s *sq3)
 		(void) sqlite3_finalize(stmt);
 	}
 
-
 	if (run_to_delete && !err) {
-		sqlite3_prepare_debug(rc, sq3->db, "DELETE FROM admin WHERE k = ?", -1, &stmt, NULL);
+		sqlite3_prepare_debug(rc, sq3->db,
+				"DELETE FROM admin WHERE k = ?", -1, &stmt, NULL);
 		if (rc != SQLITE_OK && rc != SQLITE_DONE)
 			err = SYSERR("DB error: (%d) %s", rc, sqlite3_errmsg(sq3->db));
 		else {
 			GSList *deleted = NULL;
-			gboolean _delete (gchar *k, GByteArray *v, gpointer i) {
-				if (v && v->len)
+			gboolean _delete (gchar *k, struct _cache_entry_s *v, gpointer i UNUSED) {
+				if (!v->flag_deleted)
 					return FALSE;
-				(void) i;
 				sqlite3_reset (stmt);
 				sqlite3_clear_bindings (stmt);
 				sqlite3_bind_text (stmt, 1, k, -1, NULL);
@@ -366,7 +396,8 @@ sqlx_admin_save (struct sqlx_sqlite3_s *sq3)
 guint
 sqlx_admin_save_lazy (struct sqlx_sqlite3_s *sq3)
 {
-	if (!sq3 || !sq3->admin_dirty) return 0;
+	if (!sq3 || !sq3->admin_dirty)
+		return 0;
 	guint rc = sqlx_admin_save (sq3);
 	sq3->admin_dirty = 0;
 	return rc;
@@ -375,7 +406,8 @@ sqlx_admin_save_lazy (struct sqlx_sqlite3_s *sq3)
 guint
 sqlx_admin_save_lazy_tnx (struct sqlx_sqlite3_s *sq3)
 {
-	if (!sq3 || !sq3->admin_dirty) return 0;
+	if (!sq3 || !sq3->admin_dirty)
+		return 0;
 	sqlx_exec (sq3->db, "BEGIN");
 	guint rc = sqlx_admin_save (sq3);
 	sqlx_exec (sq3->db, "COMMIT");
@@ -394,10 +426,10 @@ sqlx_admin_load(struct sqlx_sqlite3_s *sq3)
 		EXTRA_ASSERT(stmt != NULL);
 		while (SQLITE_ROW == (rc = sqlite3_step(stmt))) {
 			const gchar *k = (const gchar*)sqlite3_column_text(stmt, 0);
-			GByteArray *v = g_byte_array_append(g_byte_array_new(),
-					sqlite3_column_blob(stmt, 1),
-					sqlite3_column_bytes(stmt, 1));
-			g_tree_replace(sq3->admin, g_strdup(k), v);
+			g_tree_replace(sq3->admin, g_strdup(k),
+					_make_cache_entry(
+						sqlite3_column_blob(stmt, 1),
+						sqlite3_column_bytes(stmt, 1)));
 		}
 		sqlite3_finalize(stmt);
 	}
@@ -428,3 +460,37 @@ sqlx_admin_get_url (struct sqlx_sqlite3_s *sq3)
 	oio_url_set (u, OIOURL_TYPE, sq3->name.type);
 	return u;
 }
+
+static gboolean
+hook_extract(gchar *k, struct _cache_entry_s *v, GTree *version)
+{
+	if (!g_str_has_prefix(k, "version:"))
+		return FALSE;
+
+	gchar *p;
+	if (!(p = strchr(v->buffer, ':')))
+		return FALSE;
+
+	struct object_version_s ov;
+	ov.version = atoi(v->buffer);
+	ov.when = atoi(p+1);
+	g_tree_insert(version,
+			hashstr_create(k+sizeof("version:")-1),
+			g_memdup(&ov, sizeof(ov)));
+	return FALSE;
+}
+
+GTree*
+version_empty(void)
+{
+	return g_tree_new_full(hashstr_quick_cmpdata, NULL, g_free, g_free);
+}
+
+GTree*
+version_extract_from_admin_tree(GTree *t)
+{
+	GTree *v = version_empty();
+	g_tree_foreach(t, (GTraverseFunc)hook_extract, v);
+	return v;
+}
+

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -292,7 +292,9 @@ sqlx_admin_get_status(struct sqlx_sqlite3_s *sq3)
 gchar**
 sqlx_admin_get_keys(struct sqlx_sqlite3_s *sq3)
 {
-	gboolean runner(gchar *k, gpointer v UNUSED, GPtrArray *tmp) {
+	gboolean runner(gchar *k, struct _cache_entry_s *v, GPtrArray *tmp) {
+		if (v->flag_deleted)
+			return FALSE;
 		g_ptr_array_add (tmp, g_strdup(k));
 		return FALSE;
 	}
@@ -307,6 +309,8 @@ sqlx_admin_get_keyvalues (struct sqlx_sqlite3_s *sq3)
 {
 	gboolean runner(gchar *k, struct _cache_entry_s *v, GPtrArray *tmp) {
 		g_ptr_array_add (tmp, g_strdup(k));
+		if (v->flag_deleted)
+			return FALSE;
 		if (!v->buffer)
 			g_ptr_array_add (tmp, g_strdup(""));
 		else

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -166,8 +166,8 @@ sqlx_admin_get_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 def)
 void
 sqlx_admin_set_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 v)
 {
-	gchar buf[64];
-	g_snprintf(buf, 64, "%"G_GINT64_FORMAT, v);
+	gchar buf[32];
+	g_snprintf(buf, 32, "%"G_GINT64_FORMAT, v);
 	sqlx_admin_set_str(sq3, k, buf);
 }
 

--- a/sqliterepo/sqlite_utils.h
+++ b/sqliterepo/sqlite_utils.h
@@ -144,8 +144,7 @@ int sqlx_admin_has(struct sqlx_sqlite3_s *sq3, const gchar *k);
 
 
 void sqlx_admin_set_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 v);
-void sqlx_admin_set_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v);
-void sqlx_admin_set_gba_and_clean(struct sqlx_sqlite3_s *sq3, const gchar *k, GByteArray *gba);
+gboolean sqlx_admin_set_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v);
 
 gboolean sqlx_admin_init_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint64 v);
 gboolean sqlx_admin_init_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v);
@@ -156,23 +155,16 @@ gint64 sqlx_admin_get_i64(struct sqlx_sqlite3_s *sq3, const gchar *k, const gint
 gchar* sqlx_admin_get_str(struct sqlx_sqlite3_s *sq3, const gchar *k);
 gchar** sqlx_admin_get_keys(struct sqlx_sqlite3_s *sq3);
 gchar** sqlx_admin_get_keyvalues(struct sqlx_sqlite3_s *sq3);
-GByteArray* sqlx_admin_get_gba(struct sqlx_sqlite3_s *sq3, const gchar *k);
 
 void sqlx_admin_inc_version(struct sqlx_sqlite3_s *sq3, const gchar *k, const int d);
 void sqlx_admin_inc_all_versions(struct sqlx_sqlite3_s *sq3, const int delta);
 
-/* return FALSE if no changed happened */
-gboolean sqlx_admin_ensure_versions (struct sqlx_sqlite3_s *sq3);
+void sqlx_admin_ensure_versions (struct sqlx_sqlite3_s *sq3);
 
 /* Check if peers have been saved in the database, save them if needed.
  * Returns TRUE if peers have just been saved,
  * FALSE if they were already there */
 gboolean sqlx_admin_ensure_peers(struct sqlx_sqlite3_s *sq3, gchar **peers);
-
-/* Returns the numer of items altered. It doesn't check the <sq3->admin_dirty>
- * flag, and doesn't open/closes a transaction. This is intentional, to let
- * sqlx_admin_save_lazy() take place in a transaction managed by the caller. */
-guint sqlx_admin_save (struct sqlx_sqlite3_s *sq3);
 
 /* calls sqlx_admin_save() if the handle is dirty */
 guint sqlx_admin_save_lazy (struct sqlx_sqlite3_s *sq3);

--- a/sqliterepo/version.c
+++ b/sqliterepo/version.c
@@ -61,42 +61,6 @@ version_getslen(gboolean init, GTree *t, const guint8 *ks, gsize ks_len)
 	return o;
 }
 
-static gboolean
-hook_extract(gchar *k, GByteArray *v, GTree *version)
-{
-	if (!g_str_has_prefix(k, "version:"))
-		return FALSE;
-
-	gchar *p, buf[v->len+1];
-	memset(buf, 0, v->len + 1);
-	memcpy(buf, v->data, v->len);
-	if (!(p = strchr(buf, ':')))
-		return FALSE;
-
-	*(p++) = '\0';
-	struct object_version_s ov;
-	ov.version = atoi(buf);
-	ov.when = atoi(p);
-	g_tree_insert(version,
-			hashstr_create(k+sizeof("version:")-1),
-			g_memdup(&ov, sizeof(ov)));
-	return FALSE;
-}
-
-GTree*
-version_empty(void)
-{
-	return g_tree_new_full(hashstr_quick_cmpdata, NULL, g_free, g_free);
-}
-
-GTree*
-version_extract_from_admin_tree(GTree *t)
-{
-	GTree *v = version_empty();
-	g_tree_foreach(t, (GTraverseFunc)hook_extract, v);
-	return v;
-}
-
 GTree*
 version_extract_from_admin(struct sqlx_sqlite3_s *sq3)
 {


### PR DESCRIPTION
Better management of modified/deleted entries in the cache of the `admin` table.