### PR TITLE
CMake: add CODECOV_PATTERN_TO_IGNORE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if ( ENABLE_CODECOVERAGE )
     if ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
         set( CODECOV_HTMLOUTPUTDIR coverage_results )
     endif ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
+    set(CODECOV_PATTERN_TO_IGNORE)
 
     set(PYTHON_COVERAGE_FILE ${CMAKE_BINARY_DIR}/.python_coverage)
     set(PYTHON coverage run -p --source=${CMAKE_SOURCE_DIR})
@@ -80,6 +81,7 @@ if ( ENABLE_CODECOVERAGE )
                            ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial
                            COMMAND coverage erase)
         add_custom_target( coverage ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture
+                           COMMAND ${CODECOV_LCOV} --remove ${CODECOV_OUTPUTFILE} ${CODECOV_PATTERN_TO_IGNORE} --output ${CODECOV_OUTPUTFILE}
                            COMMAND genhtml --ignore-errors source -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE}
                            COMMAND coverage combine
                            COMMAND coverage html)


### PR DESCRIPTION
Add variable CODECOV_PATTERN_TO_IGNORE to remove some
autogenerated libs from coverage.

For example:
set(CODECOV_PATTERN_TO_IGNORE ${CMAKE_BINARY_DIR}/core/client_variables.c '${CMAKE_BINARY_DIR}/metautils/lib/*.c')