### PR TITLE
Prevent SIGPIPE signal when writing to a closed connection

### DIFF
--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -401,9 +401,10 @@ _client_manage_event_in_buffer(struct gridd_client_s *client, guint8 *d, gsize d
 				return NULL;
 
 			/* Continue to send the request */
-			rc = metautils_syscall_write(client->fd,
+			rc = metautils_syscall_send(client->fd,
 					client->request->data + client->sent_bytes,
-					client->request->len - client->sent_bytes);
+					client->request->len - client->sent_bytes,
+					MSG_NOSIGNAL);
 
 			if (rc < 0)
 				return (errno == EINTR || errno == EAGAIN) ? NULL :

--- a/metautils/lib/metautils_syscall.h
+++ b/metautils/lib/metautils_syscall.h
@@ -38,6 +38,7 @@ struct metautils_syscalls_vtable_s {
 
 	int (*poll) (struct pollfd *, int, int);
 	ssize_t (*write) (int, const void *, size_t);
+	ssize_t (*send) (int, const void *, size_t, int);
 	ssize_t (*read) (int , void *, size_t);
 
 	int (*getsockopt) (int, int, int, void *, socklen_t *);
@@ -60,6 +61,7 @@ int metautils_syscall_accept (int, struct sockaddr *, socklen_t *);
 int metautils_syscall_accept4 (int, struct sockaddr *, socklen_t *, int);
 #endif
 ssize_t metautils_syscall_write (int, const void *, size_t);
+ssize_t metautils_syscall_send (int, const void *, size_t, int);
 ssize_t metautils_syscall_read (int , void *, size_t);
 int metautils_syscall_poll (struct pollfd *, int, int);
 int metautils_syscall_getsockopt (int, int, int, void *, socklen_t *);

--- a/metautils/lib/utils_sockets.c
+++ b/metautils/lib/utils_sockets.c
@@ -532,7 +532,8 @@ sock_connect_and_send (const char *url, GError **err,
 
 	ssize_t rc;
 retry:
-	rc = sendto(fd, buf, *len, MSG_FASTOPEN, (struct sockaddr*) &sas, sas_len);
+	rc = sendto(fd, buf, *len,
+			MSG_FASTOPEN|MSG_NOSIGNAL, (struct sockaddr*) &sas, sas_len);
 	if (rc < 0) {
 		if (errno == EINTR)
 			goto retry;

--- a/metautils/lib/utils_syscall.c
+++ b/metautils/lib/utils_syscall.c
@@ -103,6 +103,14 @@ metautils_syscall_write (int fd, const void *buf, size_t count)
 }
 
 ssize_t
+metautils_syscall_send (int fd, const void *buf, size_t count, int flags)
+{
+	if (VTABLE.send)
+		return VTABLE.send(fd, buf, count, flags);
+	return send(fd, buf, count, flags);
+}
+
+ssize_t
 metautils_syscall_read (int fd, void *buf, size_t count)
 {
 	if (VTABLE.read)

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -483,8 +483,8 @@ _direct_use (struct sqlx_peering_s *self,
 		struct sockaddr *sa = (struct sockaddr*) &ss;
 		if (grid_string_to_sockaddr(url, sa, &ss_len)) {
 			GByteArray *req = sqlx_pack_USE(n);
-			const ssize_t sent =
-				sendto(p->fd_udp, req->data, req->len, 0, sa, ss_len);
+			const ssize_t sent = sendto(p->fd_udp, req->data, req->len,
+					MSG_NOSIGNAL, sa, ss_len);
 			const ssize_t len = req->len;
 			g_byte_array_unref(req);
 			if (sent != len) {


### PR DESCRIPTION
We don't need the ugly SIGPIPE to be raised, especially if we make the necessary to ignore it.