### PR TITLE
Convert eventlet Timeout to OioTimeout

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -807,9 +807,9 @@ class ECChunkWriteHandler(object):
         except SourceReadError:
             logger.warn('Source read error')
             raise
-        except Timeout:
+        except Timeout as to:
             logger.exception('Timeout writing data')
-            raise
+            raise exceptions.OioTimeout(to)
         except Exception:
             logger.exception('Exception writing data')
             raise

--- a/oio/api/replication.py
+++ b/oio/api/replication.py
@@ -138,9 +138,9 @@ class ReplicatedChunkWriteHandler(object):
         except SourceReadError:
             logger.warn('Source read error')
             raise
-        except Timeout:
+        except Timeout as to:
             logger.exception('Timeout writing data')
-            raise
+            raise exc.OioTimeout(to)
         except Exception:
             logger.exception('Exception writing data')
             raise

--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -16,10 +16,6 @@ class OioTimeout(Timeout):
         return "Timeout %s" % super(OioTimeout, self).__str__()
 
 
-class ClientReadTimeout(OioTimeout):
-    pass
-
-
 class ConnectionTimeout(OioTimeout):
     pass
 

--- a/tests/unit/api/test_ec.py
+++ b/tests/unit/api/test_ec.py
@@ -197,8 +197,8 @@ class TestEC(unittest.TestCase):
         with set_http_connect(*resps):
             handler = ECChunkWriteHandler(self.sysmeta, self.meta_chunk(),
                                           checksum, self.storage_method)
-            self.assertRaises(Timeout, handler.stream, source,
-                              size)
+            self.assertRaises(
+                exc.OioTimeout, handler.stream, source, size)
 
     def test_write_exception_source(self):
         class TestReader(object):

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -184,8 +184,8 @@ class TestReplication(unittest.TestCase):
         with set_http_connect(*resps):
             handler = ReplicatedChunkWriteHandler(
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
-            self.assertRaises(Timeout, handler.stream, source,
-                              size)
+            self.assertRaises(
+                exc.OioTimeout, handler.stream, source, size)
 
     def test_write_exception_source(self):
         class TestReader(object):


### PR DESCRIPTION
Users of our API don't have to be bothered by eventlet.