### PR TITLE
Fix segfault in sqliterepo

### DIFF
--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -496,6 +496,8 @@ label_retry:
 			// If cache was enabled, we can retry without cache
 			if (!nocache) {
 				nocache = TRUE;
+				// freed by filter_services_and_clean() but still not NULL
+				peers = NULL;
 				goto label_retry;
 			} else {
 				err = NEWERROR(CODE_CONTAINER_NOTFOUND, "Base not managed");


### PR DESCRIPTION
This happens in a weird case where the peers saved in a base do not include the service currently serving the base...