### PR TITLE
Fix upload with C client with more than one metachunk

### DIFF
--- a/core/sds.c
+++ b/core/sds.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS core library
-Copyright (C) 2015-2016 OpenIO, as part of OpenIO Software Defined Storage
+Copyright (C) 2015-2017 OpenIO, as part of OpenIO Software Defined Storage
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -123,12 +123,12 @@ oio_sds_get_compile_options (void)
 	_ADD_DBL (M2V2_CLIENT_TIMEOUT_HUGE);
 	_ADD_DBL (SQLX_CLIENT_TIMEOUT);
 
-	char **out = calloc (1+tmp->len, sizeof(void*));
-	for (guint i=0; i<tmp->len ;++i)
+	char **out = calloc(1 + tmp->len, sizeof(void*));
+	for (guint i = 0; i < tmp->len; ++i)
 		out[i] = strdup((char*) tmp->pdata[i]);
-	for (guint i=0; i<tmp->len ;++i)
-		g_free (tmp->pdata[i]);
-	g_ptr_array_free (tmp, TRUE);
+	for (guint i = 0; i < tmp->len; ++i)
+		g_free(tmp->pdata[i]);
+	g_ptr_array_free(tmp, TRUE);
 	return out;
 }
 
@@ -216,7 +216,7 @@ _metachunk_cleanv (struct metachunk_s **tab)
 {
 	if (!tab)
 		return;
-	for (struct metachunk_s **p=tab; *p ;++p)
+	for (struct metachunk_s **p = tab; *p; ++p)
 		_metachunk_clean (*p);
 	g_free (tab);
 }
@@ -252,7 +252,7 @@ _chunks_pack (GString *gs, GSList *chunks)
 	gchar strpos[32];
 
 	g_string_append (gs, "[");
