### PR TITLE
Enable codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,13 @@ script:
   - mkdir /tmp/oio && source $HOME/oio/bin/activate
   - export CMAKE_OPTS='-DCMAKE_INSTALL_PREFIX=/tmp/oio -DLD_LIBDIR=lib -DZK_LIBDIR=/usr/lib -DZK_INCDIR=/usr/include/zookeeper -DAPACHE2_LIBDIR=/usr/lib/apache2 -DAPACHE2_INCDIR=/usr/include/apache2 -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module'
   - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
-  - if [ -n "$COVERAGE" ] ; then export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"; fi
+  - export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
   - python setup.py install
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
-  - if [ -n "$COVERAGE" ] ; then make coverage_init ; fi
+  - make coverage_init
   - pwd && env && ./tools/oio-travis-tests.sh
-  - if [ -n "$COVERAGE" ] ; then make coverage && gcovr -r . | cut -c1-63 && coverage report ; fi
+  - make coverage
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -v -f cmake_coverage.output
+  - codecov

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 OpenIO SDS is a software solution for object storage, targeting very large-scale unstructured data volumes.
 
-[![Build Status](https://travis-ci.org/open-io/oio-sds.svg?branch=master)](https://travis-ci.org/open-io/oio-sds)
+[![Build Status][build_status_svg]][repo] [![Codecov][codecov_svg]][codecov]
+
 
 ## Install
 
@@ -20,3 +21,8 @@ And if it succeeds you will have the joy to experiment your own little SDS insta
 
 Please refer to [BUILD.md](./BUILD.md) for detailed information about how to compile and configure the solution.
 
+
+[build_status_svg]: https://travis-ci.org/open-io/oio-sds.svg?branch=master
+[repo]: https://travis-ci.org/open-io/oio-sds
+[codecov_svg]: https://codecov.io/gh/open-io/oio-sds/branch/master/graph/badge.svg
+[codecov]: https://codecov.io/gh/open-io/oio-sds

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ nose
 mock>=1.0
 fixtures>=1.4.0
 gcovr
+codecov

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -67,6 +67,8 @@ func_tests () {
 	# Run the test-suite of the C API
     ./core/tool_roundtrip $SOURCE
     rm -f $SOURCE
+
+    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
 }
 
 
@@ -79,6 +81,8 @@ test_meta2_filters () {
 		tox -e coverage
     fi
     ${PYTHON} $(which nosetests) tests.functional.m2_filters.test_filters
+
+    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
 }
 
 


### PR DESCRIPTION
This patch enable use of codecov.io with:
- C coverage
- Python coverage
- Badge integration