### PR TITLE
CLI: organize imports, add versioning options

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -12,8 +12,8 @@
 # License along with this library.
 
 from oio.common import exceptions
-from oio.common.http import requests, requests_adapters
-from oio.common.http import CONNECTION_TIMEOUT, READ_TIMEOUT
+from oio.common.http import requests, requests_adapters, \
+    CONNECTION_TIMEOUT, READ_TIMEOUT
 from oio.common.constants import ADMIN_HEADER
 
 _ADAPTER_OPTIONS_KEYS = ["pool_connections", "pool_maxsize", "max_retries"]

--- a/oio/cli/shell.py
+++ b/oio/cli/shell.py
@@ -3,7 +3,7 @@
 import sys
 import logging
 
-from cliff import app
+import cliff.app
 
 import oio
 from oio.common import utils
@@ -11,7 +11,7 @@ from oio.cli.commandmanager import CommandManager
 from oio.cli import clientmanager
 
 
-class OpenIOShell(app.App):
+class OpenIOShell(cliff.app.App):
     log = logging.getLogger(__name__)
 
     def __init__(self):
@@ -97,9 +97,7 @@ class OpenIOShell(app.App):
             api = module.API_NAME
             cmd_group = 'openio.' + api.replace('-', '_')
             self.command_manager.add_command_group(cmd_group)
-            self.log.debug(
-                '%s API: cmd group %s' % (api, cmd_group)
-            )
+            self.log.debug('%s API: cmd group %s', api, cmd_group)
         self.command_manager.add_command_group('openio.common')
         self.command_manager.add_command_group('openio.ext')
 

--- a/tests/functional/cli/storage/test_obj.py
+++ b/tests/functional/cli/storage/test_obj.py
@@ -23,7 +23,8 @@ HEADERS = ['Name', 'Created']
 OBJ_HEADERS = ['Name', 'Size', 'Hash']
 CONTAINER_LIST_HEADERS = ['Name', 'Bytes', 'Count']
 CONTAINER_FIELDS = ['account', 'base_name', 'bytes_usage', 'quota',
-                    'container', 'ctime', 'storage_policy', 'objects']
+                    'container', 'ctime', 'storage_policy', 'objects',
+                    'max_versions']
 OBJ_FIELDS = ['account', 'container', 'ctime', 'hash', 'id', 'mime-type',
               'object', 'policy', 'size', 'version']
 


### PR DESCRIPTION
* Organize module imports to make the CLI faster to load (not that much).
* Add `--max-versions` option to `openio container create` and `openio container set`.
* Add `--max-versions`, `--quota` and `--storage-policy` options to `openio container unset`.