### PR TITLE
Bulk requests: Fixed memleak, easier integration

### DIFF
--- a/proxy/common.h
+++ b/proxy/common.h
@@ -306,6 +306,7 @@ enum http_rc_e _reply_notfound_error (struct req_args_s *args, GError * err);
 enum http_rc_e _reply_forbidden_error (struct req_args_s *args, GError * err);
 enum http_rc_e _reply_method_error (struct req_args_s *args);
 enum http_rc_e _reply_conflict_error (struct req_args_s *args, GError * err);
+enum http_rc_e _reply_too_large (struct req_args_s *args, GError * err);
 enum http_rc_e _reply_nocontent (struct req_args_s *args);
 enum http_rc_e _reply_accepted (struct req_args_s *args);
 enum http_rc_e _reply_created (struct req_args_s *args);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1189,79 +1189,85 @@ _m2_container_create (struct req_args_s *args, struct json_object *jbody)
 	return _reply_m2_error (args, err);
 }
 
+static void
+_bulk_item_result(GString *gresponse,
+		const guint i, const char *name,
+		const GError *err, gint code_ok)
+{
+	if (i > 0)
+		g_string_append_c(gresponse, ',');
+	g_string_append_c(gresponse, '{');
+	oio_str_gstring_append_json_pair(gresponse, "name", name);
+	g_string_append_c(gresponse, ',');
+	if (err)
+		_append_status(gresponse, err->code, err->message);
+	else
+		_append_status(gresponse, code_ok, "ok");
+	g_string_append_c(gresponse, '}');
+}
+
 static enum http_rc_e
 _m2_container_create_many (struct req_args_s *args, struct json_object *jbody)
 {
 	guint max_request = OIO_CONTAINER_CREATE_MANY_NB_MAX_REQ;
-	guint nb_err = 0;
-	GError *err = NULL;
-	const char *url_user = oio_url_get(args->url, OIOURL_USER);
-	json_object *jarray = NULL;
+
 	if (!oio_url_get(args->url, OIOURL_ACCOUNT)
 			|| !oio_url_get(args->url, OIOURL_NS))
 		return _reply_format_error(args,
 				BADREQ("Missing account or namespace"));
+
+	json_object *jarray = NULL;
 	if (!json_object_object_get_ex(jbody, "containers", &jarray)
 			|| !json_object_is_type(jarray, json_type_array))
 		return _reply_format_error(args,
 				BADREQ("Invalid array of containers"));
+
+	const guint jarray_len = json_object_array_length(jarray);
+	if (jarray_len > max_request)
+		return _reply_too_large(args, NEWERROR(HTTP_CODE_PAYLOAD_TO_LARGE,
+					"More than %u requested", max_request));
+
+	/* A final sanity check on the format of the payload */
+	for (guint i = 0; i < jarray_len; i++) {
+		struct json_object * jcontent = json_object_array_get_idx(jarray, i);
+		if (!json_object_is_type(jcontent, json_type_object))
+			return _reply_format_error(args, BADREQ("Invalid content description"));
+		struct json_object * jname = NULL;
+		if (!json_object_object_get_ex(jcontent, "name", &jname)
+				|| !json_object_is_type(jname, json_type_string))
+			return _reply_format_error(args, BADREQ("Invalid payload"));
+	}
+
 	GString *gresponse = g_string_sized_new(2048);
 	g_string_append(gresponse, "{\"containers\":[");
-	guint jarray_len = json_object_array_length(jarray);
-	if (jarray_len > max_request)
-		return _reply_format_error(args,
-			BADREQ("More than %u requested",
-			 max_request));
-	for (unsigned i= 0; i < jarray_len && !err; i++) {
-		struct json_object * jcontainer=NULL;
+	for (unsigned i= 0; i < jarray_len ; i++) {
+		struct json_object * jcontainer = json_object_array_get_idx(jarray, i);
+
 		struct json_object * jname = NULL;
+		json_object_object_get_ex(jcontainer, "name", &jname);
+		const gchar *name = json_object_get_string(jname);
+
 		gchar **properties = NULL;
-		const gchar *name = NULL;
-		jcontainer = json_object_array_get_idx(jarray, i);
-		g_string_append(gresponse, "{\"name\":");
-		if (!json_object_object_get_ex(jcontainer, "name", &jname)
-				|| !json_object_is_type(jname, json_type_string)) {
-			nb_err++;
-			g_string_append(gresponse, "\"(null)\",");
-			_append_status(gresponse, CODE_BAD_REQUEST,
-				"Bad \"name\" field");
-		} else {
-			name = json_object_get_string(jname);
-			err = KV_read_usersys_properties(jcontainer, &properties);
-			EXTRA_ASSERT((err != NULL) ^ (properties != NULL));
-			if (err) {
-				_append_status(gresponse, err->code, err->message);
-				nb_err++;
-				g_clear_error(&err);
-			} else {
-				/* The simple create function takes the name of the container
-				   on the url */
-				oio_url_set(args->url, OIOURL_USER, name);
-				g_string_append_printf(gresponse, "\"%s\",", name);
-				err = _m2_container_create_with_properties(args, properties);
-				g_strfreev(properties);
-				if (!err) {
-					/* No error means we actually created it. */
-					_append_status(gresponse, HTTP_CODE_CREATED, "Created");
-				} else {
-					_append_status(gresponse, err->code, err->message);
-					if (err->code != CODE_CONTAINER_EXISTS)
-						nb_err++;
-					g_clear_error(&err);
-				}
-			}
+		GError *err = KV_read_usersys_properties(jcontainer, &properties);
+		EXTRA_ASSERT((err != NULL) ^ (properties != NULL));
+
+		if (err) {
+			g_string_free(gresponse, TRUE);
+			enum http_rc_e rc = _reply_format_error(args,
+					BADREQ("Malformed properties at %d: (%d) %s", i,
+						err->code, err->message));
+			g_clear_error(&err);
+			return rc;
 		}
-		g_string_append_c(gresponse, '}');
-		if (i < jarray_len - 1)
-			g_string_append_c(gresponse, ',');
+
+		oio_url_set(args->url, OIOURL_USER, name);
+		err = _m2_container_create_with_properties(args, properties);
+		g_strfreev(properties);
+		_bulk_item_result(gresponse, i, name, err, HTTP_CODE_CREATED);
+		if (err) g_clear_error(&err);
 	}
-	oio_url_set(args->url, OIOURL_USER, url_user);
-	if (err)
-		g_error_free(err);
 	g_string_append(gresponse, "]}");
-	if (nb_err == jarray_len)
-		return _reply_json(args, CODE_BAD_REQUEST, "Error on all requests",
-					 gresponse);
+
 	return _reply_success_json(args, gresponse);
 }
 
@@ -1889,10 +1895,7 @@ enum http_rc_e action_content_delete (struct req_args_s *args) {
 static enum http_rc_e
 _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
 	guint max_requests = OIO_CONTENT_DELETE_MANY_NB_MAX_REQ;
-	GError *err = NULL;
-	gboolean error =FALSE;
 	json_object *jarray = NULL;
-	gchar *url_path = NULL;
 	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url); }
 
 	if (!oio_url_has_fq_container(args->url))
@@ -1909,56 +1912,37 @@ _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
 		return _reply_format_error(args,
 				BADREQ("At least one element is needed"));
 
-	if (jarray_len > max_requests) {
-		GString * gstr = g_string_new("");
-		g_string_append_printf(gstr, "More than %u requests", max_requests);
-		return _reply_json(args, HTTP_CODE_PAYLOAD_TO_LARGE,
-				"Payload Too Large", gstr);
-	}
-	if (oio_url_get(args->url, OIOURL_PATH)) {
-		url_path = g_strdup(oio_url_get(args->url, OIOURL_PATH));
-		STRING_STACKIFY(url_path);
+	if (jarray_len > max_requests)
+		return _reply_too_large(args, NEWERROR(HTTP_CODE_PAYLOAD_TO_LARGE,
+				"Payload Too Large"));
+
+	/* A final sanity check on the format of the payload */
+	for (guint i = 0; i < jarray_len; i++) {
+		struct json_object * jcontent = json_object_array_get_idx(jarray, i);
+		if (!json_object_is_type(jcontent, json_type_object))
+			return _reply_format_error(args, BADREQ("Invalid content description"));
+		struct json_object * jname = NULL;
+		if (!json_object_object_get_ex(jcontent, "name", &jname)
+				|| !json_object_is_type(jname, json_type_string))
+			return _reply_format_error(args, BADREQ("Invalid content name"));
 	}
 
 	GString *gresponse = g_string_sized_new(2048);
 	g_string_append(gresponse, "{\"contents\":[");
 	for (guint i = 0; i < jarray_len; i++) {
+		struct json_object * jcontent = json_object_array_get_idx(jarray, i);
+
 		struct json_object * jname = NULL;
-		struct json_object * jcontent = NULL;
-		const gchar *name = NULL;
-		jcontent = json_object_array_get_idx(jarray, i);
-		g_string_append(gresponse, "{\"name\":");
+		json_object_object_get_ex(jcontent, "name", &jname);
+		const gchar *name = json_object_get_string(jname);
 
-		if (!json_object_object_get_ex(jcontent, "name", &jname)
-				|| !json_object_is_type(jname, json_type_string)) {
-			g_string_append(gresponse, "null,");
-			_append_status(gresponse, CODE_CONTENT_NOTFOUND,
-				 "Bad \"name\" field");
-			error = TRUE;
-		} else {
-			name = json_object_get_string(jname);
-			oio_url_set(args->url, OIOURL_PATH, name);
-			oio_str_gstring_append_json_quote(gresponse, name);
-			g_string_append_c(gresponse, ',');
-			err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
-			if (err) {
-				_append_status(gresponse, err->code, err->message);
-				g_error_free(err);
-			} else {
-				_append_status(gresponse, HTTP_CODE_NO_CONTENT, "No Content");
-			}
-		}
-
-		g_string_append_c(gresponse, '}');
-		if (i < jarray_len -1)
-			g_string_append_c(gresponse, ',');
+		oio_url_set(args->url, OIOURL_PATH, name);
+		GError *err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
+		_bulk_item_result(gresponse, i, name, err, HTTP_CODE_NO_CONTENT);
+		if (err) g_clear_error(&err);
 	}
 
-	oio_url_set(args->url, OIOURL_PATH, url_path);
 	g_string_append(gresponse, "]}");
-	if (error)
-		return _reply_format_error(args, BADREQ("Bad Request"));
-
 	return _reply_success_json(args, gresponse);
 }
 

--- a/proxy/reply.c
+++ b/proxy/reply.c
@@ -169,6 +169,13 @@ _reply_conflict_error (struct req_args_s *args, GError * err)
 }
 
 enum http_rc_e
