### PR TITLE
Download container as archive

### DIFF
--- a/etc/apache2/streaming-apache.conf-sample
+++ b/etc/apache2/streaming-apache.conf-sample
@@ -1,0 +1,31 @@
+LoadModule mpm_worker_module /usr/lib/apache2/modules/mod_mpm_worker.so
+LoadModule authz_core_module /usr/lib/apache2/modules/mod_authz_core.so
+LoadModule wsgi_module /usr/lib/apache2/modules/mod_wsgi.so
+
+<IfModule !log_config_module>
+  LoadModule log_config_module /usr/lib/apache2/modules/mod_log_config.so
+</IfModule>
+
+# admin
+Listen 127.0.0.1:5001
+ServerName localhost
+PidFile /var/run/oio/sds/OPENIO-admin-1.pid
+
+User openio
+Group openio
+WSGIDaemonProcess ecd-1 processes=2 threads=1 user=openio group=openio
+WSGIProcessGroup ecd-1
+WSGIApplicationGroup ecd-1
+WSGIScriptAlias / /etc/oio/sds/OPENIO/conf/admin.wsgi
+WSGISocketPrefix /var/run/oio/sds/run
+WSGIChunkedRequest On
+LimitRequestFields 200
+
+LogFormat "%h %l %t \"%r\" %>s %b %D" log/common
+ErrorLog /var/log/oio/sds/OPENIO/logs/admin.log
+LogLevel debug
+CustomLog /var/log/oio/sds/OPENIO/sds/logs/admin.log log/common
+
+<VirtualHost 127.0.0.1:5001>
+# Leave Empty
+</VirtualHost>

--- a/etc/apache2/streaming-apache.conf-sample
+++ b/etc/apache2/streaming-apache.conf-sample
@@ -13,9 +13,8 @@ PidFile /var/run/oio/sds/OPENIO-admin-1.pid
 
 User openio
 Group openio
-WSGIDaemonProcess ecd-1 processes=2 threads=1 user=openio group=openio
-WSGIProcessGroup ecd-1
-WSGIApplicationGroup ecd-1
+WSGIDaemonProcess admin-1 processes=2 threads=1 user=openio group=openio
+WSGIApplicationGroup admin-1
 WSGIScriptAlias / /etc/oio/sds/OPENIO/conf/admin.wsgi
 WSGISocketPrefix /var/run/oio/sds/run
 WSGIChunkedRequest On

--- a/etc/wsgi/admin.wsgi-sample
+++ b/etc/wsgi/admin.wsgi-sample
@@ -1,0 +1,2 @@
+from oio.container_streaming.app import create_app
+application = create_app()

--- a/oio/container_streaming/app.py
+++ b/oio/container_streaming/app.py
@@ -211,7 +211,6 @@ class TarStreaming(object):
             self.logger.error("data written does not match blocksize")
         return mem
 
-
     def read(self, size=-1):
         # streaming file by file
         # Is there API to stream data from OIO SDK (to avoid copy ?)

