### PR TITLE
oio-blob-register: Make the action configurable

### DIFF
--- a/bin/oio-blob-registrator
+++ b/bin/oio-blob-registrator
@@ -24,18 +24,29 @@ def make_arg_parser():
     parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
     parser.add_argument('namespace', help="Namespace")
     parser.add_argument('volume', help="The volume id to rebuild")
+    parser.add_argument('-q', '--quiet', action='store_true',
+                        help="Don't print log on console")
     parser.add_argument('--first', default=False, action='store_true',
                         help="Also work on a chunk if it is the first in " + \
                              "its metachunk")
-    parser.add_argument('--no-lock', action='store_true',
-                        help="Also work on a chunk if it is the first in " + \
-                             "its metachunk")
+    parser.add_argument('--lock', action='store_true',
+                        help="Protect the run with an xattr-lock on the " + \
+                             "volume")
     parser.add_argument('--report-interval', type=int,
                         help="Report interval in seconds (3600)")
-    parser.add_argument('--chunks-per-second', type=int,
-                        help="Max chunks per second (30)")
-    parser.add_argument('-q', '--quiet', action='store_true',
-                        help="Don't print log on console")
+    parser.add_argument('--update', default=False, action='store_true',
+                        help="Should the script update the meta2 with " + \
+                             "the xattr. Mutually exclusive with --insert")
+    parser.add_argument('--insert', default=False, action='store_true',
+                        help="Should the script insert the chunkks in " + \
+                             "the container, without overriding the " + \
+                             "chunks in place. Mutually exclusive with" + \
+                             "--update, with a greater priority.")
+    parser.add_argument('--check', default=False, action='store_true',
+                        help="Default acction when neither --insert nor " + \
+                             "--update are specified (it overrides both)." + \
+                             " Only query the meta2 to check for the " + \
+                             "presence of the chunks in the volume.")
 
     return parser
 
@@ -50,28 +61,33 @@ if __name__ == '__main__':
         conf['log_facility'] = args.log_facility
     if args.log_address is not None:
         conf['log_address'] = args.log_address
-
-    conf['first'] = args.first
-
-    if args.report_interval is not None:
-        conf['report_interval'] = args.report_interval
-    if args.chunks_per_second is not None:
-        conf['chunks_per_second'] = args.chunks_per_second
-    conf['namespace'] = args.namespace
     if args.log_syslog_prefix is not None:
         conf['syslog_prefix'] = args.log_syslog_prefix
     else:
         conf['syslog_prefix'] = 'OIO,%s,blob-registrator,%s' % \
             (args.namespace, args.volume)
 
+    conf['namespace'] = args.namespace
+    conf['first'] = args.first
+
+    if args.insert:
+        conf['action'] = 'insert'
+    elif args.update:
+        conf['action'] = 'update'
+    else:
+        conf['action'] = 'check'
+
+    if args.report_interval is not None:
+        conf['report_interval'] = args.report_interval
+
     logger = get_logger(conf, None, not args.quiet)
 
     try:
         worker = BlobRegistratorWorker(conf, logger, args.volume)
-        if args.no_lock:
-            worker.pass_without_lock()
-        else:
+        if args.lock:
             worker.pass_with_lock()
+        else:
+            worker.pass_without_lock()
     except Exception as e:
         logger.exception('ERROR in registrator: %s' % e)
 

--- a/meta2v2/generic.c
+++ b/meta2v2/generic.c
@@ -625,20 +625,9 @@ GError *
 _db_insert_beans_list (sqlite3 *db, GSList *list)
 {
 	EXTRA_ASSERT(db != NULL);
-
 	GError *err = NULL;
 	for (; !err && list ;list=list->next)
 		err = _db_insert_bean (db, list->data);
-	return err;
-}
-
-GError *
-_db_insert_beans_array (sqlite3 *db, GPtrArray *tmp)
-{
-	EXTRA_ASSERT(db != NULL);
-	GError *err = NULL;
-	for (guint i=0; !err && i<tmp->len; i++)
-		err = _db_insert_bean (db, tmp->pdata[i]);
 	return err;
 }
 
