### PR TITLE
tests/functional: Rely on the deployed rdir for the tests

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,6 +1,6 @@
 cliff>=2.0.0,<2.1.0
 eventlet>=0.15.2
-requests>=2.6.0
+requests<2.13.0
 werkzeug>=0.9.1
 redis>=2.10.3
 gunicorn>=19.4.5

--- a/bin/oio-account-server
+++ b/bin/oio-account-server
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+import eventlet.hubs
 from optparse import OptionParser
-
 from oio.common.utils import parse_options, read_conf
+from oio.common.green import get_hub
 from oio.account.server import create_app
 from oio.common.wsgi import Application, ServiceLogger
 
@@ -10,6 +11,7 @@ from oio.common.wsgi import Application, ServiceLogger
 if __name__ == '__main__':
     parser = OptionParser("%prog CONFIG [options]")
     conf_file, options = parse_options(parser)
+    eventlet.hubs.use_hub(get_hub())
     conf = read_conf(conf_file, 'account-server')
     app = create_app(conf)
     Application(app, conf, logger_class=ServiceLogger).run()

--- a/tests/functional/rdir/test_server.py
+++ b/tests/functional/rdir/test_server.py
@@ -2,72 +2,27 @@ import time
 import tempfile
 import shutil
 import simplejson as json
-import unittest
 import subprocess
 import requests
 from os import remove
 
-from tests.utils import random_str, random_id
+from tests.utils import BaseTestCase, random_str, random_id
 
 
 def _key(rec):
     return '|'.join((rec['container_id'], rec['content_id'], rec['chunk_id']))
 
 
-class TestRdirServer(unittest.TestCase):
+class TestRdirServer(BaseTestCase):
     def setUp(self):
         super(TestRdirServer, self).setUp()
-        self.addr = ('127.0.0.1', 5999)
-        self.db_path = tempfile.mkdtemp()
-        self.cfg_path = tempfile.mktemp()
-        with open(self.cfg_path, 'w') as f:
-            f.write("[rdir-server]\n")
-            f.write("bind_addr = {0}\n".format(self.addr[0]))
-            f.write("bind_port = {0}\n".format(self.addr[1]))
-            f.write("namespace = OPENIO\n")
-            f.write("db_path = {0}\n".format(self.db_path))
-            f.write("syslog_prefix = OIO,OPENIO,rdir,1\n")
-
-        self.child = subprocess.Popen(['oio-rdir-server', self.cfg_path],
-                                      close_fds=True)
+        self.num, self.db_path, self.host, self.port = self.get_service('rdir')
         self.session = requests.Session()
-        if not self._wait_for_that_fucking_slow_startup_on_travis():
-            self.child.kill()
-            raise Exception("The RDIR server is too long to start")
+        self.vol = self._volume()
 
     def tearDown(self):
         super(TestRdirServer, self).tearDown()
         self.session.close()
-        self._kill_and_watch_it_die()
-        shutil.rmtree(self.db_path)
-        remove(self.cfg_path)
-
-    def _kill_and_watch_it_die(self):
-        """Massive attack"""
-        for i in range(5):
-            self.child.terminate()
-            time.sleep(i * 0.2)
-            if not self._check_for_server():
-                return True
-        self.child.kill()
-        return True
-
-    def _wait_for_that_fucking_slow_startup_on_travis(self):
-        for i in range(5):
-            if self._check_for_server():
-                return True
-            time.sleep(i * 0.2)
-        return False
-
-    def _check_for_server(self):
-        hexport = "%04X" % int(self.addr[1])
-        with open("/proc/net/tcp", "r") as f:
-            for line in f:
-                tokens = line.strip().split()
-                port = tokens[1][9:13]
-                if port == hexport:
-                    return True
-        return False
 
     def _volume(self):
         return random_id(8)
@@ -78,49 +33,48 @@ class TestRdirServer(unittest.TestCase):
                 "chunk_id": random_id(64),
                 "mtime": 17}
 
-    def _url(self, tail):
-        return 'http://{0}:{1}{2}'.format(self.addr[0], self.addr[1], tail)
+    def _rdir_url(self, tail):
+        return 'http://{0}:{1}{2}'.format(self.host, self.port, tail)
 
     def _get(self, url, **kwargs):
-        return self.session.get(self._url(url), **kwargs)
+        return self.session.get(self._rdir_url(url), **kwargs)
 
     def _post(self, url, **kwargs):
-        return self.session.post(self._url(url), **kwargs)
+        return self.session.post(self._rdir_url(url), **kwargs)
 
     def _delete(self, url, **kwargs):
-        return self.session.delete(self._url(url), **kwargs)
+        return self.session.delete(self._rdir_url(url), **kwargs)
 
     def test_explicit_create(self):
