### PR TITLE
Python API: fix requests ids and kwargs API traversal

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -46,7 +46,8 @@ class HttpApi(object):
         self.session = session
         self.admin_mode = kwargs.get('admin_mode', False)
 
-    def _direct_request(self, method, url, session=None, **kwargs):
+    def _direct_request(self, method, url, session=None, admin_mode=False,
+                        **kwargs):
         """
         Make an HTTP request.
 
@@ -56,6 +57,8 @@ class HttpApi(object):
         :type url: `str`
         :param session: the session to use instead of `self.session`
         :type session: requests.Session
+        :keyword admin_mode: allow operations on slave or worm namespaces
+        :type admin_mode: `bool`
         :keyword timeout: optional timeout for the request (in seconds).
             May be a tuple `(connection_timeout, response_timeout)`.
         :type timeout: `float`
@@ -66,8 +69,8 @@ class HttpApi(object):
             session = self.session
         in_headers = kwargs.get('headers') or dict()
         headers = {k: str(v) for k, v in in_headers.items()}
-        if self.admin_mode or kwargs.get('admin_mode', False):
-            headers.update({ADMIN_HEADER: "1"})
+        if self.admin_mode or admin_mode:
+            headers[ADMIN_HEADER] = "1"
         kwargs['headers'] = headers
         if "timeout" not in kwargs:
             resp = session.request(

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -1,4 +1,4 @@
-from urllib import quote_plus
+# from urllib import quote_plus
 from oio.common.http import requests
 from oio.common import exceptions as exc, utils
 from oio.common.constants import chunk_headers, chunk_xattr_keys_optional
@@ -8,25 +8,6 @@ from oio.common.storage_method import STORAGE_METHODS
 
 
 READ_BUFFER_SIZE = 65535
-
-
-def gen_put_headers(meta):
-    headers = {
-        chunk_headers['container_id']: meta['container_id'],
-        chunk_headers['chunk_id']: meta['chunk_id'],
-        chunk_headers['chunk_pos']: meta['chunk_pos'],
-        chunk_headers['content_id']: meta['content_id'],
-        chunk_headers['content_path']: meta['content_path'],
-        chunk_headers['content_version']: meta['content_version'],
-        chunk_headers['content_chunkmethod']: meta['content_chunkmethod'],
-        chunk_headers['content_policy']: meta['content_policy']}
-
-    for k in ['metachunk_hash', 'metachunk_size', 'chunk_hash']:
-        v = meta.get(k)
-        if v is not None:
-            headers[chunk_headers[k]] = meta[k]
-
-    return {k: quote_plus(str(v)) for (k, v) in headers.iteritems()}
 
 
 def extract_headers_meta(headers):

--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -132,7 +132,6 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
                     container,
                     file_or_path=f,
                     obj_name=name,
-                    content_length=get_file_size(f),
                     policy=policy,
                     metadata=properties,
                     key_file=key_file,

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -52,7 +52,5 @@ class ProxyClient(HttpApi):
             headers["X-oio-action-mode"] = "autocreate"
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
-        return super(ProxyClient, self)._direct_request(method, url,
-                                                        session=session,
-                                                        headers=headers,
-                                                        **kwargs)
+        return super(ProxyClient, self)._direct_request(
+            method, url, session=session, headers=headers, **kwargs)

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -20,6 +20,7 @@ from optparse import OptionParser
 from ConfigParser import SafeConfigParser
 
 from itertools import islice
+from functools import wraps
 
 import codecs
 from oio.common.exceptions import OioException
@@ -558,3 +559,11 @@ def group_chunk_errors(chunk_err_iter):
         err_list.append(chunk)
         errors[err] = err_list
     return errors
+
+
+def ensure_headers(func):
+    @wraps(func)
+    def ensure_headers_wrapper(*args, **kwargs):
+        kwargs['headers'] = kwargs.get('headers') or dict()
+        return func(*args, **kwargs)
+    return ensure_headers_wrapper

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -90,7 +90,7 @@ class ECContent(Content):
                         yield d
                 stream.close()
 
-    def create(self, stream):
+    def create(self, stream, **kwargs):
         sysmeta = {}
         sysmeta['id'] = self.content_id
         sysmeta['version'] = self.version
@@ -112,5 +112,5 @@ class ECContent(Content):
         # TODO sanity checks
 
         self.checksum = content_checksum
-        self._create_object()
+        self._create_object(**kwargs)
         return final_chunks, bytes_transferred, content_checksum

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -26,10 +26,10 @@ from oio.common.storage_method import STORAGE_METHODS
 class ContentFactory(object):
     DEFAULT_DATASEC = "plain", {"nb_copy": "1", "distance": "0"}
 
-    def __init__(self, conf):
+    def __init__(self, conf, **kwargs):
         self.conf = conf
         self.logger = get_logger(conf)
-        self.container_client = ContainerClient(conf)
+        self.container_client = ContainerClient(conf, **kwargs)
 
     def get(self, container_id, content_id):
         try:
@@ -43,7 +43,8 @@ class ContentFactory(object):
         storage_method = STORAGE_METHODS.load(chunk_method)
 
         cls = ECContent if storage_method.ec else PlainContent
-        return cls(self.conf, container_id, meta, chunks, storage_method)
+        return cls(self.conf, container_id, meta, chunks, storage_method,
+                   container_client=self.container_client)
 
     def new(self, container_id, path, size, policy):
         meta, chunks = self.container_client.content_prepare(

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -48,7 +48,7 @@ class PlainContent(Content):
                     for d in part['iter']:
                         yield d
 
-    def create(self, stream):
+    def create(self, stream, **kwargs):
         sysmeta = {}
         sysmeta['id'] = self.content_id
         sysmeta['version'] = self.version
@@ -73,7 +73,7 @@ class PlainContent(Content):
         # TODO sanity checks
 
         self.checksum = content_checksum.upper()
-        self._create_object()
+        self._create_object(**kwargs)
         return final_chunks, bytes_transferred, content_checksum
 
     def rebuild_chunk(self, chunk_id, allow_same_rawx=False):

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -496,7 +496,7 @@ _reply_simplified_beans (struct req_args_s *args, GError *err,
 		}
 		else if (&descr_struct_PROPERTIES == DESCR(l0->data)) {
 			struct bean_PROPERTIES_s *prop = l0->data;
-			gchar *k = g_strdup_printf (PROXYD_HEADER_PREFIX "content-meta-x-%s",
+			gchar *k = g_strdup_printf (PROXYD_HEADER_PREFIX "content-meta-%s",
 					PROPERTIES_get_key(prop)->str);
 			GByteArray *v = PROPERTIES_get_value (prop);
 			args->rp->add_header(k, g_strndup ((gchar*)v->data, v->len));

--- a/tests/functional/m2_filters/test_filters.py
+++ b/tests/functional/m2_filters/test_filters.py
@@ -18,13 +18,10 @@
 
 import os
 import time
-import mock
 from io import BytesIO
 
-from oio.blob.client import BlobClient
 from oio.common.exceptions import ClientException
 from oio.common.utils import cid_from_name
-from oio.common.constants import ADMIN_HEADER
 from oio.container.client import ContainerClient
 from oio.content.factory import ContentFactory
 from tests.utils import BaseTestCase
@@ -34,36 +31,27 @@ def random_data(data_size):
     return os.urandom(data_size)
 
 
-def gen_headers_mock():
-    hdrs = {'x-oio-action-mode': 'autocreate',
-            ADMIN_HEADER: '1'}
-    return hdrs
-
-
 class TestFilters(BaseTestCase):
 
     def setUp(self):
-        with mock.patch('oio.container.client.gen_headers',
-                        gen_headers_mock):
-            super(TestFilters, self).setUp()
-            self.account = self.conf['account']
-            self.namespace = self.conf['namespace']
-            self.chunk_size = self.conf['chunk_size']
-            self.gridconf = {'namespace': self.namespace}
-            self.content_factory = ContentFactory(self.gridconf)
-            self.container_name = 'TestFilter%f' % time.time()
-            self.blob_client = BlobClient()
-            self.container_client = ContainerClient(self.gridconf)
-            self.container_client.container_create(
-                account=self.account, reference=self.container_name)
-            self.container_id = cid_from_name(self.account,
-                                              self.container_name).upper()
-            self.stgpol = "SINGLE"
+        super(TestFilters, self).setUp()
+        self.account = self.conf['account']
+        self.namespace = self.conf['namespace']
+        self.chunk_size = self.conf['chunk_size']
+        self.gridconf = {'namespace': self.namespace}
+        self.content_factory = ContentFactory(self.gridconf)
+        self.container_name = 'TestFilter%f' % time.time()
+        self.container_client = ContainerClient(self.gridconf, admin_mode=True)
+        self.container_client.container_create(
+            account=self.account, reference=self.container_name)
+        self.container_id = cid_from_name(self.account,
+                                          self.container_name).upper()
+        self.stgpol = "SINGLE"
 
     def _new_content(self, data, path):
         old_content = self.content_factory.new(self.container_id, path,
                                                len(data), self.stgpol)
-        old_content.create(BytesIO(data))
+        old_content.create(BytesIO(data), admin_mode=True)
         return self.content_factory.get(self.container_id,
                                         old_content.content_id)
 
@@ -77,9 +65,8 @@ class TestFilters(BaseTestCase):
         except ClientException as exc:
             print str(exc)
             self.assertTrue(str(exc).find('NS slave!') != -1)
-        with mock.patch('oio.container.client.gen_headers', gen_headers_mock):
-            content = self._new_content(data, path)
-            content.delete()
+        content = self._new_content(data, path)
+        content.delete(admin_mode=True)
 
     def test_worm_and_admin(self):
         if not os.getenv("WORM"):
@@ -93,5 +80,4 @@ class TestFilters(BaseTestCase):
             self.assertTrue(str(exc).find('NS wormed!') != -1)
         downloaded_data = ''.join(content.fetch())
         self.assertEqual(downloaded_data, data)
-        with mock.patch('oio.container.client.gen_headers', gen_headers_mock):
-            content.delete()
+        content.delete(admin_mode=True)

--- a/tests/unit/api/test_objectstorage.py
+++ b/tests/unit/api/test_objectstorage.py
@@ -140,7 +140,8 @@ class ObjectStorageTest(unittest.TestCase):
         self.headers['x-oio-action-mode'] = 'autocreate'
         data = json.dumps({'properties': {}, 'system': {}})
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, params=params, data=data, headers=self.headers)
+            'POST', uri, autocreate=True, params=params, data=data,
+            headers=self.headers)
 
     def test_container_create_exist(self):
         api = self.api


### PR DESCRIPTION
Rework oio/container/client.py so that `headers` is used only where necessary, and `kwargs` are passed where needed.