### PR TITLE
Travis-CI: Stop dumping the /var/log at exit

### DIFF
--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -12,21 +12,8 @@ if [ $# -eq 2 ] ; then
 fi
 
 function dump_syslog {
-    cmd=tail
-    if ! [ -r /var/log/syslog ] ; then
-        cmd="sudo tail"
-    fi
     echo
-    $cmd -n 1000 /var/log/syslog
-    echo
-    ps -efjH
-    echo
-    ulimit -a
-    echo
-    python --version
-    pip show setuptools
-    echo
-    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status2
+    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
 }
 
 trap dump_syslog EXIT


### PR DESCRIPTION
Prove useful under certain temporary circumstances, not necessary in the
mainstream conditions.