### PR TITLE
Add Python coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ script:
   - make coverage_init
   - python setup.py install
   - echo "travis_fold:end:BUILD_Debug"
-  - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
+  - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib" PYTHON_COVERAGE=1
   - ./tools/oio-travis-tests.sh
   - echo "travis_fold:start:COVERAGE_Debug"
   - make coverage
   - gcovr -r . | cut -c1-63
+  - coverage report
   - echo "travis_fold:start:BUILD_Release"
   - make clean
   - cmake -DCMAKE_INSTALL_PREFIX="/tmp/oio" -DLD_LIBDIR="lib" -DCMAKE_BUILD_TYPE="Release" -DZK_LIBDIR="/usr/lib" -DZK_INCDIR="/usr/include/zookeeper" -DAPACHE2_LIBDIR="/usr/lib/apache2" -DAPACHE2_INCDIR="/usr/include/apache2" -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if (NOT ABI_VERSION)
 endif()
 
 set(CMAKE_C_FLAGS "-g -fPIC -pipe -Wall -Wextra -std=gnu99")
+set(PYTHON python)
 
 # necessary to benefit from zero'ed static allocation of structures
 # as proposed by C99. (we only allocate the first field and let the compiler
@@ -65,6 +66,9 @@ if ( ENABLE_CODECOVERAGE )
         set( CODECOV_HTMLOUTPUTDIR coverage_results )
     endif ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
 
+    set(PYTHON_COVERAGE_FILE ${CMAKE_BINARY_DIR}/.python_coverage)
+    set(PYTHON coverage run -p --source=${CMAKE_SOURCE_DIR})
+
     if ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
         find_program( CODECOV_GCOV gcov )
         find_program( CODECOV_LCOV lcov )
@@ -72,10 +76,14 @@ if ( ENABLE_CODECOVERAGE )
         add_definitions( -fprofile-arcs -ftest-coverage )
         link_libraries( gcov )
         set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} --coverage )
-        add_custom_target( coverage_init ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial )
-        add_custom_target( coverage ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture COMMAND genhtml --ignore-errors source -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE} )
-    endif ( CMAKE_COMPILER_IS_GNUCXX )
-
+        add_custom_target( coverage_init
+                           ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial
+                           COMMAND coverage erase)
+        add_custom_target( coverage ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture
+                           COMMAND genhtml --ignore-errors source -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE}
+                           COMMAND coverage combine
+                           COMMAND coverage html)
+    endif ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
 endif (ENABLE_CODECOVERAGE )
 
 set(CMAKE_C_FLAGS_DEBUG          "-O0 -fno-inline")

--- a/tests/func/CMakeLists.txt
+++ b/tests/func/CMakeLists.txt
@@ -38,14 +38,16 @@ target_link_libraries(oiosds_test oiosds)
 set_target_properties(oiosds_test PROPERTIES
 		SOVERSION ${ABI_VERSION})
 add_test(NAME core/sds
-		COMMAND /usr/bin/env python ${CMAKE_CURRENT_SOURCE_DIR}/test_oiosds.py ${CMAKE_CURRENT_BINARY_DIR})
+		COMMAND /usr/bin/env ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/test_oiosds.py ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(core/sds PROPERTIES ENVIRONMENT CTEST_OUTPUT_ON_FAILURE=1)
 
 add_library(oiohttp_test SHARED testlib_http.c)
 target_link_libraries(oiohttp_test oiosds)
 set_target_properties(oiohttp_test PROPERTIES
 		SOVERSION ${ABI_VERSION})
 add_test(NAME core/http
-		COMMAND /usr/bin/env python ${CMAKE_CURRENT_SOURCE_DIR}/test_oiohttp.py ${CMAKE_CURRENT_BINARY_DIR})
+		COMMAND /usr/bin/env ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/test_oiohttp.py ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(core/http PROPERTIES ENVIRONMENT CTEST_OUTPUT_ON_FAILURE=1)
 
 add_executable(test_oio_cs test_cs.c)
 target_link_libraries(test_oio_cs oiosds)

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -4,6 +4,12 @@ export COLUMNS=512 LANG=
 export G_DEBUG=fatal_warnings
 export G_SLICE=always-malloc
 
+export PYTHON=python
+
+if [ "${PYTHON_COVERAGE:-}" == "1" ]; then
+    PYTHON="coverage run -p --omit=/home/travis/oio/lib/python2.7/*"
+fi
+
 SRCDIR=$PWD
 WRKDIR=$PWD
 if [ $# -eq 2 ] ; then
@@ -34,10 +40,10 @@ func_tests () {
 
     # test a content with a strange name, through the CLI and the API
     /usr/bin/fallocate -l $RANDOM /tmp/blob%
-    openio object create $RANDOM /tmp/blob%
+    ${PYTHON} $(which openio) object create $RANDOM /tmp/blob%
 
     cd $SRCDIR
-    tox && tox -e func
+    tox -e coverage && tox -e func,coverage
     cd $WRKDIR
     make -C tests/func test
     ./core/tool_roundtrip /etc/passwd
@@ -50,9 +56,9 @@ test_worm () {
     echo -e "END OF RESET" | logger -t TEST
     cd $SRCDIR
     export WORM=1
-    tox
+    tox -e coverage
     echo "test_filters: begin WORM test"
-    nosetests tests.functional.m2_filters.test_filters
+    ${PYTHON} $(which nosetests) tests.functional.m2_filters.test_filters
     unset WORM
 }
 
@@ -65,7 +71,7 @@ test_slave () {
     export SLAVE=1
     tox
     echo "test_filters: begin SLAVE test"
-    nosetests tests.functional.m2_filters.test_filters
+    ${PYTHON} $(which nosetests) tests.functional.m2_filters.test_filters
     unset SLAVE
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ deps =
 commands = nosetests {posargs:tests/unit}
 passenv = OIO_*
 
+[testenv:coverage]
+commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {posargs:tests/unit}
+
 [testenv:cover]
 setenv = VIRTUAL_ENV={envdir}
          NOSE_WITH_COVERAGE=1


### PR DESCRIPTION
To achieve Python coverage, a new environment was added in `tox.ini` to have global coverage.
For each Python test, command is set to `coverage run -p` instead of python. 