### PR TITLE
rawx: Improvement and fixes around the uploads of chunks

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -617,8 +617,9 @@ class ECWriter(object):
 
         # in the trailer
         # metachunk_size & metachunk_hash
-        h["Trailer"] = (chunk_headers["metachunk_size"],
-                        chunk_headers["metachunk_hash"])
+        h["Trailer"] = ', '.join((chunk_headers["metachunk_size"],
+                                  chunk_headers["metachunk_hash"],
+                                  chunk_headers["chunk_hash"]))
         with green.ConnectionTimeout(
                 connection_timeout or io.CONNECTION_TIMEOUT):
             conn = io.http_connect(
@@ -677,6 +678,8 @@ class ECWriter(object):
                             metachunk_size),
             '%s: %s\r\n' % (chunk_headers['metachunk_hash'],
                             metachunk_hash),
+            '%s: %s\r\n' % (chunk_headers['chunk_hash'],
+                            self.checksum.hexdigest()),
             '\r\n'
         ]
         to_send = "".join(parts)

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -153,7 +153,6 @@ dav_rawx_cmd_gridconfig_docroot(cmd_parms *cmd, void *config, const char *arg1)
 	dav_rawx_server_conf *conf;
 
 	(void) config;
-	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
 
 	/* Check the directory exists */
 	do {
@@ -228,19 +227,6 @@ dav_rawx_cmd_gridconfig_namespace(cmd_parms *cmd, void *config, const char *arg1
 	return NULL;
 }
 
-static int
-_str_to_boolean(const char *arg)
-{
-	int n_arg = 0;
-	n_arg |= (0 == apr_strnatcasecmp(arg, "on"));
-	n_arg |= (0 == apr_strnatcasecmp(arg, "true"));
-	n_arg |= (0 == apr_strnatcasecmp(arg, "yes"));
-	n_arg |= (0 == apr_strnatcasecmp(arg, "enabled"));
-	n_arg |= (0 == apr_strnatcasecmp(arg, "1"));
-
-	return n_arg;
-}
-
 static const char *
 dav_rawx_cmd_gridconfig_fsync(cmd_parms *cmd, void *config, const char *arg1)
 {
@@ -250,7 +236,7 @@ dav_rawx_cmd_gridconfig_fsync(cmd_parms *cmd, void *config, const char *arg1)
 	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
 
 	conf = ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-	if (_str_to_boolean(arg1))
+	if (oio_str_parse_bool(arg1, FALSE))
 		conf->fsync_on_close |= FSYNC_ON_CHUNK;
 	else
 		conf->fsync_on_close &= ~FSYNC_ON_CHUNK;
@@ -267,7 +253,7 @@ dav_rawx_cmd_gridconfig_fsync_dir(cmd_parms *cmd, void *config, const char *arg1
 	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
 
 	conf = ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-	if (_str_to_boolean(arg1))
+	if (oio_str_parse_bool(arg1, FALSE))
 		conf->fsync_on_close |= FSYNC_ON_CHUNK_DIR;
 	else
 		conf->fsync_on_close &= ~FSYNC_ON_CHUNK_DIR;
@@ -284,7 +270,7 @@ dav_rawx_cmd_gridconfig_fallocate(cmd_parms *cmd, void *config, const char *arg1
 	DAV_XDEBUG_POOL(cmd->pool, 0, "%s()", __FUNCTION__);
 
 	conf = ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-	conf->fallocate = _str_to_boolean(arg1);
+	conf->fallocate = oio_str_parse_bool(arg1, FALSE);
 
 	return NULL;
 }

--- a/rawx-apache2/src/rawx_config.h
+++ b/rawx-apache2/src/rawx_config.h
@@ -98,6 +98,12 @@ struct shm_stats_s {
 	apr_uint64_t padding[16];
 };
 
+enum rawx_checksum_mode_e {
+	CHECKSUM_ALWAYS = 0, /* by default */
+	CHECKSUM_SMART, /* not for EC/ */
+	CHECKSUM_NEVER,
+};
+
 typedef struct dav_rawx_server_conf_s dav_rawx_server_conf;
 
 struct dav_rawx_server_conf_s {
@@ -110,7 +116,10 @@ struct dav_rawx_server_conf_s {
 	int fsync_on_close;
 	int fallocate;
 	char event_agent_addr[RAWX_EVENT_ADDR_SIZE];
+
 	char compression_algo[64];
+
+	enum rawx_checksum_mode_e checksum_mode;
 
 	/* Statistics involved data */
 	struct {

--- a/rawx-apache2/src/rawx_internals.h
+++ b/rawx-apache2/src/rawx_internals.h
@@ -92,11 +92,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define DAV_PROPID_FS_executable        1
 
-/* returns an appropriate HTTP status code given an APR status code for a
- * failed I/O operation.  ### use something besides 500? */
-#define MAP_IO2HTTP(e) (APR_STATUS_IS_ENOSPC(e) ? HTTP_INSUFFICIENT_STORAGE : \
-		HTTP_INTERNAL_SERVER_ERROR)
-
 #define SHM_HANDLE_KEY "rawx_shm_master_handle"
 
 dav_rawx_server_conf * resource_get_server_config(const dav_resource *resource);

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -842,7 +842,13 @@ retry:
 		ds->compress_checksum = checksum;
 	}
 
-	ds->md5 = g_checksum_new (G_CHECKSUM_MD5);
+	ds->md5 = NULL;
+	if (conf->checksum_mode == CHECKSUM_ALWAYS) {
+		ds->md5 = g_checksum_new (G_CHECKSUM_MD5);
+	} else if (conf->checksum_mode == CHECKSUM_SMART) {
+	   if (!oio_str_prefixed(ctx->chunk.content_chunk_method, STGPOL_DSPREFIX_EC, "/"))
+		   ds->md5 = g_checksum_new (G_CHECKSUM_MD5);
+	}
 
 	*result = ds;
 

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -63,7 +63,8 @@ _set_chunk_extended_attributes(dav_stream *stream, struct chunk_textinfo_s *cti)
 	if (!set_rawx_info_to_fd(fileno(stream->f), &ge, cti))
 		e = server_create_and_stat_error(resource_get_server_config(stream->r), stream->p,
 				HTTP_FORBIDDEN, 0, apr_pstrdup(stream->p, gerror_get_message(ge)));
-	if (ge) g_clear_error (&ge);
+	if (ge)
+		g_clear_error (&ge);
 	return e;
 }
 

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -318,6 +318,16 @@ dav_rawx_open_stream(const dav_resource *resource, dav_stream_mode mode, dav_str
 	return NULL;
 }
 
+static void
+_rollback_and_log(dav_stream *stream)
+{
+	dav_error *e = rawx_repo_rollback_upload(stream);
+	if (!e)
+		return;
+	DAV_ERROR_REQ(stream->r->info->request, 0,
+			"Error while rolling back upload: %s", e->desc);
+}
+
 static dav_error *
 dav_rawx_close_stream(dav_stream *stream, int commit)
 {
@@ -336,14 +346,11 @@ dav_rawx_close_stream(dav_stream *stream, int commit)
 		if (e) {
 			DAV_DEBUG_REQ(stream->r->info->request, 0,
 					"Cannot commit, an error occured while writing end of data");
-			dav_error *e_tmp = NULL;
-			e_tmp = rawx_repo_rollback_upload(stream);
-			if (e_tmp) {
-				DAV_ERROR_REQ(stream->r->info->request, 0,
-						"Error while rolling back upload: %s", e_tmp->desc);
-			}
+			_rollback_and_log(stream);
 		} else {
 			e = rawx_repo_commit_upload(stream);
+			if (e)
+				_rollback_and_log(stream);
 		}
 	}
 

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -1013,8 +1013,8 @@ dav_rawx_patch_exec(const dav_resource *resource, const apr_xml_elem *elem, int 
 	(void) operation;
 	(void) context;
 	(void) rollback_ctx;
-	/* XXX JFS : TODO dump the xattr handle in the file */
-	return __dav_new_error(resource->info->pool, HTTP_INTERNAL_SERVER_ERROR, 0, "PROPPATCH not yet implemented");
+	return __dav_new_error(resource->info->pool, HTTP_NOT_IMPLEMENTED,
+			0, "PROPPATCH not yet implemented");
 }
 
 static void

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -433,7 +433,9 @@ dav_rawx_write_stream(dav_stream *stream, const void *buf, apr_size_t bufsize)
 	stream->compress_checksum = checksum;
 
 	/* update the hash and the stats */
-	g_checksum_update(stream->md5, buf, bufsize);
+	if (stream->md5)
+		g_checksum_update(stream->md5, buf, bufsize);
+
 	/* update total_size */
 	stream->total_size += bufsize;
 	return NULL;

--- a/rawx-apache2/src/rawx_req_info.c
+++ b/rawx-apache2/src/rawx_req_info.c
@@ -87,8 +87,6 @@ __gen_info(const dav_resource *resource, apr_pool_t *pool)
 static const char *
 __gen_stats(const dav_resource *resource, apr_pool_t *pool)
 {
-	DAV_XDEBUG_POOL(pool, 0, "%s()", __FUNCTION__);
-
 	dav_rawx_server_conf *c = resource_get_server_config(resource);
 
 	struct shm_stats_s *stats = apr_shm_baseaddr_get(c->shm.handle);
@@ -128,11 +126,7 @@ __gen_stats(const dav_resource *resource, apr_pool_t *pool)
 static dav_resource*
 __build_req_resource(const request_rec *r, const dav_hooks_repository *hooks, generator_f gen)
 {
-	dav_resource *resource;
-
-	DAV_XDEBUG_REQ(r, 0, "%s(...)", __FUNCTION__);
-
-	resource = apr_pcalloc(r->pool, sizeof(*resource));
+	dav_resource *resource = apr_pcalloc(r->pool, sizeof(*resource));
 	resource->type = DAV_RESOURCE_TYPE_PRIVATE;
 	resource->hooks = hooks;
 	resource->pool = r->pool;
@@ -156,7 +150,6 @@ dav_rawx_stat_get_resource(request_rec *r, const char *root_dir, const char *lab
 	(void) label;
 	(void) use_checked_in;
 
-	DAV_XDEBUG_REQ(r, 0, "%s(...)", __FUNCTION__);
 	*result_resource = NULL;
 
 	if (r->method_number != M_GET)
@@ -176,7 +169,6 @@ dav_rawx_info_get_resource(request_rec *r, const char *root_dir, const char *lab
 	(void) label;
 	(void) use_checked_in;
 
-	DAV_XDEBUG_REQ(r, 0, "%s(...)", __FUNCTION__);
 	*result_resource = NULL;
 
 	if (r->method_number != M_GET)
@@ -191,7 +183,6 @@ dav_rawx_info_get_resource(request_rec *r, const char *root_dir, const char *lab
 static dav_error *
 dav_rawx_get_parent_resource_SPECIAL(const dav_resource *resource, dav_resource **result_parent)
 {
-	DAV_XDEBUG_POOL(resource->info->pool, 0, "%s(...)", __FUNCTION__);
 	*result_parent = __build_req_resource(resource->info->request,
 		resource->hooks, resource->info->generator);
 	return NULL;
@@ -202,15 +193,12 @@ dav_rawx_is_same_resource_SPECIAL(const dav_resource *res1, const dav_resource *
 {
 	(void) res1;
 	(void) res2;
-
-	DAV_XDEBUG_RES(res1, 0, "%s(...)", __FUNCTION__);
 	return (res1->type == res2->type) && (res1->hooks == res2->hooks);
 }
 
 static int
 dav_rawx_is_parent_resource_SPECIAL(const dav_resource *res1, const dav_resource *res2)
 {
-	DAV_XDEBUG_RES(res1, 0, "%s(...)", __FUNCTION__);
 	return dav_rawx_is_same_resource_SPECIAL(res1, res2);
 }
 
@@ -224,7 +212,6 @@ dav_rawx_deliver_SPECIAL(const dav_resource *resource, ap_filter_t *output)
 	apr_bucket_brigade *bb;
 	apr_bucket *bkt;
 
-	DAV_XDEBUG_RES(resource, 0, "%s()", __FUNCTION__);
 	pool = resource->info->request->pool;
 
 	/* Check resource type */
@@ -247,8 +234,6 @@ dav_rawx_deliver_SPECIAL(const dav_resource *resource, ap_filter_t *output)
 	/* Nothing more to reply */
 	bkt = apr_bucket_eos_create(output->c->bucket_alloc);
 	APR_BRIGADE_INSERT_TAIL(bb, bkt);
-
-	DAV_XDEBUG_RES(resource, 0, "%s : ready to deliver", __FUNCTION__);
 
 	if ((status = ap_pass_brigade(output, bb)) != APR_SUCCESS)
 		return server_create_and_stat_error(resource_get_server_config(resource), pool,


### PR DESCRIPTION
* More secure rollback() of uploads
* Atomic chunk creation
* MD5 compared between the request and the local computation: only effective when both are present.
* Local MD5 computation can be siabled by a configuration directive `grid_checksum: on|off|smart` where `smart` activates it when meaningful (i.e. not when managing an EC/ chunk).