@@ -690,25 +679,10 @@ _db_save_bean(sqlite3 *db, gpointer bean)
 GError*
 _db_save_beans_list(sqlite3 *db, GSList *list)
 {
-	GError *err = NULL;
-
 	EXTRA_ASSERT(db != NULL);
-	for (; !err && list ;list=list->next) {
-		if (list->data)
-			err = _db_save_bean(db, list->data);
-	}
-	return err;
-}
-
-GError*
-_db_save_beans_array(sqlite3 *src, GPtrArray *tmp)
-{
 	GError *err = NULL;
-
-	EXTRA_ASSERT(src != NULL);
-	EXTRA_ASSERT(tmp != NULL);
-	for (guint i=0; !err && i<tmp->len; i++)
-		err = _db_save_bean (src, tmp->pdata[i]);
+	for (; !err && list ;list=list->next)
+		err = _db_save_bean(db, list->data);
 	return err;
 }
 

--- a/meta2v2/generic.h
+++ b/meta2v2/generic.h
@@ -133,11 +133,9 @@ void _bean_cleanl2(GSList *v);
 
 GError* _db_insert_bean(sqlite3 *db, gpointer bean);
 GError* _db_insert_beans_list(sqlite3 *db, GSList *list);
-GError* _db_insert_beans_array(sqlite3 *db, GPtrArray *array);
 
 GError* _db_save_bean(sqlite3 *db, gpointer bean);
 GError* _db_save_beans_list(sqlite3 *db, GSList *list);
-GError* _db_save_beans_array(sqlite3 *db, GPtrArray *array);
 
 /* substitues bean0 by bean1, with an UPDATE statement that will
  * even overwrite the fields of the PK */

