### PR TITLE
oio/api: allow append operations

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -530,7 +530,9 @@ class ObjectStorageApi(object):
         :keyword key_file:
         :param append: if set, data will be append to existing object (or
         object will be created if unset)
-        :type append: boolean
+        :type append: `bool`
+
+        :returns: `list` of chunks, size and hash of the what has been uploaded
         """
         if (data, file_or_path) == (None, None):
             raise exc.MissingData()
@@ -749,12 +751,9 @@ class ObjectStorageApi(object):
     def _content_preparer(self, account, container, obj_name,
                           policy=None, **kwargs):
         # TODO: optimize by asking more than one metachunk at a time
-        if not kwargs.get('append', False):
-            kwargs['autocreate'] = True
-
         obj_meta, first_body = self.container.content_prepare(
             account, container, obj_name, size=1, stgpol=policy,
-            **kwargs)
+            autocreate=True, **kwargs)
         storage_method = STORAGE_METHODS.load(obj_meta['chunk_method'])
 
         def _fix_mc_pos(chunks, mc_pos):
@@ -774,7 +773,7 @@ class ObjectStorageApi(object):
                 mc_pos += 1
                 _, next_body = self.container.content_prepare(
                         account, container, obj_name, 1, stgpol=policy,
-                        **kwargs)
+                        autocreate=True, **kwargs)
                 _fix_mc_pos(next_body, mc_pos)
                 yield next_body
 

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -52,11 +52,5 @@ class ProxyClient(HttpApi):
             headers["X-oio-action-mode"] = "autocreate"
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
-        if kwargs.get("append"):
-            if not headers:
-                headers = dict()
-            headers["X-oio-action-mode"] = "append"
-            kwargs = kwargs.copy()
-            kwargs.pop("append")
         return super(ProxyClient, self)._direct_request(
             method, url, session=session, headers=headers, **kwargs)

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -52,5 +52,11 @@ class ProxyClient(HttpApi):
             headers["X-oio-action-mode"] = "autocreate"
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
+        if kwargs.get("append"):
+            if not headers:
+                headers = dict()
+            headers["X-oio-action-mode"] = "append"
+            kwargs = kwargs.copy()
+            kwargs.pop("append")
         return super(ProxyClient, self)._direct_request(
             method, url, session=session, headers=headers, **kwargs)

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -310,7 +310,7 @@ class ContainerClient(ProxyClient):
         if chunk_method is not None:
             hdrs['x-oio-content-meta-chunk-method'] = chunk_method
         resp, body = self._direct_request(
-            'POST', uri, data=data, params=params, autocreate=True,
+            'POST', uri, data=data, params=params,
             headers=hdrs, **kwargs)
         return resp, body
 

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -356,3 +356,33 @@ class TestObjectStorageAPI(BaseTestCase):
         fdata = self._fetch_range(name, (start, end))
         self.assertEqual(len(fdata), end-start+1)
         self.assertEqual(fdata, data[start:end+1])
+
+    def test_object_create_then_append(self):
+        """Create an object then append data"""
+        name = random_str(16)
+        self.api.object_create(self.account, name, data="1"*128, obj_name=name)
+        self.api.object_create(self.account, name, data="2"*128, obj_name=name,
+                               append=True)
+        _, data = self.api.object_fetch(self.account, name, name)
+        data = "".join(data)
+        self.assertEqual(len(data), 256)
+        self.assertEqual(data, "1"*128 + "2" *128)
+
+    def test_object_create_from_append(self):
+        """Create an object with append operation"""
+        name = random_str(16)
+        self.api.container_create(self.account, name)
+        self.api.object_create(self.account, name, data="1"*128, obj_name=name,
+                               append=True)
+        _, data = self.api.object_fetch(self.account, name, name)
+        data = "".join(data)
+        self.assertEqual(len(data), 128)
+        self.assertEqual(data, "1"*128)
+
+    def test_container_object_create_from_append(self):
+        """Try to create container and object with append operatio"""
+        name = random_str(16)
+        self.assertRaises(
+            exc.NoSuchContainer,
+            self.api.object_create, self.account, name, data="1"*128,
+                                    obj_name=name, append=True)


### PR DESCRIPTION
This patch introduces a new parameter for object_create to support
appending data to an existing object.

If object doesn't exist, it is created, only if container exists as
flag append can not be used at same time with flag autocreate.