### PR TITLE
travis: Speed up the test suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,20 @@ install:
   - pip install --upgrade -r test-requirements.txt
   - pip install --upgrade zkpython
 env:
-  - TEST_SUITE=build-release
-  - TEST_SUITE=unit
-  - TEST_SUITE=single
-  - TEST_SUITE=worm
-  - TEST_SUITE=slave
+  - TEST_SUITE=build,unit,small-cache
+  - TEST_SUITE=worm,slave
+  - TEST_SUITE=3copies
   - TEST_SUITE=repli
   - TEST_SUITE=ec
 script:
+  - set -e
+  - mkdir /tmp/oio && source $HOME/oio/bin/activate
   - export CMAKE_OPTS='-DCMAKE_INSTALL_PREFIX=/tmp/oio -DLD_LIBDIR=lib -DZK_LIBDIR=/usr/lib -DZK_INCDIR=/usr/include/zookeeper -DAPACHE2_LIBDIR=/usr/lib/apache2 -DAPACHE2_INCDIR=/usr/include/apache2 -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module'
   - if [ -n "$COVERAGE" ] ; then export PYTHON_COVERAGE=1 ; fi
-  - mkdir /tmp/oio && source $HOME/oio/bin/activate
-  - if [ "$TEST_SUITE" == 'build-release' ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
+  - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
+  - python setup.py install
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
   - if [ -n "$COVERAGE" ] ; then make coverage_init ; fi
-  - python setup.py install
   - pwd && env && ./tools/oio-travis-tests.sh
   - if [ -n "$COVERAGE" ] ; then make coverage && gcovr -r . | cut -c1-63 && coverage report ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - echo "travis_fold:start:COVERAGE_Debug"
   - make coverage
   - gcovr -r . | cut -c1-63
+  - echo "travis_fold:end:COVERAGE_Debug"
   - coverage report
   - echo "travis_fold:start:BUILD_Release"
   - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,24 +12,22 @@ install:
   - pip install --upgrade -r all-requirements.txt
   - pip install --upgrade -r test-requirements.txt
   - pip install --upgrade zkpython
+env:
+  - TEST_SUITE=build-release
+  - TEST_SUITE=unit
+  - TEST_SUITE=single
+  - TEST_SUITE=worm
+  - TEST_SUITE=slave
+  - TEST_SUITE=repli
+  - TEST_SUITE=ec
 script:
-  - echo "travis_fold:start:BUILD_Debug"
-  - mkdir /tmp/oio
-  - source $HOME/oio/bin/activate
-  - cmake -DCMAKE_INSTALL_PREFIX="/tmp/oio" -DLD_LIBDIR="lib" -DCMAKE_BUILD_TYPE="Debug" -DSTACK_PROTECTOR=1 -DZK_LIBDIR="/usr/lib" -DZK_INCDIR="/usr/include/zookeeper" -DLIBRAIN_LIBDIR="/usr/lib" -DLIBRAIN_INCDIR="/usr/include" -DAPACHE2_LIBDIR="/usr/lib/apache2" -DAPACHE2_INCDIR="/usr/include/apache2" -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module -DENABLE_CODECOVERAGE=true .
-  - make all install
-  - make coverage_init
+  - export CMAKE_OPTS='-DCMAKE_INSTALL_PREFIX=/tmp/oio -DLD_LIBDIR=lib -DZK_LIBDIR=/usr/lib -DZK_INCDIR=/usr/include/zookeeper -DAPACHE2_LIBDIR=/usr/lib/apache2 -DAPACHE2_INCDIR=/usr/include/apache2 -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module'
+  - if [ -n "$COVERAGE" ] ; then export PYTHON_COVERAGE=1 ; fi
+  - mkdir /tmp/oio && source $HOME/oio/bin/activate
+  - if [ "$TEST_SUITE" == 'build-release' ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
+  - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
+  - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
+  - if [ -n "$COVERAGE" ] ; then make coverage_init ; fi
   - python setup.py install
-  - echo "travis_fold:end:BUILD_Debug"
-  - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib" PYTHON_COVERAGE=1
-  - ./tools/oio-travis-tests.sh
-  - echo "travis_fold:start:COVERAGE_Debug"
-  - make coverage
-  - gcovr -r . | cut -c1-63
-  - echo "travis_fold:end:COVERAGE_Debug"
-  - coverage report
-  - echo "travis_fold:start:BUILD_Release"
-  - make clean
-  - cmake -DCMAKE_INSTALL_PREFIX="/tmp/oio" -DLD_LIBDIR="lib" -DCMAKE_BUILD_TYPE="Release" -DZK_LIBDIR="/usr/lib" -DZK_INCDIR="/usr/include/zookeeper" -DAPACHE2_LIBDIR="/usr/lib/apache2" -DAPACHE2_INCDIR="/usr/include/apache2" -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module .
-  - make all
-  - echo "travis_fold:end:BUILD_Release"
+  - pwd && env && ./tools/oio-travis-tests.sh
+  - if [ -n "$COVERAGE" ] ; then make coverage && gcovr -r . | cut -c1-63 && coverage report ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ if ( ENABLE_CODECOVERAGE )
         set( CODECOV_HTMLOUTPUTDIR coverage_results )
     endif ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
 
-	set(CODECOV_PATTERN_TO_IGNORE "${CMAKE_BINARY_DIR}/metautils/asn1c/*")
+	set(CODECOV_PATTERN_TO_IGNORE
+		"'${CMAKE_BINARY_DIR}/metautils/asn1c/*.*'"
+		"'metautils/asn1c/*.*'")
 
     set(PYTHON_COVERAGE_FILE ${CMAKE_BINARY_DIR}/.python_coverage)
     set(PYTHON coverage run -p --source=${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ if ( ENABLE_CODECOVERAGE )
     if ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
         set( CODECOV_HTMLOUTPUTDIR coverage_results )
     endif ( NOT DEFINED CODECOV_HTMLOUTPUTDIR )
-    set(CODECOV_PATTERN_TO_IGNORE)
+
+	set(CODECOV_PATTERN_TO_IGNORE "${CMAKE_BINARY_DIR}/metautils/asn1c/*")
 
     set(PYTHON_COVERAGE_FILE ${CMAKE_BINARY_DIR}/.python_coverage)
     set(PYTHON coverage run -p --source=${CMAKE_SOURCE_DIR})
@@ -77,14 +78,18 @@ if ( ENABLE_CODECOVERAGE )
         add_definitions( -fprofile-arcs -ftest-coverage )
         link_libraries( gcov )
         set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} --coverage )
+
         add_custom_target( coverage_init
                            ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial
                            COMMAND coverage erase)
-        add_custom_target( coverage ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture
-                           COMMAND ${CODECOV_LCOV} --remove ${CODECOV_OUTPUTFILE} ${CODECOV_PATTERN_TO_IGNORE} --output ${CODECOV_OUTPUTFILE}
-                           COMMAND genhtml --ignore-errors source -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE}
+
+        add_custom_target( coverage
+						   ${CODECOV_LCOV} --base-directory ${CMAKE_SOURCE_DIR}  --directory ${CMAKE_BINARY_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture
+                           COMMAND ${CODECOV_LCOV} --output ${CODECOV_OUTPUTFILE} --remove ${CODECOV_OUTPUTFILE} ${CODECOV_PATTERN_TO_IGNORE}
+						   COMMAND genhtml --ignore-errors source -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE}
                            COMMAND coverage combine
                            COMMAND coverage html)
+
     endif ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
 endif (ENABLE_CODECOVERAGE )
 

--- a/meta0v2/CMakeLists.txt
+++ b/meta0v2/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(BEFORE
 		${CMAKE_SOURCE_DIR}
 		${CMAKE_BINARY_DIR}
 		${CMAKE_BINARY_DIR}/metautils/lib
+		${CMAKE_BINARY_DIR}/metautils/asn1c
 		${CMAKE_CURRENT_BINARY_DIR})
 
 include_directories(AFTER

--- a/meta2v2/CMakeLists.txt
+++ b/meta2v2/CMakeLists.txt
@@ -3,8 +3,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
 include_directories(BEFORE . ..
 		${CMAKE_CURRENT_BINARY_DIR}
-		${CMAKE_CURRENT_BINARY_DIR}/..
-		${CMAKE_CURRENT_BINARY_DIR}/../metautils/lib)
+		${CMAKE_BINARY_DIR}
+		${CMAKE_BINARY_DIR}/metautils/lib
+		${CMAKE_BINARY_DIR}/metautils/asn1c)
 
 include_directories(AFTER
 		${JSONC_INCLUDE_DIRS}

--- a/metautils/lib/CMakeLists.txt
+++ b/metautils/lib/CMakeLists.txt
@@ -2,6 +2,7 @@ add_definitions(-DG_LOG_DOMAIN="oio.utils")
 
 include_directories(BEFORE . ../..
 		${CMAKE_BINARY_DIR}
+		${CMAKE_BINARY_DIR}/metautils/asn1c
 		${CMAKE_CURRENT_BINARY_DIR})
 
 link_directories()
@@ -12,79 +13,138 @@ include_directories(AFTER
 
 add_custom_command(
 	OUTPUT
-		constraints.c constraints.h
-		constr_SET_OF.c constr_SET_OF.h
-		constr_SEQUENCE_OF.c constr_SEQUENCE_OF.h
-		constr_SEQUENCE.c constr_SEQUENCE.h
-		constr_TYPE.c constr_TYPE.h
-		constr_CHOICE.c constr_CHOICE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constraints.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constraints.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SET_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SET_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_TYPE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_TYPE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_CHOICE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_CHOICE.h
 
-		ber_tlv_tag.c ber_tlv_tag.h
-		ber_tlv_length.c ber_tlv_length.h
-		der_encoder.c der_encoder.h
-		ber_decoder.c ber_decoder.h
-		xer_support.c xer_support.h
-		xer_decoder.c xer_decoder.h
-		per_support.c per_support.h
-		per_encoder.c per_encoder.h
-		xer_encoder.c xer_encoder.h
-		per_decoder.c per_decoder.h
-		per_opentype.c
-		converter-sample.c
-		NativeEnumerated.c NativeEnumerated.h
-		NativeInteger.c NativeInteger.h
-		OCTET_STRING.c OCTET_STRING.h
-		PrintableString.c PrintableString.h
-		BIT_STRING.c BIT_STRING.h
-		BOOLEAN.c BOOLEAN.h
-		INTEGER.c INTEGER.h
-		ENUMERATED.c ENUMERATED.h
-		REAL.c REAL.h
-		NULL.c NULL.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_tag.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_tag.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_length.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_length.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/der_encoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/der_encoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_decoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_decoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_support.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_support.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_decoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_decoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_support.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_support.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_encoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_encoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_encoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_encoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_decoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_decoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_opentype.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_opentype.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/converter-sample.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeEnumerated.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeEnumerated.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeInteger.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeInteger.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/OCTET_STRING.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/OCTET_STRING.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/PrintableString.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/PrintableString.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BIT_STRING.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BIT_STRING.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BOOLEAN.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BOOLEAN.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/INTEGER.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/INTEGER.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ENUMERATED.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ENUMERATED.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/REAL.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/REAL.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NULL.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NULL.h
 
-		asn_SEQUENCE_OF.c asn_SEQUENCE_OF.h
-		asn_SET_OF.c asn_SET_OF.h
-		asn_codecs.h
-		asn_codecs_prim.c asn_codecs_prim.h
-		asn_internal.h
-		asn_system.h
-		asn_application.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SEQUENCE_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SEQUENCE_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SET_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SET_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs_prim.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs_prim.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_internal.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_system.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_application.h
 
-		AddrInfo.c AddrInfo.h
-		Message.c Message.h
-		Meta0Info.c Meta0Info.h
-		Meta0InfoSequence.c Meta0InfoSequence.h
-		NamespaceInfo.c NamespaceInfo.h
-		Parameter.c Parameter.h
-		ParameterSequence.c ParameterSequence.h
-		Score.c Score.h
-		ServiceInfo.c ServiceInfo.h
-		ServiceInfoSequence.c ServiceInfoSequence.h
-		ServiceTag.c ServiceTag.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/AddrInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/AddrInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Message.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Message.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0Info.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0Info.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0InfoSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0InfoSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NamespaceInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NamespaceInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Parameter.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Parameter.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ParameterSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ParameterSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Score.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Score.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfoSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfoSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceTag.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceTag.h
 
-		RowFieldSequence.c RowFieldSequence.h
-		RowFieldValue.c RowFieldValue.h
-		RowFieldType.c RowFieldType.h
-		RowField.c RowField.h
-		Row.c Row.h
-		RowSet.c RowSet.h
-		RowName.c RowName.h
-		TableHeader.c TableHeader.h
-		Table.c Table.h
-		TableSequence.c TableSequence.h
-		TableVersion.c TableVersion.h
-		BaseVersion.c BaseVersion.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldValue.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldValue.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldType.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldType.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowField.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowField.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Row.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Row.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowSet.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowSet.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowName.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowName.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableHeader.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableHeader.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Table.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Table.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableVersion.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableVersion.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BaseVersion.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BaseVersion.h
 
-		M2V2BeanSequence.c M2V2BeanSequence.h
-		M2V2Bean.c M2V2Bean.h
-		M2V2Alias.c M2V2Alias.h
-		M2V2Chunk.c M2V2Chunk.h
-		M2V2ContentHeader.c M2V2ContentHeader.h
-		M2V2Property.c M2V2Property.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2BeanSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2BeanSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Bean.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Bean.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Alias.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Alias.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Chunk.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Chunk.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2ContentHeader.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2ContentHeader.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Property.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Property.h
 
 	PRE_BUILD
 	COMMAND
-		${ASN1C_EXECUTABLE}
+	mkdir -p ${CMAKE_BINARY_DIR}/metautils/asn1c && cd ${CMAKE_BINARY_DIR}/metautils/asn1c && ${ASN1C_EXECUTABLE}
 	ARGS
 		${ASN1C_EXE_OPTS}
 		-fcompound-names
@@ -169,129 +229,130 @@ add_library(metautils SHARED
 		${CMAKE_CURRENT_BINARY_DIR}/common_variables.c
 		${CMAKE_CURRENT_BINARY_DIR}/common_variables.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/constraints.c
-		${CMAKE_CURRENT_BINARY_DIR}/constraints.h
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SET_OF.c
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SET_OF.h
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SEQUENCE_OF.c
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SEQUENCE_OF.h
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SEQUENCE.c
-		${CMAKE_CURRENT_BINARY_DIR}/constr_SEQUENCE.h
-		${CMAKE_CURRENT_BINARY_DIR}/constr_TYPE.c
-		${CMAKE_CURRENT_BINARY_DIR}/constr_TYPE.h
-		${CMAKE_CURRENT_BINARY_DIR}/constr_CHOICE.c
-		${CMAKE_CURRENT_BINARY_DIR}/constr_CHOICE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constraints.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constraints.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SET_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SET_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_SEQUENCE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_TYPE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_TYPE.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_CHOICE.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/constr_CHOICE.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/ber_tlv_tag.c
-		${CMAKE_CURRENT_BINARY_DIR}/ber_tlv_tag.h
-		${CMAKE_CURRENT_BINARY_DIR}/ber_tlv_length.c
-		${CMAKE_CURRENT_BINARY_DIR}/ber_tlv_length.h
-		${CMAKE_CURRENT_BINARY_DIR}/der_encoder.c
-		${CMAKE_CURRENT_BINARY_DIR}/der_encoder.h
-		${CMAKE_CURRENT_BINARY_DIR}/ber_decoder.c
-		${CMAKE_CURRENT_BINARY_DIR}/ber_decoder.h
-		${CMAKE_CURRENT_BINARY_DIR}/xer_support.c
-		${CMAKE_CURRENT_BINARY_DIR}/xer_support.h
-		${CMAKE_CURRENT_BINARY_DIR}/xer_decoder.c
-		${CMAKE_CURRENT_BINARY_DIR}/xer_decoder.h
-		${CMAKE_CURRENT_BINARY_DIR}/per_opentype.c
-		${CMAKE_CURRENT_BINARY_DIR}/per_support.c
-		${CMAKE_CURRENT_BINARY_DIR}/per_support.h
-		${CMAKE_CURRENT_BINARY_DIR}/per_encoder.c
-		${CMAKE_CURRENT_BINARY_DIR}/per_encoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_tag.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_tag.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_length.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_tlv_length.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/der_encoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/der_encoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_decoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ber_decoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_support.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_support.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_decoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/xer_decoder.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_opentype.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_opentype.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_support.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_support.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_encoder.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/per_encoder.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/NativeEnumerated.c
-		${CMAKE_CURRENT_BINARY_DIR}/NativeEnumerated.h
-		${CMAKE_CURRENT_BINARY_DIR}/NativeInteger.c
-		${CMAKE_CURRENT_BINARY_DIR}/NativeInteger.h
-		${CMAKE_CURRENT_BINARY_DIR}/OCTET_STRING.c
-		${CMAKE_CURRENT_BINARY_DIR}/OCTET_STRING.h
-		${CMAKE_CURRENT_BINARY_DIR}/PrintableString.c
-		${CMAKE_CURRENT_BINARY_DIR}/PrintableString.h
-		${CMAKE_CURRENT_BINARY_DIR}/BIT_STRING.c
-		${CMAKE_CURRENT_BINARY_DIR}/BIT_STRING.h
-		${CMAKE_CURRENT_BINARY_DIR}/BOOLEAN.c
-		${CMAKE_CURRENT_BINARY_DIR}/BOOLEAN.h
-		${CMAKE_CURRENT_BINARY_DIR}/INTEGER.c
-		${CMAKE_CURRENT_BINARY_DIR}/INTEGER.h
-		${CMAKE_CURRENT_BINARY_DIR}/ENUMERATED.c
-		${CMAKE_CURRENT_BINARY_DIR}/ENUMERATED.h
-		${CMAKE_CURRENT_BINARY_DIR}/REAL.c
-		${CMAKE_CURRENT_BINARY_DIR}/REAL.h
-		${CMAKE_CURRENT_BINARY_DIR}/NULL.c
-		${CMAKE_CURRENT_BINARY_DIR}/NULL.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeEnumerated.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeEnumerated.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeInteger.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NativeInteger.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/OCTET_STRING.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/OCTET_STRING.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/PrintableString.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/PrintableString.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BIT_STRING.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BIT_STRING.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BOOLEAN.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BOOLEAN.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/INTEGER.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/INTEGER.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ENUMERATED.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ENUMERATED.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/REAL.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/REAL.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NULL.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NULL.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/asn_SEQUENCE_OF.c
-		${CMAKE_CURRENT_BINARY_DIR}/asn_SEQUENCE_OF.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_SET_OF.c
-		${CMAKE_CURRENT_BINARY_DIR}/asn_SET_OF.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_codecs.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_codecs_prim.c
-		${CMAKE_CURRENT_BINARY_DIR}/asn_codecs_prim.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_internal.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_application.h
-		${CMAKE_CURRENT_BINARY_DIR}/asn_system.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SEQUENCE_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SEQUENCE_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SET_OF.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_SET_OF.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs_prim.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_codecs_prim.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_internal.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_application.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/asn_system.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/AddrInfo.c
-		${CMAKE_CURRENT_BINARY_DIR}/AddrInfo.h
-		${CMAKE_CURRENT_BINARY_DIR}/Message.c
-		${CMAKE_CURRENT_BINARY_DIR}/Message.h
-		${CMAKE_CURRENT_BINARY_DIR}/Meta0Info.c
-		${CMAKE_CURRENT_BINARY_DIR}/Meta0Info.h
-		${CMAKE_CURRENT_BINARY_DIR}/Meta0InfoSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/Meta0InfoSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/NamespaceInfo.c
-		${CMAKE_CURRENT_BINARY_DIR}/NamespaceInfo.h
-		${CMAKE_CURRENT_BINARY_DIR}/Parameter.c
-		${CMAKE_CURRENT_BINARY_DIR}/Parameter.h
-		${CMAKE_CURRENT_BINARY_DIR}/ParameterSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/ParameterSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/Score.c
-		${CMAKE_CURRENT_BINARY_DIR}/Score.h
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceInfo.c
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceInfo.h
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceInfoSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceInfoSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceTag.c
-		${CMAKE_CURRENT_BINARY_DIR}/ServiceTag.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/AddrInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/AddrInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Message.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Message.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0Info.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0Info.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0InfoSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Meta0InfoSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NamespaceInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/NamespaceInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Parameter.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Parameter.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ParameterSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ParameterSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Score.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Score.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfo.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfo.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfoSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceInfoSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceTag.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/ServiceTag.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldValue.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldValue.h
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldType.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowFieldType.h
-		${CMAKE_CURRENT_BINARY_DIR}/RowField.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowField.h
-		${CMAKE_CURRENT_BINARY_DIR}/Row.c
-		${CMAKE_CURRENT_BINARY_DIR}/Row.h
-		${CMAKE_CURRENT_BINARY_DIR}/RowSet.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowSet.h
-		${CMAKE_CURRENT_BINARY_DIR}/RowName.c
-		${CMAKE_CURRENT_BINARY_DIR}/RowName.h
-		${CMAKE_CURRENT_BINARY_DIR}/TableHeader.c
-		${CMAKE_CURRENT_BINARY_DIR}/TableHeader.h
-		${CMAKE_CURRENT_BINARY_DIR}/Table.c
-		${CMAKE_CURRENT_BINARY_DIR}/Table.h
-		${CMAKE_CURRENT_BINARY_DIR}/TableSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/TableSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/TableVersion.c
-		${CMAKE_CURRENT_BINARY_DIR}/TableVersion.h
-		${CMAKE_CURRENT_BINARY_DIR}/BaseVersion.c
-		${CMAKE_CURRENT_BINARY_DIR}/BaseVersion.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldValue.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldValue.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldType.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowFieldType.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowField.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowField.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Row.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Row.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowSet.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowSet.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowName.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/RowName.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableHeader.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableHeader.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Table.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/Table.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableVersion.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/TableVersion.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BaseVersion.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/BaseVersion.h
 
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2BeanSequence.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2BeanSequence.c
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Bean.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Bean.c
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Alias.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Alias.c
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Chunk.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Chunk.c
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2ContentHeader.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2ContentHeader.c
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Property.h
-		${CMAKE_CURRENT_BINARY_DIR}/M2V2Property.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2BeanSequence.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2BeanSequence.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Bean.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Bean.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Alias.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Alias.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Chunk.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Chunk.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2ContentHeader.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2ContentHeader.c
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Property.h
+		${CMAKE_BINARY_DIR}/metautils/asn1c/M2V2Property.c
 
 		comm_message.c
 		comm_converter.c

--- a/metautils/lib/codec.h
+++ b/metautils/lib/codec.h
@@ -22,41 +22,36 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * as necessary (with the risk of stack smashing). */
 #define ASN1C_MAX_STACK 0
 
-#include <metautils/lib/asn_codecs.h>
-#include <metautils/lib/asn_SET_OF.h>
-#include <metautils/lib/asn_SEQUENCE_OF.h>
-
-#include <metautils/lib/RowFieldValue.h>
-#include <metautils/lib/RowField.h>
-#include <metautils/lib/RowFieldSequence.h>
-#include <metautils/lib/Row.h>
-#include <metautils/lib/RowSet.h>
-#include <metautils/lib/RowName.h>
-#include <metautils/lib/TableHeader.h>
-#include <metautils/lib/Table.h>
-#include <metautils/lib/TableSequence.h>
-
-#include <metautils/lib/M2V2Bean.h>
-#include <metautils/lib/M2V2BeanSequence.h>
-#include <metautils/lib/M2V2Alias.h>
-#include <metautils/lib/M2V2ContentHeader.h>
-#include <metautils/lib/M2V2Property.h>
-
-#include <metautils/lib/AddrInfo.h>
-#include <metautils/lib/Meta0Info.h>
-#include <metautils/lib/Meta0InfoSequence.h>
-#include <metautils/lib/NamespaceInfo.h>
-#include <metautils/lib/Score.h>
-#include <metautils/lib/ServiceTag.h>
-#include <metautils/lib/ServiceInfo.h>
-#include <metautils/lib/ServiceInfoSequence.h>
-
-#include <metautils/lib/Parameter.h>
-#include <metautils/lib/ParameterSequence.h>
-#include <metautils/lib/Message.h>
-
-#include <metautils/lib/der_encoder.h>
-#include <metautils/lib/ber_decoder.h>
+#include <metautils/asn1c/asn_codecs.h>
+#include <metautils/asn1c/asn_SET_OF.h>
+#include <metautils/asn1c/asn_SEQUENCE_OF.h>
+#include <metautils/asn1c/RowFieldValue.h>
+#include <metautils/asn1c/RowField.h>
+#include <metautils/asn1c/RowFieldSequence.h>
+#include <metautils/asn1c/Row.h>
+#include <metautils/asn1c/RowSet.h>
+#include <metautils/asn1c/RowName.h>
+#include <metautils/asn1c/TableHeader.h>
+#include <metautils/asn1c/Table.h>
+#include <metautils/asn1c/TableSequence.h>
+#include <metautils/asn1c/M2V2Bean.h>
+#include <metautils/asn1c/M2V2BeanSequence.h>
+#include <metautils/asn1c/M2V2Alias.h>
+#include <metautils/asn1c/M2V2ContentHeader.h>
+#include <metautils/asn1c/M2V2Property.h>
+#include <metautils/asn1c/AddrInfo.h>
+#include <metautils/asn1c/Meta0Info.h>
+#include <metautils/asn1c/Meta0InfoSequence.h>
+#include <metautils/asn1c/NamespaceInfo.h>
+#include <metautils/asn1c/Score.h>
+#include <metautils/asn1c/ServiceTag.h>
+#include <metautils/asn1c/ServiceInfo.h>
+#include <metautils/asn1c/ServiceInfoSequence.h>
+#include <metautils/asn1c/Parameter.h>
+#include <metautils/asn1c/ParameterSequence.h>
+#include <metautils/asn1c/Message.h>
+#include <metautils/asn1c/der_encoder.h>
+#include <metautils/asn1c/ber_decoder.h>
 
 /* Give a pretty prefixed name to the ugly unprefixed macros from asn1c */
 #define ASN1C_CALLOC(N,S)  CALLOC(N,S)

--- a/sqliterepo/CMakeLists.txt
+++ b/sqliterepo/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(BEFORE
 		${CMAKE_CURRENT_SOURCE_DIR}
 		${CMAKE_SOURCE_DIR}
 		${CMAKE_BINARY_DIR}
+		${CMAKE_BINARY_DIR}/metautils/asn1c
 		${CMAKE_BINARY_DIR}/metautils/lib
 		${CMAKE_CURRENT_BINARY_DIR})
 

--- a/sqlx/CMakeLists.txt
+++ b/sqlx/CMakeLists.txt
@@ -3,7 +3,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
 include_directories(BEFORE . ..
 		${CMAKE_CURRENT_BINARY_DIR}/..
-		${CMAKE_CURRENT_BINARY_DIR}/../metautils/lib)
+		${CMAKE_BINARY_DIR}/metautils/asn1c
+		${CMAKE_BINARY_DIR}/metautils/lib)
 
 include_directories(AFTER
 		${ZK_INCLUDE_DIRS}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,13 @@
 add_definitions(-DG_LOG_DOMAIN="oio.tests.unit")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
-include_directories(BEFORE . ../..
-		${CMAKE_CURRENT_BINARY_DIR}/../..
-		${CMAKE_CURRENT_BINARY_DIR}/../../metautils/lib
+include_directories(BEFORE
+		${CMAKE_SOURCE_DIR}
+		${CMAKE_BINARY_DIR}
+		${CMAKE_BINARY_DIR}/metautils/lib
+		${CMAKE_BINARY_DIR}/metautils/asn1c)
+
+include_directories(ATER
 		${ZK_INCLUDE_DIRS}
 		${SQLITE3_INCLUDE_DIRS})
 


### PR DESCRIPTION
Bring the Travis execution from 22 minutes to 9 minutes.

* Split each test suite into a specific Travis job
* Add one specific test suite for code coverage, that is not systematically scheduled because it sequentially run all the test suites
* Remove the log folding because this is not needed anymore
