### PR TITLE
New LB tests for tight platforms

### DIFF
--- a/core/lb.c
+++ b/core/lb.c
@@ -29,7 +29,6 @@ License along with this library.
 
 typedef guint32 generation_t;
 
-// actually not prime but OK
 #define OIO_LB_SHUFFLE_JUMP ((1UL << 31) - 1)
 
 


### PR DESCRIPTION
Check how many unbalanced repartitions we get on platforms where
there is not enough locations to ensure a perfect data securing.

For example, when there is 3 host with 4 services each, and we ask
for 9 services, the load-balancer sometimes returns 4 services from
the first host, 2 from the second and 3 from the third,
whereas we expect 3, 3 and 3.