### PR TITLE
Avoid filling the RPC with useless fields

### DIFF
--- a/core/sds.c
+++ b/core/sds.c
@@ -1443,8 +1443,11 @@ _sds_upload_add_headers(struct oio_sds_ul_s *ul, struct http_put_dest_s *dest)
 	http_put_dest_add_header (dest, PROXYD_HEADER_REQID,
 			"%s", oio_ext_get_reqid());
 
-	http_put_dest_add_header (dest, PROXYD_HEADER_ADMIN,
-			"%s", oio_ext_is_admin()?"1":"0");
+	if (oio_ext_is_admin()) {
+		/* TODO(jfs): melt these informatiion with the 'mode' (already
+		 * containing autocreate, etc */
+		http_put_dest_add_header (dest, PROXYD_HEADER_ADMIN, "yes");
+	}
 
 	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "container-id",
 			"%s", oio_url_get (ul->dst->url, OIOURL_HEXID));

--- a/metautils/lib/comm_message.c
+++ b/metautils/lib/comm_message.c
@@ -122,8 +122,8 @@ message_marshall_gba(MESSAGE m, GError **err)
 		metautils_message_set_ID(m, (guint8*)reqid, strlen(reqid));
 	}
 
-	metautils_message_add_field_strint(m, NAME_MSGKEY_ADMIN_COMMAND,
-			oio_ext_is_admin());
+	if (oio_ext_is_admin())
+		metautils_message_add_field_strint(m, NAME_MSGKEY_ADMIN_COMMAND, 1);
 
 	/*try to encode */
 	guint32 u32 = 0;

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -97,7 +97,7 @@ License along with this library.
 #define NS_STATE_VALUE_SLAVE      "slave"
 #define NS_STATE_VALUE_STANDALONE "standalone"
 
-#define NAME_MSGKEY_ADMIN_COMMAND "ADM_CMD"
+#define NAME_MSGKEY_ADMIN_COMMAND "ADM"
 #define NAME_MSGKEY_NS_STATE      "STT"
 #define NAME_MSGKEY_WORMED        "WRM"
 


### PR DESCRIPTION
When the RPC mode is not set to "admin", don't tell "admin=false"
because this is the default.