--- a/oio/container_streaming/streaming.py
+++ b/oio/container_streaming/streaming.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from io import BytesIO
+import math
+import re
+from tarfile import TarInfo, REGTYPE, NUL, PAX_FORMAT, BLOCKSIZE
+import os
+import xattr
+
+from werkzeug.wrappers import Request, Response
+
+from oio import ObjectStorageApi
+
+EXP = re.compile(r"^bytes=(\d+)-(\d+)$")
+
+# https://www.gnu.org/software/tar/manual/html_node/Standard.html
+# TODO: check how thoses functions store ACL / XATTR
+# https://www.cyberciti.biz/faq/linux-tar-rsync-preserving-acls-selinux-contexts/
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+# PAX/POSIX TAR: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html
+
+# FIXME move parameters somewhere (URL, Header, ... ?)
+NS = "OPENIO"
+ACCOUNT = "AUTH_demo"
+PROXY_URL = "http://127.0.0.1:6000"
+
+class ContainerStreaming(object):
+    def __init__(self, conf):
+        self.conf = conf
+        self.conn = ObjectStorageApi(NS)
+
+    def generate_oio_tarinfo_entry(self, container, name):
+        """ return tuple (buf, number of blocks, filesize) """
+        entry = self.conn.object_get_properties(ACCOUNT, container, name)
+
+        tarinfo = TarInfo()
+        tarinfo.name = entry['name']
+        tarinfo.mode = 0o700 # ?
+        tarinfo.uid = 0
+        tarinfo.gid = 0
+        tarinfo.size = int(entry['length'])
+        tarinfo.mtime = entry['ctime'] # should be mtime
+        tarinfo.type = REGTYPE
+        tarinfo.linkname = ""
+
+        # XATTR
+        # do we have to store basic properties like policy, mime_type, hash, ... ?
+        properties = entry['properties']
+        for key, val in properties.items():
+            assert isinstance(val, basestring), "Invalid type detected for %s:%s:%s" % (
+                container, name, key)
+            tarinfo.pax_headers["SCHILY.xattr.user." + key] = val
+
+        # PAX_FORMAT should be used only if xattr was found
+        buf = tarinfo.tobuf(format=PAX_FORMAT)
+        blocks, remainder = divmod(len(buf), BLOCKSIZE)
+
+        assert remainder == 0, "Invalid size of generated TarInfo"
+        return buf, blocks, tarinfo.size
+
+    def generate_oio_map(self, container):
+        objs = self.conn.object_list(ACCOUNT, container)
+        map_objs = []
+        start_block = 0
+        for obj in sorted(objs['objects']):
+            # FIXME should also backup deleted object ?
+            if obj['deleted']:
+                continue
+            _, entry_blocks, size = self.generate_oio_tarinfo_entry(container, obj['name'])
+            entry = {
+                'name': obj['name'],
+                'size': size,
+                'block': entry_blocks + int(math.ceil(size / float(BLOCKSIZE))),
+                'start_block': start_block,
+            }
+            start_block += entry['block']
+            map_objs.append(entry)
+        return map_objs
+
+    def create_tar_oio_stream(self, container, name, blocks):
+        mem = BytesIO()
+
+        # FIXME, we could add number of blocks reserved for the header in generate_oio_map to avoid
+        # doing useless network call if not needed
+        buf, entry_blocks, size = self.generate_oio_tarinfo_entry(container, name)
+
+        for bl in xrange(entry_blocks):
+            if bl in blocks:
+                mem.write(buf[bl * BLOCKSIZE : bl * BLOCKSIZE + BLOCKSIZE])
+                blocks.remove(bl)
+
+        if len(blocks) == 0:
+            mem.seek(0)
+            return mem.read()
+
+        # for sanity, shift blocks
+        blocks = [v-entry_blocks for v in blocks]
+
+        # compute needed padding data
+        nb_blocks, remainder = divmod(size, BLOCKSIZE)
+
+        # FIXME: we should optimize to read in one operation all needed blocks
+        for b in blocks[:]:
+            if b < nb_blocks:
+                _, data = self.conn.object_fetch(ACCOUNT, container, name, ranges=[(b*BLOCKSIZE, b*BLOCKSIZE + BLOCKSIZE -1)])
+                mem.write("".join(data))
+                blocks.remove(b)
+
+        if remainder > 0 and nb_blocks in blocks:
+            if nb_blocks in blocks:
+                _, data = self.conn.object_fetch(ACCOUNT, container, name, ranges=[(nb_blocks*BLOCKSIZE, nb_blocks*BLOCKSIZE + remainder - 1)])
+                mem.write("".join(data))
+                # add padding
+                mem.write(NUL * (BLOCKSIZE - remainder))
+                blocks.remove(nb_blocks)
+
+        assert len(blocks) == 0, "Blocks was not all consumed"
+        assert mem.tell() > 0, "No data written"
+        mem.seek(0)
+        return mem.read()
+
+    def wsgi_app(self, environ, start_response):
+        request = Request(environ)
+        response = self.dispatch_request(request)
+        return response(environ, start_response)
+
+    def __call__(self, environ, start_response):
+        return self.wsgi_app(environ, start_response)
+
+    def _do_head(self, req):
+        container = req.path.strip('/')
+
+        results = self.generate_oio_map(container)
+        hdrs = {
+            'X-Blocks': sum([i['block'] for i in results]),
+            'Content-Length': sum([i['block'] for i in results]) * BLOCKSIZE,
+            'Accept-Ranges': 'bytes',
+            'Content-Type': 'application/tar'
+        }
+        return Response(headers=hdrs, status=200)
+
+    def _do_get(self, req):
+        container = req.path.strip('/')
+
+        results = self.generate_oio_map(container)
+        blocks = sum([i['block'] for i in results])
+        length = blocks * BLOCKSIZE
+        response = Response()
+        response.headers['Accept-Ranges'] = 'bytes'
+        response.headers['Content-Type'] = 'application/tar'
+
+        if 'Range' not in req.headers:
+            response.status_code = 200
+            response.headers['Content-Length'] = length
+
+            for val in results:
+                response.data += self.create_tar_oio_stream(container, val['name'], range(val['block']))
+            return response
+
+        # accept only single part range
+        val = req.headers['Range']
+        m = EXP.match(val)
+        if m is None:
+            response.status_code = 416
+            return response
+        start = int(m.group(1))
+        end = int(m.group(2))
+        if start >= end:
+            response.status_code = 416
+            return response
+
+        def check_range(value):
+            block, remainder = divmod(value, BLOCKSIZE)
+            if remainder or block < 0 or block > blocks:
+                return -1
+            return block
+
+        block_start = check_range(start)
+        block_end = check_range(end + 1) # Check Range RFC
+        if block_start < 0 or block_end < 0:
+            response.status_code = 416
+            return response
+
+        block_to_read = block_start
+        blocks_to_read = list(xrange(block_start, block_end))
+
+        response.status_code = 206
+        response.headers['Content-Length'] = end - start + 1
+        response.headers['Content-Range'] = 'bytes %d-%d/%d' % (start, end, length)
+
+        # FIXME: rework this part to allow several parts to be downloaded
+        for val in reversed(results):
+            if block_to_read < val['start_block']:
+                continue
+            block_to_read -= val['start_block']
+            # response.data += create_tar_file_stream(val['name'], [block_to_read])
+            response.data += self.create_tar_oio_stream(container, val['name'], [block_to_read])
+            break
+        return response
+
+    def dispatch_request(self, req):
+        if req.method == 'HEAD':
+            return self._do_head(req)
+            # Response(headers={'Content-Length': 333})
+
+        if req.method == 'GET':
+            return self._do_get(req)
+
+        return Response("Not supported", 405)
+
+def create_app(conf=None):
+    conf = {} if conf is None else conf
+    app = ContainerStreaming(conf)
+    return app
+
+if __name__ == "__main__":
+    #run_server(port=8081)
+    from werkzeug.serving import run_simple
+    run_simple('127.0.0.1', 5001, create_app(),
+               use_debugger=True, use_reloader=True)

