### PR TITLE
Account: send a lua script to redis to update containers.

### DIFF
--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -123,6 +123,7 @@ class Account(object):
         dtime = d.get('dtime')
         object_count = d.get('objects')
         bytes_used = d.get('bytes')
+        # Exceptions are catched by dispatch_request
         info = self.backend.update_container(
             account_id, name, mtime, dtime, object_count, bytes_used)
         result = json.dumps(info)
@@ -133,8 +134,6 @@ class Account(object):
         try:
             endpoint, values = adapter.match()
             return getattr(self, 'on_' + endpoint)(req)
-        except NotFound:
-            return BadRequest()
         except HTTPException as e:
             return e
         except Exception:

--- a/tests/functional/account/test_server.py
+++ b/tests/functional/account/test_server.py
@@ -1,9 +1,11 @@
+from time import time
 import simplejson as json
 
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 from oio.account.server import create_app
 from tests.utils import BaseTestCase
+from oio.common.utils import Timestamp
 
 
 class TestAccountServer(BaseTestCase):
@@ -53,7 +55,8 @@ class TestAccountServer(BaseTestCase):
         self.assertEqual(resp.status_code, 204)
 
     def test_account_container_update(self):
-        data = {'name': 'foo', 'mtime': 0, 'objects': 0, 'bytes': 0}
+        data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
+                'objects': 0, 'bytes': 0}
         data = json.dumps(data)
         resp = self.app.post('/v1.0/account/container/update',
                              data=data, query_string={'id': self.account_id})


### PR DESCRIPTION
Replace the lock/unlock by a script to redis.
Since a script is atomic it should prevent the problem of tilted redis that left lock.