-        vol = self._volume()
         rec = self._record()
 
         # try to push on unknown volume
         resp = self._post(
-                "/v1/rdir/push", params={'vol': vol},
+                "/v1/rdir/push", params={'vol': self.vol},
                 data=json.dumps(rec))
         self.assertEqual(resp.status_code, 404)
 
         # The fetch fails
-        resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+        resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 404)
 
         # create volume
-        resp = self._post("/v1/rdir/create", params={'vol': vol})
+        resp = self._post("/v1/rdir/create", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 201)
 
         # the fetch returns an empty array
-        resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+        resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [])
 
         # now the push must succeed
         resp = self._post(
-                "/v1/rdir/push", params={'vol': vol},
+                "/v1/rdir/push", params={'vol': self.vol},
                 data=json.dumps(rec))
         self.assertEqual(resp.status_code, 204)
 
         # we must fetch the same data
-        resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+        resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 200)
         reference = [
             [_key(rec), {'mtime': rec['mtime'], 'rtime': 0}]
@@ -129,32 +83,32 @@ class TestRdirServer(unittest.TestCase):
 
         # deleting must succeed
         resp = self._delete(
-                "/v1/rdir/delete", params={'vol': vol}, data=json.dumps(rec))
+                "/v1/rdir/delete", params={'vol': self.vol},
+                data=json.dumps(rec))
         self.assertEqual(resp.status_code, 204)
 
         # fetching must return an empty array
-        resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+        resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [])
 
     def test_implicit_create(self):
-        vol = self._volume()
         rec = self._record()
 
         # try to push on unknown volume
         resp = self._post(
-                "/v1/rdir/push", params={'vol': vol},
+                "/v1/rdir/push", params={'vol': self.vol},
                 data=json.dumps(rec))
         self.assertEqual(resp.status_code, 404)
 
         # try to push on unknown volume WITH create flag
         resp = self._post(
-                "/v1/rdir/push", params={'vol': vol, 'create': True},
+                "/v1/rdir/push", params={'vol': self.vol, 'create': True},
                 data=json.dumps(rec))
         self.assertEqual(resp.status_code, 204)
 
         # We must fetch the same data
-        resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+        resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [
             [_key(rec), {'mtime': rec['mtime'], 'rtime': 0}]
@@ -162,126 +116,171 @@ class TestRdirServer(unittest.TestCase):
 
     def test_push_missing_fields(self):
         rec = self._record()
-        vol = self._volume()
 
         # DB creation
-        resp = self._post("/v1/rdir/create", params={'vol': vol})
+        resp = self._post("/v1/rdir/create", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 201)
 
         for k in ['container_id', 'content_id', 'chunk_id']:
             save = rec.pop(k)
             # push an incomplete record
             resp = self._post(
-                    "/v1/rdir/push", params={'vol': vol},
+                    "/v1/rdir/push", params={'vol': self.vol},
                     data=json.dumps(rec))
             self.assertEqual(resp.status_code, 400)
             # check we list nothing
-            resp = self._post("/v1/rdir/fetch", params={'vol': vol})
+            resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
             self.assertEqual(resp.status_code, 200)
             self.assertListEqual(resp.json(), [])
             rec[k] = save
 
     def test_lock_unlock(self):
-        vol = self._volume()
         who = random_str(64)
 
         # lock without who, DB not created
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({}))
         self.assertEqual(resp.status_code, 400)
 
         # lock with who, DB not created
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({'who': who}))
         self.assertEqual(resp.status_code, 404)
 
         # DB creation
-        resp = self._post("/v1/rdir/create", params={'vol': vol})
+        resp = self._post("/v1/rdir/create", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 201)
 
         # lock without who
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({}))
         self.assertEqual(resp.status_code, 400)
 
         # lock
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({'who': who}))
         self.assertEqual(resp.status_code, 204)
 
         # double lock, different who
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({'who': random_str(64)}))
         self.assertEqual(resp.status_code, 403)
         body = resp.json()
         self.assertEqual(body['message'], "Already locked by %s" % who)
 
         # unlock
-        resp = self._post("/v1/rdir/admin/unlock", params={'vol': vol})
+        resp = self._post("/v1/rdir/admin/unlock", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 204)
 
     def test_rdir_clear_and_lock(self):
         rec = self._record()
-        vol = self._volume()
         who = random_id(32)
 
         # push with autocreate
         resp = self._post(
-                "/v1/rdir/push", params={'vol': vol, 'create': True},
+                "/v1/rdir/push", params={'vol': self.vol, 'create': True},
                 data=json.dumps(rec))
         self.assertEqual(resp.status_code, 204)
 
         # lock
         resp = self._post(
-                "/v1/rdir/admin/lock", params={'vol': vol},
+                "/v1/rdir/admin/lock", params={'vol': self.vol},
                 data=json.dumps({'who': who}))
         self.assertEqual(resp.status_code, 204)
 
         # try to clear while the lock is held