--- a/tests/functional/container_streaming/test_container_streaming.py
+++ b/tests/functional/container_streaming/test_container_streaming.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+import random
+import tarfile
+from io import BytesIO
+import itertools
+
+import requests
+from oio import ObjectStorageApi
+from tests.utils import BaseTestCase
+
+
+def random_container(pfx=""):
+    return '{0}content-{1}'.format(pfx, random.randint(0, 65536))
+
+def gen_data(size):
+    with open("/dev/urandom", "rb") as rand:
+        return rand.read(size)
+
+def gen_names():
+    index = 0
+    for c0 in "01234567":
+        for c1 in "01234567":
+            i, index = index, index + 1
+            yield i, '{0}/{1}/plop'.format(c0, c1)
+
+
+# class TestContainerDownload(TestCase):
+class TestContainerDownload(BaseTestCase):
+
+    def setUp(self):
+        super(TestContainerDownload, self).setUp()
+        # FIXME: should we use direct API from BaseTestCase or still container.client ?
+        self.conn = ObjectStorageApi(self.ns)
+        self._streaming = 'http://' + self.get_service_url('admin')[2] + '/'
+        self._cnt = random_container()
+        self._uri = self._streaming + self._cnt
+        self._data = {}
+        self.conn.container_create(self.account, self._cnt)
+        self.raw = ""
+
+    def tearDown(self):
+        for name in self._data:
+            self.conn.object_delete(self.account, self._cnt, name)
+        self.conn.container_delete(self.account, self._cnt)
+        super(TestContainerDownload, self).tearDown()
+
+    def _create_data(self):
+        for idx, name in itertools.islice(gen_names(), 5):
+            data = gen_data(513 * idx)
+            self._data[name] = data
+            self.conn.object_create(self.account, self._cnt, obj_name=name, data=data)
+
+    def test_missing_container(self):
+        ret = requests.get(self._streaming + random_container("ms-"))
+        self.assertEqual(ret.status_code, 404)
+
+    def test_invalid_url(self):
+        ret = requests.get(self._streaming)
+        self.assertEqual(ret.status_code, 404)
+
+        ret = requests.head(self._streaming + random_container('inv')
+                            + '/' +  random_container('inv'))
+        self.assertEqual(ret.status_code, 404)
+
+    def test_download_empty_container(self):
+        ret = requests.get(self._uri)
+        self.assertEqual(ret.status_code, 204)
+
+    def test_simple_download(self):
+        self._create_data()
+
+        ret = requests.get(self._uri)
+        self.assertGreater(len(ret.content), 0)
+        self.assertEqual(ret.status_code, 200)
+        self.raw = ret.content
+
+        raw = BytesIO(ret.content)
+        tar = tarfile.open(fileobj=raw)
+        info = self._data.keys()
+        for entry in tar.getnames():
+            self.assertIn(entry, info)
+
+            tmp = tar.extractfile(entry)
+            self.assertEqual(self._data[entry], tmp.read())
+
+            info.remove(entry)
+
+        self.assertEqual(len(info), 0)
+
+    def test_download_per_range(self):
+        self._create_data()
+
+        org = requests.get(self._uri)
+
+        data = []
+        for idx in xrange(0, int(org.headers['content-length']), 512):
+            ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' % (idx, idx+511)})
+            data.append(ret.content)
+
+        data = "".join(data)
+        self.assertGreater(len(data), 0)
+        self.assertEqual(org.content, data)
+
+    def test_invalid_range(self):
+        self._create_data()
+
+        ranges = ((-512, 511), (512, 0), (1, 3), (98888, 99999))
+        for start, end in ranges:
+            ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' % (start, end)})
+            self.assertEqual(ret.status_code, 416, "for range %d-%d" % (start, end))
+
+        ret = requests.get(self._uri, headers={'Range': 'bytes=0-511, 512-1023'})
+        self.assertEqual(ret.status_code, 416)