-	for (GSList *l=chunks; l ;l=l->next) {
+	for (GSList *l = chunks; l; l = l->next) {
 		struct chunk_s *c = l->data;
 		if (gs->str[gs->len - 1] != '[')
 			g_string_append_c (gs, ',');
@@ -273,7 +273,7 @@ _chunks_load (GSList **out, struct json_object *jtab)
 	GSList *chunks = NULL;
 	GError *err = NULL;
 
-	for (int i=json_object_array_length(jtab); i>0 && !err ;i--) {
+	for (int i = json_object_array_length(jtab); i > 0 && !err; i--) {
 		struct json_object *jurl = NULL, *jpos = NULL, *jsize = NULL,
 				*jhash = NULL, *jscore = NULL;
 		struct oio_ext_json_mapping_s m[] = {
@@ -325,7 +325,7 @@ _get_meta_bound (GSList *lchunks)
 	if (!lchunks)
 		return 0;
 	guint highest_meta = 0;
-	for (GSList *l=lchunks; l ;l=l->next) {
+	for (GSList *l = lchunks; l; l = l->next) {
 		struct chunk_s *c = l->data;
 		highest_meta = MAX(highest_meta, c->position.meta);
 	}
@@ -346,11 +346,11 @@ _organize_chunks (GSList *lchunks, struct metachunk_s ***result,
 
 	/* build the metachunk */
 	struct metachunk_s **out = g_malloc0 ((meta_bound+1) * sizeof(void*));
-	for (guint i=0; i<meta_bound ;++i) {
+	for (guint i = 0; i < meta_bound; ++i) {
 		out[i] = g_malloc0 (sizeof(struct metachunk_s));
 		out[i]->meta = i;
 	}
-	for (GSList *l=lchunks; l ;l=l->next) {
+	for (GSList *l = lchunks; l; l = l->next) {
 		struct chunk_s *c = l->data;
 		guint i = c->position.meta;
 		struct metachunk_s *mc = out[i];
@@ -360,7 +360,7 @@ _organize_chunks (GSList *lchunks, struct metachunk_s ***result,
 	/* check the sequence of metachunks has no gap. In addition we
 	 * apply a shuffling of the chunks to avoid preferring always the
 	 * same 'first' chunk returned by the proxy. */
-	for (guint i=0; i<meta_bound ;++i) {
+	for (guint i = 0; i < meta_bound; ++i) {
 		struct metachunk_s *mc = out[i];
 		if (!mc->chunks) {
 			_metachunk_cleanv (out);
@@ -373,7 +373,7 @@ _organize_chunks (GSList *lchunks, struct metachunk_s ***result,
 	}
 
 	/* Compute each metachunk's size */
-	for (guint i=0; i<meta_bound ;++i) {
+	for (guint i = 0; i < meta_bound; ++i) {
 		/* Even with EC, the value of the 'chunk_size' attribute stored with each
 		 * chunk is the size of the metachunk. */
 		out[i]->size = ((struct chunk_s*)(out[i]->chunks->data))->size;
@@ -381,7 +381,7 @@ _organize_chunks (GSList *lchunks, struct metachunk_s ***result,
 
 	/* Compute each metachunk's offset in the main content */
 	gsize offset = 0;
-	for (guint i=0; i<meta_bound ;++i) {
+	for (guint i = 0; i < meta_bound; ++i) {
 		out[i]->offset = offset;
 		offset += out[i]->size;
 	}
@@ -619,7 +619,7 @@ _show_content (struct oio_sds_s *sds, struct oio_url_s *url, void *cb_data,
 
 		/* Eventually the chunks */
 		if (cb_chunks) {
-			for (GSList *l=chunks; l ;l=l->next)
+			for (GSList *l = chunks; l; l = l->next)
 				cb_chunks(cb_data, l->data);
 			g_slist_free (chunks);
 		} else {
@@ -659,7 +659,7 @@ _dl_debug (const char *caller, struct oio_sds_dl_src_s *src,
 	g_string_append_printf (out, "SRC{%s", oio_url_get(src->url, OIOURL_WHOLE));
 	if (src->ranges && src->ranges[0]) {
 		g_string_append (out, ",[");
-		for (struct oio_sds_dl_range_s **p=src->ranges; *p ;++p)
+		for (struct oio_sds_dl_range_s **p = src->ranges; *p; ++p)
 			g_string_append_printf (out,
 					"[%"G_GSIZE_FORMAT",%"G_GSIZE_FORMAT"]",
 					(*p)->offset, (*p)->size);
@@ -874,7 +874,7 @@ _download_range (struct _download_ctx_s *dl, struct oio_sds_dl_range_s *range)
 
 	struct oio_sds_dl_range_s r0 = *range;
 
-	for (struct metachunk_s **p=dl->metachunks; *p ;++p) {
+	for (struct metachunk_s **p = dl->metachunks; *p; ++p) {
 		if ((r0.offset >= (*p)->offset)
 				&& (r0.offset < (*p)->offset + (*p)->size)) {
 			struct oio_sds_dl_range_s r1;
@@ -910,14 +910,14 @@ _download (struct _download_ctx_s *dl)
 	/* Compute the total number of bytes in the content. We will need it for
 	 * subsequent checks. */
 	size_t total = 0;
-	for (struct metachunk_s **p=dl->metachunks; *p ;++p)
+	for (struct metachunk_s **p = dl->metachunks; *p; ++p)
 		total += (*p)->size;
 	GRID_TRACE2("computed size = %"G_GSIZE_FORMAT, total);
 
 	/* validate the ranges do not point out of the content, or ensure at least
 	 * a range is set. */
 	if (dl->src->ranges && dl->src->ranges[0]) {
-		for (struct oio_sds_dl_range_s **p=dl->src->ranges; *p ;++p) {
+		for (struct oio_sds_dl_range_s **p = dl->src->ranges; *p; ++p) {
 			if ((*p)->offset >= total)
 				return BADREQ("Range (%zd+%zd)/%zd not satisfiable: %s",
 						(*p)->offset, (*p)->size, total,
@@ -942,7 +942,7 @@ _download (struct _download_ctx_s *dl)
 
 	/* Ok, let's download each range sequentially */
 	GError *err = NULL;
-	for (struct oio_sds_dl_range_s **p=dl->src->ranges; *p ;++p) {
+	for (struct oio_sds_dl_range_s **p = dl->src->ranges; *p; ++p) {
 		if (NULL != (err = _download_range (dl, *p)))
 			break;
 	}
@@ -1069,7 +1069,7 @@ _download_to_buffer (struct oio_sds_s *sds, struct oio_sds_dl_src_s *src,
 	if (src->ranges != NULL && src->ranges[0] != NULL) {
 		/* Validate all the range can fit into the buffer */
 		size_t total = 0;
-		for (struct oio_sds_dl_range_s **p=src->ranges; *p ;++p)
+		for (struct oio_sds_dl_range_s **p = src->ranges; *p; ++p)
 			total += (*p)->size;
 		if (total > dst->data.buffer.length)
 			return (struct oio_error_s*) BADREQ(
@@ -1430,7 +1430,7 @@ _finish_metachunk_upload(struct oio_sds_ul_s *ul)
 
 	ul->mc->size = ul->local_done;
 
-	for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+	for (GSList *l = ul->mc->chunks; l; l = l->next) {
 		struct chunk_s *c = l->data;
 		EXTRA_ASSERT (c->position.meta == ul->mc->meta);
 		c->size = ul->mc->size;
@@ -1439,7 +1439,7 @@ _finish_metachunk_upload(struct oio_sds_ul_s *ul)
 
 	if (ul->checksum_chunk) {
 		const char *h = g_checksum_get_string (ul->checksum_chunk);
-		for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+		for (GSList *l = ul->mc->chunks; l; l = l->next) {
 			struct chunk_s *c = l->data;
 			g_strlcpy (c->hexhash, h, sizeof(c->hexhash));
 			oio_str_upper (c->hexhash);
@@ -1468,7 +1468,7 @@ _sds_upload_finish (struct oio_sds_ul_s *ul)
 		/* TODO: in case of EC, we may wanna read response headers */
 
 		/* store the structure in holders for further commit/abort */
-		for (GSList *l = ul->chunks; l ;l=l->next) {
+		for (GSList *l = ul->chunks; l; l = l->next) {
 			struct chunk_s *chunk = l->data;
 			if (is_ec || chunk->flag_success) {
 				ul->chunks_done = g_slist_prepend (ul->chunks_done, chunk);
@@ -1558,7 +1558,7 @@ _sds_upload_renew (struct oio_sds_ul_s *ul)
 	}
 
 	/* then patch each chunk with the same meta-position */
-	for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+	for (GSList *l = ul->mc->chunks; l; l = l->next) {
 		struct chunk_s *c = l->data;
 		c->position.meta = ul->mc->meta;
 	}
@@ -1585,7 +1585,7 @@ _sds_upload_renew (struct oio_sds_ul_s *ul)
 				"%u", ul->mc->meta);
 		ul->http_dests = g_slist_append (ul->http_dests, dest);
 	} else {
-		for (GSList *l=ul->mc->chunks; l ;l=l->next) {
+		for (GSList *l = ul->mc->chunks; l; l = l->next) {
 			struct chunk_s *c = l->data;
 			struct http_put_dest_s *dest = http_put_add_dest (ul->put, c->url, c);
 
@@ -1742,7 +1742,7 @@ oio_sds_upload_commit (struct oio_sds_ul_s *ul)
 		return (struct oio_error_s *) SYSERR("RAWX upload not completed");
 
 	gint64 size = ul->dst->offset;
-	for (GList *l=g_list_first(ul->metachunk_done); l ;l=g_list_next(l))
+	for (GList *l = g_list_first(ul->metachunk_done); l; l = g_list_next(l))
 		size += ((struct metachunk_s*) l->data)->size;
 
 	GString *request_body = g_string_new("");
@@ -2074,7 +2074,7 @@ _notify_list_result (struct oio_sds_list_listener_s *listener,
 	const int count_objects = json_object_array_length(jobjects);
 	if (count_objects >= 0)
 		*pcount = (size_t) count_objects;
-	for (int i=count_objects; i>0 && !err ;i--) {
+	for (int i = count_objects; i > 0 && !err; i--) {
 		struct json_object *it = json_object_array_get_idx (jobjects, i-1);
 		err = _notify_list_item (listener, it);
 	}
@@ -2365,7 +2365,7 @@ oio_sds_show_content (struct oio_sds_s *sds, struct oio_url_s *url,
 	if (!err) {
 		GTree *positions_seen = g_tree_new_full(oio_str_cmp3, NULL, g_free, NULL);
 		chunks = g_slist_sort (chunks, (GCompareFunc)_compare_chunks);
-		for (GSList *l=chunks; l ;l=l->next) {
+		for (GSList *l = chunks; l; l = l->next) {
 			const struct chunk_s *chunk = l->data;
 			gchar *position = g_strdup_printf("%u", chunk->position.meta);
 			if (g_tree_lookup(positions_seen, position)) {

--- a/meta0v2/CMakeLists.txt
+++ b/meta0v2/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_definitions(-DG_LOG_DOMAIN="oio.m0v2")
+add_definitions(-DG_LOG_DOMAIN="oio.m0v2" -DTHREADED)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
 include_directories(BEFORE . ..)

--- a/sqliterepo/CMakeLists.txt
+++ b/sqliterepo/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_definitions(-DG_LOG_DOMAIN="oio.sqlite")
+add_definitions(-DG_LOG_DOMAIN="oio.sqlite" -DTHREADED)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
 include_directories(BEFORE . ..

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -35,7 +35,11 @@ func_tests () {
     tox && tox -e func
     cd $WRKDIR
     make -C tests/func test
-    ./core/tool_roundtrip /etc/passwd
+    # Create a file just bigger than chunk size
+    SOURCE=$(mktemp)
+    dd if=/dev/urandom of=$SOURCE bs=128K count=9
+    ./core/tool_roundtrip $SOURCE
+    rm -f $SOURCE
 }
 
 test_worm () {


### PR DESCRIPTION
Due to a variable mismatch, only the first chunk of the first metachunk was referenced in meta2 database.