+_reply_too_large (struct req_args_s *args, GError * err)
+{
+	return _reply_json_error (args, HTTP_CODE_PAYLOAD_TO_LARGE,
+			"Payload too large", _create_status_error (err));
+}
+
+enum http_rc_e
 _reply_nocontent (struct req_args_s *args)
 {
 	return _reply_json_error (args, HTTP_CODE_NO_CONTENT, "No Content", NULL);

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -132,8 +132,6 @@ class TestMeta2Containers(BaseTestCase):
             self.url_container('create_many'), params=params, data=data,
             headers=headers)
         self.assertEqual(resp.status_code, 400)
-        data = json.loads(resp.content)["containers"]
-        self.assertEqual(data[0]["status"], 400)
 
         # Send a non conform json (missing '{')
         data = ('{"containers":' +
@@ -402,7 +400,6 @@ class TestMeta2Contents(BaseTestCase):
         json_data = resp.json()
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json_data['contents'][0]['status'], 204)
-        self.assertEqual(json_data['contents'][0]['message'], 'No Content')
 
         # Send one nonexistent
         data = ('{"contents":[{"name":"should_not_exist"}]}')
@@ -410,8 +407,6 @@ class TestMeta2Contents(BaseTestCase):
                                  params=params, data=data)
         json_data = resp.json()
         self.assertEqual(json_data['contents'][0]['status'], 420)
