### PR TITLE
meta0: Fix a memory leak happening during the bootstrap

### DIFF
--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -273,7 +273,10 @@ _json_to_meta0_mapping(const char *json_mapping, GPtrArray **result)
 		}
 	}
 
+	if (jbody)
+		json_object_put(jbody);
 	json_tokener_free(parser);
+
 	if (err)
 		meta0_utils_array_clean(urls_by_pfx);
 	else


### PR DESCRIPTION
Fix #953