--- a/meta2v2/m2gen.py
+++ b/meta2v2/m2gen.py
@@ -386,12 +386,12 @@ the list."""
             # sql_insert
             t0 = ",".join(t.get_fields_names())
             t1 = ",".join(['?' for f in t.fields])
-            sql = "INSERT  INTO "+t.sql_name+"("+t0+") VALUES ("+t1+")"
+            sql = "INSERT OR ABORT INTO "+t.sql_name+"("+t0+") VALUES ("+t1+")"
             out.write('\t'+dquoted(sql)+',\n')
             out.write('\t'+str(len(sql))+',\n')
 
             # sql_replace
-            sql = "REPLACE INTO "+t.sql_name+"("+t0+") VALUES ("+t1+")"
+            sql = "INSERT OR REPLACE INTO "+t.sql_name+"("+t0+") VALUES ("+t1+")"
             out.write('\t'+dquoted(sql)+',\n')
             out.write('\t'+str(len(sql))+',\n')
 

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1047,11 +1047,12 @@ meta2_backend_force_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 
 GError*
 meta2_backend_insert_beans(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *beans)
+		struct oio_url_s *url, GSList *beans, gboolean force)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
 	struct sqlx_repctx_s *repctx = NULL;
+	int error_already = 0;
 
 	EXTRA_ASSERT(m2b != NULL);
 	EXTRA_ASSERT(url != NULL);
@@ -1059,12 +1060,27 @@ meta2_backend_insert_beans(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
-			err = _db_save_beans_list (sq3->db, beans);
+			if (force)
+				err = _db_save_beans_list (sq3->db, beans);
+			else
+				err = _db_insert_beans_list (sq3->db, beans);
 			if (!err)
 				m2db_increment_version(sq3);
+			else {
+				/* A constraint error is usually raised by an actual constraint
+				 * violation in the DB (inside the transaction) or also by a
+				 * failure of the commit hook (on the final COMMIT). */
+				error_already |= (err->code == SQLITE_CONSTRAINT);
+			}
 			err = sqlx_transaction_end(repctx, err);
 		}
 		m2b_close(sq3);
+	}
+
+	if (error_already) {
+		EXTRA_ASSERT(err != NULL);
+		g_clear_error(&err);
+		err = NEWERROR(CODE_CONTENT_EXISTS, "Bean already present");
 	}
 
 	return err;

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -105,7 +105,7 @@ GError* meta2_backend_delete_beans(struct meta2_backend_s *m2b,
 /** Inserts all the beans listed, as is, regardless of their type. This is REALLY
  * DANGEROUS, do not use this feature. */
 GError* meta2_backend_insert_beans(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *beans);
+		struct oio_url_s *url, GSList *beans, gboolean force);
 
 /** Updates all the beans listed (old by new), as is, regardless of their type.
  * This is REALLY DANGEROUS, do not use this feature. */

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -420,12 +420,14 @@ int
 meta2_filter_action_insert_beans(struct gridd_filter_ctx_s *ctx,
 		struct gridd_reply_ctx_s *reply)
 {
-	(void) reply;
 	struct oio_url_s *url = meta2_filter_ctx_get_url(ctx);
 	struct meta2_backend_s *m2b = meta2_filter_ctx_get_backend(ctx);
 	GSList *beans = meta2_filter_ctx_get_input_udata(ctx);
 
-	GError *err = meta2_backend_insert_beans(m2b, url, beans);
+	const gboolean force = metautils_message_extract_flag(
+			reply->request, NAME_MSGKEY_FORCE, FALSE);
+
+	GError *err = meta2_backend_insert_beans(m2b, url, beans, force);
 	if (!err)
 		return FILTER_OK;
 

--- a/meta2v2/meta2v2_remote.c
+++ b/meta2v2/meta2v2_remote.c
@@ -301,10 +301,12 @@ m2v2_remote_pack_RAW_DEL(struct oio_url_s *url, GSList *beans)
 }
 
 GByteArray*
-m2v2_remote_pack_RAW_ADD(struct oio_url_s *url, GSList *beans)
+m2v2_remote_pack_RAW_ADD(struct oio_url_s *url, GSList *beans, gboolean force)
 {
 	GByteArray *body = bean_sequence_marshall(beans);
-	return _m2v2_pack_request(NAME_MSGNAME_M2V2_RAW_ADD, url, body);
+	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_RAW_ADD, url, body);
+	metautils_message_add_field_struint(msg, NAME_MSGKEY_FORCE, BOOL(force));
+	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*

--- a/meta2v2/meta2v2_remote.h
+++ b/meta2v2/meta2v2_remote.h
@@ -151,7 +151,7 @@ GByteArray* m2v2_remote_pack_LIST_BY_HEADERID(
 		struct list_params_s *p, GBytes *h);
 
 GByteArray* m2v2_remote_pack_RAW_DEL(struct oio_url_s *url, GSList *beans);
-GByteArray* m2v2_remote_pack_RAW_ADD(struct oio_url_s *url, GSList *beans);
+GByteArray* m2v2_remote_pack_RAW_ADD(struct oio_url_s *url, GSList *beans, gboolean force);
 GByteArray* m2v2_remote_pack_RAW_SUBST(struct oio_url_s *url, GSList *new_chunks, GSList *old_chunks);
 GByteArray* m2v2_remote_pack_PROP_DEL(struct oio_url_s *url, gchar **names);
 

--- a/oio/blob/registrator.py
+++ b/oio/blob/registrator.py
@@ -1,9 +1,14 @@
 from contextlib import contextmanager
+from os.path import basename
+from time import clock as now
 
 from oio.common.utils import paths_gen
 from oio.blob.utils import check_volume, read_chunk_metadata
 from oio.container.client import ContainerClient
-from oio.common import exceptions as exc
+from oio.common.exceptions import Conflict, NotFound
+
+
+default_report_interval = 60.0
 
 
 @contextmanager
@@ -32,39 +37,92 @@ class BlobRegistratorWorker(object):
         c = dict()
         c['namespace'] = self.namespace
         self.client = ContainerClient(c)
+        self.report_interval = conf.get(
+                "report_period", default_report_interval)
+
+        actions = {
+                'update': BlobRegistratorWorker._update_chunk,
+                'insert': BlobRegistratorWorker._insert_chunk,
+                'check': BlobRegistratorWorker._check_chunk,
+        }
+        self.action = actions[conf.get("action", "check")]
 
     def pass_with_lock(self):
         with lock_volume(self.volume):
             return self.pass_without_lock()
 
     def pass_without_lock(self):
+        last_report = now()
+        count, success, fail = 0, 0, 0
         if self.namespace != self.volume_ns:
             self.logger.warn("Forcing the NS to [%s] (previously [%s])",
                              self.namespace, self.volume_ns)
-        # TODO(jfs): do the startup reporting
+
+        self.logger.info("START %s", self.volume)
+
         paths = paths_gen(self.volume)
         for path in paths:
+            # Action
             try:
-                self._register_chunk(path)
-                # TODO(jfs): do the throttling
+                with open(path) as f:
+                    meta = read_chunk_metadata(f)
+                    self.action(self, path, f, meta)
+                    success = success + 1
+            except NotFound as e:
+                fail = fail + 1
+                self.logger.info("ORPHAN %s/%s in %s/%s %s",
+                                 meta['content_id'], meta['chunk_id'],
+                                 meta['container_id'], meta['content_path'],
+                                 str(e))
+            except Conflict as e:
+                fail = fail + 1
+                self.logger.info("ALREADY %s/%s in %s/%s %s",
+                                 meta['content_id'], meta['chunk_id'],
+                                 meta['container_id'], meta['content_path'],
+                                 str(e))
             except Exception as e:
-                self.logger.warn("Faulty chunk found at %s: %s", path, str(e))
-            # TODO(jfs): do the periodical reporting
-        # TODO(jfs): do the final reporting
+                fail = fail + 1
+                self.logger.warn("ERROR %s/%s in %s/%s %s",
+                                 meta['content_id'], meta['chunk_id'],
+                                 meta['container_id'], meta['content_path'],
+                                 str(e))
+            count = count + 1
 
-    def _register_chunk(self, path):
-        with open(path) as f:
-            try:
-                meta = read_chunk_metadata(f)
-                cid = meta['container_id']
-                if str(meta['chunk_pos']).startswith('0'):
-                    if not self.conf['first']:
-                        self.logger.info("skip %s from %s", path, cid)
-                        return
-                pre = meta2bean(self.volume_id, meta)
-                post = meta2bean(self.volume_id, meta)
-                self.client.raw_update(pre, post, cid=cid,
-                                       path=meta['content_path'])
-                self.logger.info("registered %s in %s", path, cid)
-            except exc.MissingAttribute as e:
-                raise exc.FaultyChunk('Missing extended attribute %s' % e)
+            # TODO(jfs): do the throttling
+
+            # periodical reporting
+            t = now()
+            if t - last_report > self.report_interval:
+                self.logger.info("STEP %d ok %d ko %d",
+                                 count, success, fail)
+
+        self.logger.info("FINAL %s %d ok %d ko %d",
+                         self.volume, count, success, fail)
+
+    def _check_chunk(self, path, f, meta):
+        raise Exception("CHECK not yet implemented")
+
+    def _insert_chunk(self, path, f, meta):
+        cid = meta['container_id']
+        chunkid = basename(path)
+        bean = meta2bean(self.volume_id, meta)
+        self.client.container_raw_insert(bean, cid=cid)
+        self.logger.info("inserted %s/%s in %s/%s",
+                         meta['content_id'], chunkid, cid,
+                         meta['content_path'])
+
+    def _update_chunk(self, path, f, meta):
+        cid = meta['container_id']
+        chunkid = basename(path)
+        if str(meta['chunk_pos']).startswith('0'):
+            if not self.conf['first']:
+                self.logger.info("skip %s/%s from %s/%s",
+                                 meta['content_id'], chunkid, cid,
+                                 meta['content_path'])
+                return
+        pre = meta2bean(self.volume_id, meta)
+        post = meta2bean(self.volume_id, meta)
+        self.client.container_raw_update(pre, post, cid=cid)
+        self.logger.info("updated %s/%s in %s/%s",
+                         meta['content_id'], chunkid, cid,
+                         meta['content_path'])

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -121,21 +121,19 @@ class ContainerClient(Client):
         params = self._make_params(acct, ref, cid=cid)
         resp, body = self._request('POST', uri, params=params)
 
-    def container_raw_insert(self, acct=None, ref=None, data=None, cid=None,
+    def container_raw_insert(self, bean, acct=None, ref=None, cid=None,
                              **kwargs):
         uri = self._make_uri('container/raw_insert')
         params = self._make_params(acct, ref, cid=cid)
-        data = json.dumps(data)
-        resp, body = self._request(
-            'POST', uri, data=data, params=params)
+        data = json.dumps((bean,))
+        resp, body = self._request('POST', uri, data=data, params=params)
 
-    def container_raw_update(self, acct=None, ref=None, data=None, cid=None,
+    def container_raw_update(self, old, new, acct=None, ref=None, cid=None,
                              **kwargs):
         uri = self._make_uri('container/raw_update')
-        params = self._make_params(acct, ref, cid=cid)
-        data = json.dumps(data)
-        resp, body = self._request(
-            'POST', uri, data=data, params=params)
+        params = self._make_params(acct=acct, ref=ref, cid=cid)
+        data = json.dumps({"old": [old], "new": [new]})
+        resp, body = self._request('POST', uri, data=data, params=params)
 
     def container_raw_delete(self, acct=None, ref=None, data=None, cid=None,
                              **kwargs):
@@ -238,12 +236,4 @@ class ContainerClient(Client):
         data = json.dumps(data)
         resp, body = self._request(
             'POST', uri, data=data, params=params)
-        return body
-
-    def raw_update(self, old, new, cid=None, path=None, **kwargs):
-        uri = self._make_uri('container/raw_update')
-        params = self._make_params(cid=cid, content=path)
-        data = {"old": [old], "new": [new]}
-        resp, body = self._request(
-            'POST', uri, data=json.dumps(data), params=params)
         return body

--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -73,10 +73,8 @@ class Content(object):
                 'size': current_chunk.size,
                 'pos': current_chunk.pos,
                 'content': self.content_id}]
-        update_data = {'old': old, 'new': new}
-
         self.container_client.container_raw_update(
-            cid=self.container_id, data=update_data)
+            old, new, cid=self.container_id)
 
     def _create_object(self):
         self.container_client.content_create(

--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -61,18 +61,18 @@ class Content(object):
         return url_list
 
     def _update_spare_chunk(self, current_chunk, new_url):
-        old = [{'type': 'chunk',
-                'id': current_chunk.url,
-                'hash': current_chunk.checksum,
-                'size': current_chunk.size,
-                'pos': current_chunk.pos,
-                'content': self.content_id}]
-        new = [{'type': 'chunk',
-                'id': new_url,
-                'hash': current_chunk.checksum,
-                'size': current_chunk.size,
-                'pos': current_chunk.pos,
-                'content': self.content_id}]
+        old = {'type': 'chunk',
+               'id': current_chunk.url,
+               'hash': current_chunk.checksum,
+               'size': current_chunk.size,
+               'pos': current_chunk.pos,
+               'content': self.content_id}
+        new = {'type': 'chunk',
+               'id': new_url,
+               'hash': current_chunk.checksum,
+               'size': current_chunk.size,
+               'pos': current_chunk.pos,
+               'content': self.content_id}
         self.container_client.container_raw_update(
             old, new, cid=self.container_id)
 

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1055,6 +1055,8 @@ action_m2_container_touch (struct req_args_s *args, struct json_object *j UNUSED
 static enum http_rc_e
 action_m2_container_raw_insert (struct req_args_s *args, struct json_object *jargs)
 {
+	const gboolean force = _request_get_flag (args, "force");
+
 	GSList *beans = NULL;
 	GError *err = m2v2_json_load_setof_xbean (jargs, &beans);
 	if (err) {
@@ -1064,7 +1066,9 @@ action_m2_container_raw_insert (struct req_args_s *args, struct json_object *jar
 	if (!beans)
 		return _reply_format_error (args, BADREQ("Empty beans list"));
 
-	PACKER_VOID(_pack) { return m2v2_remote_pack_RAW_ADD (args->url, beans); }
+	PACKER_VOID(_pack) {
+		return m2v2_remote_pack_RAW_ADD (args->url, beans, force);
+	}
 	err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
 	_bean_cleanl2(beans);
 	if (NULL != err)


### PR DESCRIPTION
Prior to this pull request, the oio-blob-register was only able to force the refresh of the chunks in their corresponding container.

Now the operator can choose, on the CLI, between:
* refreshing the chunk (--upgrade) being only effective if the chunk is already registered
* inserting it (--insert) with no effect is yet present
* checking it's presence (not yet implemented)