### PR TITLE
sqliterepo: Add a security belt around fetches of the peers

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -29,6 +29,14 @@ extern "C" {
 #  define EXTRA_ASSERT(X)
 # endif
 
+# ifdef __GNUC__
+#  define likely(x)       __builtin_expect((x),1)
+#  define unlikely(x)     __builtin_expect((x),0)
+# else
+#  define likely(x)       (x)
+#  define unlikely(x)     (x)
+# endif
+
 #define LIMIT_LENGTH_REQID 64
 
 #define OLDEST(now,delay) (((now)>(delay)) ? ((now)-(delay)) : 0)

--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -61,6 +61,9 @@ gchar ** oio_strv_append(gchar **dst, gchar *s);
 /** frees *s and set it to NULL */
 void oio_str_clean(gchar **s);
 
+/** g_strfreev *p and set it to NULL */
+void oio_str_cleanv(gchar ***p);
+
 /** frees *dst and set it to src */
 void oio_str_replace(gchar **dst, const char *src);
 

--- a/core/str.c
+++ b/core/str.c
@@ -688,3 +688,13 @@ gchar ** KV_extract_not_prefixed (gchar **kv, const char *prefix) {
 	g_ptr_array_add(tmp, NULL);
 	return (gchar**) g_ptr_array_free(tmp, FALSE);
 }
+
+void oio_str_cleanv(gchar ***p) {
+	if (unlikely(p == NULL))
+		return;
+	if (*p) {
+		g_strfreev(*p);
+		*p = NULL;
+	}
+}
+

--- a/meta0v2/meta0_server.c
+++ b/meta0v2/meta0_server.c
@@ -94,9 +94,10 @@ _get_peers(struct sqlx_service_s *ss, const struct sqlx_name_s *n,
 
 	*result = strv_filter(ss, peers);
 	g_slist_free_full(peers, (GDestroyNotify)free_zknode);
-	if (unlikely(*result == NULL))
-		return NEWERROR(CODE_CONTAINER_NOTFOUND, "Base not managed");
-	return NULL;
+	if (likely(*result != NULL))
+		return NULL;
+
+	return NEWERROR(CODE_CONTAINER_NOTFOUND, "Base not managed");
 }
 
 static void

--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -142,9 +142,10 @@ _get_peers(struct sqlx_service_s *ss, const struct sqlx_name_s *n,
 		_reload_prefixes(ss, FALSE);
 
 	*result = meta1_prefixes_get_peers(meta1_backend_get_prefixes(m1), cid);
-	if (unlikely(*result == NULL))
-		return NEWERROR(CODE_CONTAINER_NOTFOUND, "Base not managed");
-	return NULL;
+	if (likely(*result != NULL))
+		return NULL;
+
+	return NEWERROR(CODE_CONTAINER_NOTFOUND, "Base not managed");
 }
 
 static gboolean

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -576,7 +576,7 @@ meta2_backend_create_container(struct meta2_backend_s *m2,
 			return err;
 	}
 
-	if (params->local) // NOREFCHECK: do not call get_peers()
+	if (params->local)
 		open_mode = M2V2_OPEN_LOCAL|M2V2_OPEN_NOREFCHECK;
 	else
 		open_mode = M2V2_OPEN_MASTERONLY;

--- a/metautils/lib/metautils_bits.h
+++ b/metautils/lib/metautils_bits.h
@@ -24,14 +24,6 @@ License along with this library.
 
 /* A place for all the macros playing with integer bits */
 
-# ifdef __GNUC__
-#  define likely(x)       __builtin_expect(BOOL(x),1)
-#  define unlikely(x)     __builtin_expect(BOOL(x),0)
-# else
-#  define likely(x)       (x)
-#  define unlikely(x)     (x)
-# endif
-
 struct hash_len_s
 {
 	guint32 h;

--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -47,12 +47,12 @@ struct replication_config_s
 	/** Locate the replication peers of the base identified by <n,t>. An error
 	 * means the base cannot be replicated or managed. A base not managed
 	 *  locally must return an error. A base locally managed but not replicated
-	 *  must return NULL and fill result with a NULL pointer or an empty array.
+	 *  must return NULL and fill result with an empty array.
 	 *
 	 * @param ctx the pointer registered in the configuration
 	 * @param n the logical name of the base (not the physical path)
 	 * @param result a placeholder for the array of peers.
-	 * @return NULL if 'result'
+	 * @return NULL if 'result' is set, and not-NULL if 'result' is not set
 	 */
 	GError* (*get_peers) (gpointer ctx, const struct sqlx_name_s *n,
 			gboolean nocache, gchar ***result);

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1226,7 +1226,6 @@ do_destroy(struct gridd_reply_ctx_s *reply, struct sqlx_repository_s *repo,
 		struct sqlx_name_s *name, gboolean local)
 {
 	GError *err = NULL;
-	gchar **peers = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
 
 	GRID_DEBUG("Opening for destruction [%s][%s] (%s)",
@@ -1237,13 +1236,15 @@ do_destroy(struct gridd_reply_ctx_s *reply, struct sqlx_repository_s *repo,
 		return err;
 
 	if (!local) {
+		gchar **peers = NULL;
 		err = election_get_peers(sq3->manager, name, FALSE, &peers);
-		if (err)
+		if (err) {
+			EXTRA_ASSERT(peers == NULL);
 			goto end_label;
-		if (NULL != peers) {
+		} else {
+			EXTRA_ASSERT(peers != NULL);
 			err = sqlx_remote_execute_DESTROY_many(peers, NULL, name);
 			g_strfreev(peers);
-			peers = NULL;
 		}
 	}
 

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1499,11 +1499,11 @@ sqlx_repository_get_peers2(sqlx_repository_t *repo,
 	GError *err = sqlx_repository_open_and_lock(repo, n, SQLX_OPEN_LOCAL|SQLX_OPEN_NOREFCHECK, &sq3, NULL);
 	if (!err) {
 		gchar *tmp = sqlx_admin_get_str(sq3, SQLX_ADMIN_PEERS);
+		sqlx_repository_unlock_and_close_noerror2(sq3, SQLX_CLOSE_IMMEDIATELY);
 		if (tmp) {
 			*result = g_strsplit(tmp, ",", -1);
 			g_free(tmp);
 		}
-		sqlx_repository_unlock_and_close_noerror2(sq3, SQLX_CLOSE_IMMEDIATELY);
 	}
 	return err;
 }


### PR DESCRIPTION
Each time the application locates for peers, whatever the level, ensure...
* the output pointer is set to something
* an array is used when no error occur (even if it is empty)
* NULL is never used to represent an empty list of peers.
* NULL is used when an error returned