### PR TITLE
Check validity of oio_url_s instance

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -258,7 +258,10 @@ oio_ext_set_admin (const gboolean admin)
 /* -------------------------------------------------------------------------- */
 
 # ifdef HAVE_BACKTRACE
-#warn "Backtrace enabled"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcpp"
+#warning "Backtrace enabled"
+#pragma GCC diagnostic pop
 #include <execinfo.h>
 #define STACK_MAX 8
 

--- a/core/oiourl.h
+++ b/core/oiourl.h
@@ -128,6 +128,15 @@ int oio_url_has_fq_path (const struct oio_url_s *u);
 /** Returns wether all the mandatory components for a container are present */
 int oio_url_has_fq_container (const struct oio_url_s *u);
 
+/** Validate contains of oio_url
+ *
+ * @param u the URL
+ * @param n the namespace (optional)
+ * @param e will contains faulty field
+ * @return true if valid
+*/
+gboolean oio_url_check(const struct oio_url_s *u, const char *n, const gchar **e);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/url.c
+++ b/core/url.c
@@ -506,3 +506,29 @@ oio_url_to_json (GString *out, struct oio_url_s *u)
 	}
 }
 
+gboolean
+oio_url_check(const struct oio_url_s *u, const char *namespace, const gchar **err )
+{
+#define _ERR(v)  \
+    if (err) { \
+        *err = v; \
+    }
+
+    _ERR(NULL);
+    if (namespace && u->ns && strcmp(namespace, u->ns)) {
+        _ERR("namespace");
+        return 0;
+    }
+    if (u->version && !oio_str_is_number(u->version, NULL)) {
+        _ERR("version");
+        return 0;
+    }
+
+    if (u->path && !g_utf8_validate(u->path, -1, NULL)) {
+        _ERR("path");
+        return 0;
+    }
+    return 1;
+
+#undef _ERR
+}

