### PR TITLE
Add a general trigger around the activiation of TFO

### DIFF
--- a/core/oiocfg.h
+++ b/core/oiocfg.h
@@ -345,6 +345,7 @@ extern "C" {
 # define OIO_CFG_RAWX_EVENTS   "rawx_events"
 # define OIO_CFG_LOG_OUTGOING  "log_outgoing"
 # define OIO_CFG_UDP_ALLOWED  "udp_allowed"
+# define OIO_CFG_TFO_ALLOWED  "tcp_fastopen_allowed"
 # define OIO_CFG_AVOID_BADSRV  "avoid_faulty_services"
 # define OIO_CFG_ZK_SHUFFLED  "zk_shuffled"
 

--- a/metautils/lib/metautils_sockets.h
+++ b/metautils/lib/metautils_sockets.h
@@ -39,6 +39,8 @@ struct metautils_sockets_vtable_s
 	gboolean (*set_linger) (int fd, int onoff, int linger);
 };
 
+extern gboolean oio_allow_tcp_fastopen;
+
 void metautils_set_vtable_sockets(struct metautils_sockets_vtable_s *vtable);
 struct metautils_sockets_vtable_s* metautils_get_vtable_sockets(void);
 

--- a/metautils/lib/utils_sockets.c
+++ b/metautils/lib/utils_sockets.c
@@ -507,6 +507,8 @@ sock_connect (const char *url, GError **err)
 
 static volatile gint64 _fastopen_last_error = 0;
 
+gboolean oio_allow_tcp_fastopen = FALSE;
+
 int
 sock_connect_and_send (const char *url, GError **err,
 		const uint8_t *buf, gsize *len)
@@ -521,8 +523,9 @@ sock_connect_and_send (const char *url, GError **err,
 
 	const gint64 now = oio_ext_monotonic_time();
 
-	if (!buf || !len || (_fastopen_last_error != 0 &&
-				_fastopen_last_error > OLDEST(now,G_TIME_SPAN_MINUTE)))
+	if (!oio_allow_tcp_fastopen || !buf || !len ||
+			(_fastopen_last_error != 0 &&
+			 _fastopen_last_error > OLDEST(now,G_TIME_SPAN_MINUTE)))
 		goto label_simple_connect;
 
 #ifdef HAVE_ENBUG

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -984,6 +984,14 @@ grid_main_configure (int argc, char **argv)
 	if (oio_cache_avoid_on_error)
 		GRID_NOTICE("Faulty peers avoidance: ENABLED");
 
+	/* Check if TCP_FASTOPEN is allowed */
+	gchar *str_tcp_fastopen = oio_cfg_get_value (ns_name, OIO_CFG_TFO_ALLOWED);
+	if (str_tcp_fastopen) {
+		oio_allow_tcp_fastopen = oio_str_parse_bool(str_tcp_fastopen, FALSE);
+		g_free(str_tcp_fastopen);
+	}
+	GRID_NOTICE("TCP_FASTOPEN %s", oio_allow_tcp_fastopen ? "allowed" : "forbidden");
+
 	/* init the networking capability of the processus */
 	server = network_server_init ();
 

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -240,9 +240,17 @@ _configure_with_arguments(struct sqlx_service_s *ss, int argc, char **argv)
 	gchar *str_udp_allowed = oio_cfg_get_value (ss->ns_name, OIO_CFG_UDP_ALLOWED);
 	if (str_udp_allowed) {
 		udp_allowed = oio_str_parse_bool(str_udp_allowed, FALSE);
-		GRID_NOTICE("UDP %s", udp_allowed ? "allowed" : "forbidden");
 		g_free(str_udp_allowed);
 	}
+	GRID_NOTICE("UDP %s", udp_allowed ? "allowed" : "forbidden");
+
+	/* Check if TCP_FASTOPEN is allowed */
+	gchar *str_tcp_fastopen = oio_cfg_get_value (ss->ns_name, OIO_CFG_TFO_ALLOWED);
+	if (str_tcp_fastopen) {
+		oio_allow_tcp_fastopen = oio_str_parse_bool(str_tcp_fastopen, FALSE);
+		g_free(str_tcp_fastopen);
+	}
+	GRID_NOTICE("TCP_FASTOPEN %s", oio_allow_tcp_fastopen ? "allowed" : "forbidden");
 
 	/* Check if the logging of outgoing requests has been activated */
 	gchar *str_log_out = oio_cfg_get_value(ss->ns_name, OIO_CFG_LOG_OUTGOING);


### PR DESCRIPTION
TCP_FASTOPEN improved the behavior on small-to-medium loads but it seems to induce some side effects such an extra load when strongly stressing the services. Let's deactivate it by default and continue the job of improving our support.