-        self.assertEqual(json_data['contents'][0]['message'],
-                         'Alias not found')
         # Send one existent and one nonexistent
         self._create_content('should_exist')
         data = ('{"contents":[{"name":"should_exist"},'
@@ -421,10 +416,7 @@ class TestMeta2Contents(BaseTestCase):
         json_data = resp.json()
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json_data['contents'][0]['status'], 204)
-        self.assertEqual(json_data['contents'][0]['message'], 'No Content')
         self.assertEqual(json_data['contents'][1]['status'], 420)
-        self.assertEqual(json_data['contents'][1]['message'],
-                         'Alias not found')
         # Send 2 nonexistents
         data = ('{"contents":[{"name":"should_not_exist"},'
                 + '{"name":"should_also_not_exist"}]}')
@@ -432,14 +424,10 @@ class TestMeta2Contents(BaseTestCase):
                                  params=params, data=data)
         json_data = resp.json()
         self.assertEqual(json_data['contents'][0]['status'], 420)
-        self.assertEqual(json_data['contents'][0]['message'],
-                         'Alias not found')
         self.assertEqual(json_data['contents'][1]['status'], 420)
-        self.assertEqual(json_data['contents'][1]['message'],
-                         'Alias not found')
         # Send 2 existents
         self._create_content('should_exist')
-        self._create_content('shold_also_exist')
+        self._create_content('should_also_exist')
         data = ('{"contents":[{"name":"should_exist"},'
                 + '{"name":"should_also_exist"}]}')
         resp = self.session.post(self.url_content('delete_many'),
@@ -447,9 +435,7 @@ class TestMeta2Contents(BaseTestCase):
         json_data = resp.json()
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json_data['contents'][0]['status'], 204)
-        self.assertEqual(json_data['contents'][0]['message'], 'No Content')
-        self.assertEqual(json_data['contents'][0]['status'], 204)
-        self.assertEqual(json_data['contents'][0]['message'],  'No Content')
+        self.assertEqual(json_data['contents'][1]['status'], 204)
 
         strange_paths = [
             "Annual report.txt",


### PR DESCRIPTION
Allow the "good old unitary requests" as a fallback for their respective bulk requests, when unsupported. Also manage batches of excessive size.