-        resp = self._post("/v1/rdir/admin/clear", params={'vol': vol})
+        resp = self._post("/v1/rdir/admin/clear", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 403)
 
         # unlock
-        resp = self._post("/v1/rdir/admin/unlock", params={'vol': vol})
+        resp = self._post("/v1/rdir/admin/unlock", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 204)
 
         # clear all entries
         resp = self._post(
-                "/v1/rdir/admin/clear", params={'vol': vol},
+                "/v1/rdir/admin/clear", params={'vol': self.vol},
                 data=json.dumps({'all': True}))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'removed': 1})
 
     def test_vol_status(self):
-        vol = self._volume()
-
         # Status on inexistant DB
-        resp = self._post("/v1/rdir/status", params={'vol': vol})
+        resp = self._post("/v1/rdir/status", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 404)
 
         # DB creation
-        resp = self._post("/v1/rdir/create", params={'vol': vol})
+        resp = self._post("/v1/rdir/create", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 201)
 
         # Status on an empty DB
-        resp = self._get("/v1/rdir/status", params={'vol': vol})
+        resp = self._get("/v1/rdir/status", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'chunk': {'total': 0}, 'container': {}})
 
-    def test_status(self):
-        vol = self._volume()
 
+class TestRdirServer2(TestRdirServer):
+    def setUp(self):
+        super(TestRdirServer2, self).setUp()
+        self.host = '127.0.0.1'
+        self.port = 5999
+        self.db_path = tempfile.mkdtemp()
+        self.cfg_path = tempfile.mktemp()
+        with open(self.cfg_path, 'w') as f:
+            f.write("[rdir-server]\n")
+            f.write("bind_addr = {0}\n".format(self.host))
+            f.write("bind_port = {0}\n".format(self.port))
+            f.write("namespace = OSEF\n")
+            f.write("db_path = {0}\n".format(self.db_path))
+            f.write("syslog_prefix = OIO,OPENIO,rdir,1\n")
+
+        self.child = subprocess.Popen(['oio-rdir-server', self.cfg_path],
+                                      close_fds=True)
+        if not self._wait_for_that_fucking_slow_startup_on_travis():
+            self.child.kill()
+            raise Exception("The RDIR server is too long to start")
+
+    def tearDown(self):
+        super(TestRdirServer2, self).tearDown()
+        self.session.close()
+        self._kill_and_watch_it_die()
+        shutil.rmtree(self.db_path)
+        remove(self.cfg_path)
+
+    def _kill_and_watch_it_die(self):
+        self.child.terminate()
+        self.child.wait()
+
+    def _wait_for_that_fucking_slow_startup_on_travis(self):
+        for i in range(5):
+            if self._check_for_server():
+                return True
+            time.sleep(i * 0.2)
+        return False
+
+    def _check_for_server(self):
+        hexport = "%04X" % self.port
+        with open("/proc/net/tcp", "r") as f:
+            for line in f:
+                tokens = line.strip().split()
+                port = tokens[1][9:13]
+                if port == hexport:
+                    return True
+        return False
+
+    def test_status(self):
+
+        # check the service has no opened DB
         resp = self._get('/status')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'opened_db_count': 0})
 
         # DB creation
-        resp = self._post("/v1/rdir/create", params={'vol': vol})
+        resp = self._post("/v1/rdir/create", params={'vol': self.vol})
         self.assertEqual(resp.status_code, 201)
 
         # The base remains open after it has been created

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -55,6 +55,7 @@ install(TARGETS
 install(PROGRAMS
             zk-bootstrap.py
             zk-reset.py
+            oio-wrap.sh
             oio-election-reset.py
             oio-election-smudge.py
             oio-election-dump.py

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -12,6 +12,14 @@ if [ $# -eq 2 ] ; then
 fi
 
 function dump_syslog {
+    cmd=tail
+    if ! [ -r /var/log/syslog ] ; then
+        cmd="sudo tail"
+    fi
+    echo
+    $cmd -n 500 /var/log/syslog
+    echo
+    pip list
     echo
     gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
 }

--- a/tools/oio-wrap.sh
+++ b/tools/oio-wrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+LOG=$1 ; shift
+CMD=$1 ; shift
+#exec "$1" $@ > "${LOG}${$}.out" 2> "${LOG}${$}.err"
+exec "$CMD" $@ 2>&1 | /usr/bin/logger --id --tag "${LOG}"


### PR DESCRIPTION
It avoids restarting processes, and this took a while on Travis.