--- a/tests/functional/container_streaming/test_container_streaming.py
+++ b/tests/functional/container_streaming/test_container_streaming.py
@@ -33,7 +33,7 @@ class TestContainerDownload(BaseTestCase):
         self.conn = ObjectStorageApi(self.ns)
         self._streaming = 'http://' + self.get_service_url('admin')[2] + '/'
         self._cnt = random_container()
-        self._uri = self._streaming + self._cnt
+        self._uri = self._streaming + 'v1.0/dump?acct=' + self.account + '&ref=' + self._cnt
         self._data = {}
         self.conn.container_create(self.account, self._cnt)
         self.raw = ""
@@ -107,7 +107,7 @@ class TestContainerDownload(BaseTestCase):
         ranges = ((-512, 511), (512, 0), (1, 3), (98888, 99999))
         for start, end in ranges:
             ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' % (start, end)})
-            self.assertEqual(ret.status_code, 416, "for range %d-%d" % (start, end))
+            self.assertEqual(ret.status_code, 416, "Invalid error code for range %d-%d" % (start, end))
 
         ret = requests.get(self._uri, headers={'Range': 'bytes=0-511, 512-1023'})
         self.assertEqual(ret.status_code, 416)


### PR DESCRIPTION
Allow to download a container with support of HTTP Ranges

Limitations:
- Ranges must be aligned with 512-byte boundaries
- no support of multipart range
- Container is not yet frozen

Still missing:
- support Head with Range
- include versions of object
- include deleted object

Example:
```
$ s3cmd mb s3://test1
$ s3cmd put /etc/passwd s3://test1
$ s3cmd --add-header=UserAdd:value modify s3://test1/passwd

$ ./streaming.py
$ curl -I http://localhost:5001/test1
HTTP/1.0 200 OK
Content-Length: 7168
X-Blocks: 14
Content-Type: application/tar
Accept-Ranges: bytes
Server: Werkzeug/0.12.1 Python/2.7.13
Date: Wed, 07 Jun 2017 14:59:25 GMT

$ curl http://localhost:5001/test1 -H "Range: bytes=0-3583" > a.tar
$ curl http://localhost:5001/test1 -H "Range: bytes=3584-7167" >> a.tar
$ tar --xattrs -xf a.tar
$ xattr -l passwd
```