--- a/meta1v2/meta1_gridd_dispatcher.c
+++ b/meta1v2/meta1_gridd_dispatcher.c
@@ -50,9 +50,8 @@ static GByteArray *encode_and_clean(GByteArray* (*e)(gchar**), gchar **pv) {
 
 static gboolean
 meta1_dispatch_v2_USERCREATE(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
 	gsize length = 0;
@@ -72,15 +71,13 @@ meta1_dispatch_v2_USERCREATE(struct gridd_reply_ctx_s *reply,
 	else
 		reply->send_reply(CODE_FINAL_OK, "Created");
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_USERDESTROY(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gboolean force = metautils_message_extract_flag(reply->request, NAME_MSGKEY_FORCE, FALSE);
 	reply->subject("%s|%s|%d", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID), force);
 
@@ -90,15 +87,13 @@ meta1_dispatch_v2_USERDESTROY(struct gridd_reply_ctx_s *reply,
 	else
 		reply->send_reply(CODE_FINAL_OK, "OK");
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_USERINFO(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
 	gchar **info = NULL;
@@ -111,15 +106,13 @@ meta1_dispatch_v2_USERINFO(struct gridd_reply_ctx_s *reply,
 		reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_LINK(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gchar *srvtype = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_TYPENAME);
 	gboolean dryrun = metautils_message_extract_flag(reply->request, NAME_MSGKEY_DRYRUN, FALSE);
 	gboolean autocreate = metautils_message_extract_flag(reply->request, NAME_MSGKEY_AUTOCREATE, FALSE);
@@ -135,16 +128,14 @@ meta1_dispatch_v2_SRV_LINK(struct gridd_reply_ctx_s *reply,
 		reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean(url);
 	g_free0 (srvtype);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_RENEW(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gboolean ac = metautils_message_extract_flag(reply->request, NAME_MSGKEY_AUTOCREATE, FALSE);
 	gboolean dryrun = metautils_message_extract_flag(reply->request, NAME_MSGKEY_DRYRUN, FALSE);
 	gchar *srvtype = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_TYPENAME);
@@ -160,16 +151,14 @@ meta1_dispatch_v2_SRV_RENEW(struct gridd_reply_ctx_s *reply,
 		reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean(url);
 	g_free0 (srvtype);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_FORCE(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gboolean ac = metautils_message_extract_flag (reply->request, NAME_MSGKEY_AUTOCREATE, FALSE);
 	gboolean force = metautils_message_extract_flag (reply->request, NAME_MSGKEY_FORCE, FALSE);
 	reply->subject("%s|%s|?", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
@@ -188,15 +177,13 @@ meta1_dispatch_v2_SRV_FORCE(struct gridd_reply_ctx_s *reply,
 			reply->send_reply(200, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_CONFIG(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
 	gchar *m1url = NULL;
@@ -212,16 +199,14 @@ meta1_dispatch_v2_SRV_CONFIG(struct gridd_reply_ctx_s *reply,
 			reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_UNLINK(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
 	gchar *srvtype = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_TYPENAME);
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID), srvtype);
 
 	if (!srvtype)
@@ -243,16 +228,14 @@ meta1_dispatch_v2_SRV_UNLINK(struct gridd_reply_ctx_s *reply,
 		}
 	}
 
-	oio_url_clean (url);
 	g_free0 (srvtype);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_LIST(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gchar *srvtype = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_TYPENAME);
 	reply->subject("%s|%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID), srvtype);
 	STRING_STACKIFY(srvtype);
@@ -267,15 +250,13 @@ meta1_dispatch_v2_SRV_LIST(struct gridd_reply_ctx_s *reply,
 		reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_SRV_ALLONM1(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 	reply->send_reply(CODE_TEMPORARY, "Received");
 
@@ -289,15 +270,13 @@ meta1_dispatch_v2_SRV_ALLONM1(struct gridd_reply_ctx_s *reply,
 		reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_PROPGET(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
 	gsize length = 0;
@@ -319,15 +298,13 @@ meta1_dispatch_v2_PROPGET(struct gridd_reply_ctx_s *reply,
 		}
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_PROPSET(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gboolean flush = metautils_message_extract_flag(reply->request, NAME_MSGKEY_FLUSH, FALSE);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
@@ -346,15 +323,13 @@ meta1_dispatch_v2_PROPSET(struct gridd_reply_ctx_s *reply,
 			reply->send_reply(CODE_FINAL_OK, "OK");
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
 static gboolean
 meta1_dispatch_v2_PROPDEL(struct gridd_reply_ctx_s *reply,
-		struct meta1_backend_s *m1, gpointer ignored UNUSED)
+		struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	reply->subject("%s|%s", oio_url_get(url, OIOURL_WHOLE), oio_url_get(url, OIOURL_HEXID));
 
 	gchar **keys = NULL;
@@ -373,7 +348,6 @@ meta1_dispatch_v2_PROPDEL(struct gridd_reply_ctx_s *reply,
 		g_strfreev (keys);
 	}
 
-	oio_url_clean (url);
 	return TRUE;
 }
 
@@ -390,9 +364,8 @@ meta1_dispatch_v2_GET_PREFIX(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 meta1_dispatch_v2_SRVRELINK(struct gridd_reply_ctx_s *reply,
-	struct meta1_backend_s *m1, gpointer ignored UNUSED)
+	struct meta1_backend_s *m1, struct oio_url_s *url)
 {
-	struct oio_url_s *url = metautils_message_extract_url (reply->request);
 	gchar *kept = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_OLD);
 	gchar *replaced = metautils_message_extract_string_copy (reply->request, NAME_MSGKEY_NOTIN);
 	gboolean dryrun = metautils_message_extract_flag (reply->request, NAME_MSGKEY_DRYRUN, FALSE);
@@ -412,7 +385,6 @@ meta1_dispatch_v2_SRVRELINK(struct gridd_reply_ctx_s *reply,
 		}
 	}
 
-	oio_url_pclean (&url);
 	g_free0 (kept);
 	g_free0 (replaced);
 	return TRUE;
@@ -422,30 +394,53 @@ meta1_dispatch_v2_SRVRELINK(struct gridd_reply_ctx_s *reply,
 
 typedef gboolean (*hook) (struct gridd_reply_ctx_s *, gpointer, gpointer);
 
+
+typedef gboolean (*action) (struct gridd_reply_ctx_s *, struct meta1_backend_s *, struct oio_url_s *u);
+
+
+static gboolean meta1_dispatch_all(struct gridd_reply_ctx_s *reply,
+                                   struct meta1_backend_s *m1, gpointer callback)
+{
+	struct oio_url_s *url = metautils_message_extract_url(reply->request);
+
+	const gchar *_err;
+	if (!oio_url_check(url, NULL, &_err)) {
+		reply->send_error(0, BADREQ("Invalid %s", _err));
+		oio_url_pclean(&url);
+		return TRUE;
+	}
+
+    action ptr = callback;
+    gboolean ret = (*ptr)(reply, m1, url);
+    oio_url_pclean(&url);
+
+    return ret;
+}
+
 const struct gridd_request_descr_s *
 meta1_gridd_get_requests(void)
 {
 	static struct gridd_request_descr_s descriptions[] = {
 
-		{NAME_MSGNAME_M1V2_USERINFO,    (hook) meta1_dispatch_v2_USERINFO,    NULL},
-		{NAME_MSGNAME_M1V2_USERCREATE,  (hook) meta1_dispatch_v2_USERCREATE,  NULL},
-		{NAME_MSGNAME_M1V2_USERDESTROY, (hook) meta1_dispatch_v2_USERDESTROY, NULL},
+		{NAME_MSGNAME_M1V2_USERINFO,    (hook) meta1_dispatch_all, meta1_dispatch_v2_USERINFO},
+		{NAME_MSGNAME_M1V2_USERCREATE,  (hook) meta1_dispatch_all, meta1_dispatch_v2_USERCREATE},
+		{NAME_MSGNAME_M1V2_USERDESTROY, (hook) meta1_dispatch_all, meta1_dispatch_v2_USERDESTROY},
 
-		{NAME_MSGNAME_M1V2_SRVLIST,     (hook) meta1_dispatch_v2_SRV_LIST,    NULL},
-		{NAME_MSGNAME_M1V2_SRVLINK,     (hook) meta1_dispatch_v2_SRV_LINK,    NULL},
-		{NAME_MSGNAME_M1V2_SRVUNLINK,   (hook) meta1_dispatch_v2_SRV_UNLINK,  NULL},
-		{NAME_MSGNAME_M1V2_SRVFORCE,    (hook) meta1_dispatch_v2_SRV_FORCE,   NULL},
-		{NAME_MSGNAME_M1V2_SRVRENEW,    (hook) meta1_dispatch_v2_SRV_RENEW,   NULL},
-		{NAME_MSGNAME_M1V2_SRVCONFIG,   (hook) meta1_dispatch_v2_SRV_CONFIG,  NULL},
+		{NAME_MSGNAME_M1V2_SRVLIST,     (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_LIST},
+		{NAME_MSGNAME_M1V2_SRVLINK,     (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_LINK},
+		{NAME_MSGNAME_M1V2_SRVUNLINK,   (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_UNLINK},
+		{NAME_MSGNAME_M1V2_SRVFORCE,    (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_FORCE},
+		{NAME_MSGNAME_M1V2_SRVRENEW,    (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_RENEW},
+		{NAME_MSGNAME_M1V2_SRVCONFIG,   (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_CONFIG},
 
-		{NAME_MSGNAME_M1V2_PROPGET,     (hook) meta1_dispatch_v2_PROPGET, NULL},
-		{NAME_MSGNAME_M1V2_PROPSET,     (hook) meta1_dispatch_v2_PROPSET, NULL},
-		{NAME_MSGNAME_M1V2_PROPDEL,     (hook) meta1_dispatch_v2_PROPDEL, NULL},
+		{NAME_MSGNAME_M1V2_PROPGET,     (hook) meta1_dispatch_all, meta1_dispatch_v2_PROPGET},
+		{NAME_MSGNAME_M1V2_PROPSET,     (hook) meta1_dispatch_all, meta1_dispatch_v2_PROPSET},
+		{NAME_MSGNAME_M1V2_PROPDEL,     (hook) meta1_dispatch_all, meta1_dispatch_v2_PROPDEL},
 
-		{NAME_MSGNAME_M1V2_SRVALLONM1,  (hook) meta1_dispatch_v2_SRV_ALLONM1, NULL},
-		{NAME_MSGNAME_M1V2_GETPREFIX,	(hook) meta1_dispatch_v2_GET_PREFIX,  NULL},
+		{NAME_MSGNAME_M1V2_SRVALLONM1,  (hook) meta1_dispatch_all, meta1_dispatch_v2_SRV_ALLONM1},
+		{NAME_MSGNAME_M1V2_GETPREFIX,	(hook) meta1_dispatch_all, meta1_dispatch_v2_GET_PREFIX},
 
-		{NAME_MSGNAME_M1V2_SRVRELINK,   (hook) meta1_dispatch_v2_SRVRELINK, NULL},
+		{NAME_MSGNAME_M1V2_SRVRELINK,   (hook) meta1_dispatch_all, meta1_dispatch_v2_SRVRELINK},
 
 		{NULL, NULL, NULL}
 	};

--- a/meta2v2/meta2_filters_extract.c
+++ b/meta2v2/meta2_filters_extract.c
@@ -76,7 +76,14 @@ meta2_filter_extract_header_url(struct gridd_filter_ctx_s *ctx,
 		struct gridd_reply_ctx_s *reply)
 {
 	TRACE_FILTER();
+	const gchar *err = NULL;
 	struct oio_url_s *url = metautils_message_extract_url (reply->request);
+    if (!oio_url_check(url, NULL, &err)) {
+		meta2_filter_ctx_set_error(ctx, NEWERROR(CODE_BAD_REQUEST,
+					"Invalid request, Invalid %s", err));
+		oio_url_pclean(&url);
+		return FILTER_KO;
+    }
 	meta2_filter_ctx_set_url(ctx, url);
 	return FILTER_OK;
 }

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1984,12 +1984,14 @@ enum http_rc_e action_content_prop_del (struct req_args_s *args) {
 
 enum http_rc_e action_content_copy (struct req_args_s *args) {
 	const gchar *target = g_tree_lookup (args->rq->tree_headers, "destination");
+	const gchar *_err = NULL;
+
 	if (!target)
 		return _reply_format_error(args, BADREQ("Missing target header"));
 
 	struct oio_url_s *target_url = oio_url_init(target);
-	if (!target_url)
-		return _reply_format_error(args, BADREQ("Invalid URL in target header"));
+	if (!target_url || !oio_url_check(target_url, NULL, &_err))
+		return _reply_format_error(args, BADREQ("Invalid %s in target header", _err));
 
 	// Check the namespace and container match between both URLs
 	if (!oio_url_has(target_url, OIOURL_HEXID)

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -221,6 +221,7 @@ handler_action (struct http_request_s *rq, struct http_reply_ctx_s *rp)
 		rp->finalize ();
 		rc = HTTPRC_DONE;
 	} else {
+		const char *err;
 		struct req_args_s args = {0};
 		args.req_uri = &ruri;
 		args.matchings = matchings;
@@ -235,10 +236,9 @@ handler_action (struct http_request_s *rq, struct http_reply_ctx_s *rp)
 		GRID_TRACE("%s %s URL %s", __FUNCTION__,
 				ruri.path, oio_url_get(args.url, OIOURL_WHOLE));
 
-		if (oio_url_has(args.url, OIOURL_VERSION) && !oio_str_is_number(
-					oio_url_get(args.url, OIOURL_VERSION), &args.version))
-			rc = _reply_format_error(&args, BADREQ("Invalid version"));
-		else {
+		if (!oio_url_check(url, ns_name, &err)) {
+			rc = _reply_format_error(&args, BADREQ("Invalid parameter %s", err));
+		} else {
 			req_handler_f handler = (*matchings)->last->u;
 			rc = (*handler) (&args);
 		}

--- a/tests/func/test_weird_chars.c
+++ b/tests/func/test_weird_chars.c
@@ -44,8 +44,10 @@ test_create_upload_delete_destroy(struct oio_url_s *url, const gchar *obj)
 	struct oio_sds_ul_dst_s dst = {0};
 	dst.url = oio_url_dup(url);
 
-	if (obj)
+	if (obj) {
 		oio_url_set(dst.url, OIOURL_PATH, obj);
+		g_assert_true(oio_url_check(dst.url, NULL, NULL));
+    }
 	err = oio_sds_upload_from_file(client, &dst, source_file, 0, -1);
 	g_assert_no_error((GError*)err);
 
@@ -99,6 +101,7 @@ test_create_upload_delete_destroy_objname(gconstpointer user_data)
 	oio_url_set(url, OIOURL_ACCOUNT, account);
 	oio_url_set(url, OIOURL_USER, "container");
 	oio_url_set(url, OIOURL_PATH, obj_name);
+	g_assert_true(oio_url_check(url, ns_name, NULL));
 
 	const gchar *obj_name_parsed = oio_url_get(url, OIOURL_PATH);
 	g_assert_cmpstr(obj_name_parsed, ==, obj_name);


### PR DESCRIPTION
Only core, meta2 and proxy are now protected (I hope, please correct me if I miss something).

Path and version are always checked with oio_url_check.
Namespace is only checked if current one is passed as argument.