### PR TITLE
core/curl: Avoid intercepting signals upon curl errors

### DIFF
--- a/core/http_put.c
+++ b/core/http_put.c
@@ -735,6 +735,7 @@ _curl_get_handle_blob (void)
 {
 	CURL *h = curl_easy_init ();
 	curl_easy_setopt (h, CURLOPT_FORBID_REUSE, 1L);
+	curl_easy_setopt (h, CURLOPT_NOSIGNAL, 1L);
 	curl_easy_setopt (h, CURLOPT_FRESH_CONNECT, 1L);
 	curl_easy_setopt (h, CURLOPT_USERAGENT, OIOSDS_http_agent);
 	curl_easy_setopt (h, CURLOPT_NOPROGRESS, 1L);
@@ -753,6 +754,8 @@ _curl_get_handle_proxy (void)
 {
 	CURL *h = curl_easy_init ();
 	curl_easy_setopt (h, CURLOPT_USERAGENT, OIOSDS_http_agent);
+	curl_easy_setopt (h, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt (h, CURLOPT_TCP_NODELAY, 1L);
 	curl_easy_setopt (h, CURLOPT_NOPROGRESS, 1L);
 	curl_easy_setopt (h, CURLOPT_PROXY, "");
 	curl_easy_setopt (h, CURLOPT_FORBID_REUSE, 0L);


### PR DESCRIPTION
Let each service manage the signals the way it decided.

Impacts the oio-sds C SDK and the meta* services while they contact the proxy.