### PR TITLE
Fix a deadlock when shutting down meta* services

### DIFF
--- a/metautils/lib/utils_sockets.c
+++ b/metautils/lib/utils_sockets.c
@@ -522,7 +522,7 @@ sock_connect_and_send (const char *url, GError **err,
 	const gint64 now = oio_ext_monotonic_time();
 
 	if (!buf || !len || (_fastopen_last_error != 0 &&
-				_fastopen_last_error < OLDEST(now,G_TIME_SPAN_MINUTE)))
+				_fastopen_last_error > OLDEST(now,G_TIME_SPAN_MINUTE)))
 		goto label_simple_connect;
 
 #ifdef HAVE_ENBUG

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -667,12 +667,11 @@ _manager_clean(struct election_manager_s *manager)
 			count.total, count.master, count.slave, count.pending,
 			count.failed, count.none);
 
-	g_mutex_lock(&manager->lock);
-
 	if (manager->completions) {
 		g_thread_pool_free(manager->completions, FALSE, TRUE);
 		manager->completions = NULL;
 	}
+
 	if (manager->members_by_key) {
 		g_tree_destroy (manager->members_by_key);
 		manager->members_by_key = NULL;
@@ -695,7 +694,6 @@ _manager_clean(struct election_manager_s *manager)
 		manager->conditions = NULL;
 	}
 
-	g_mutex_unlock(&manager->lock);
 	g_mutex_clear(&manager->lock);
 
 	g_free(manager);


### PR DESCRIPTION
In addition, also fix the detection of the delay that prevent TFO to be retried too fast after a "not supported" error.