### PR TITLE
Fix elections troubles

### DIFF
--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -51,16 +51,16 @@ m0_to_sqlx(enum m0v2_open_type_e t)
 {
 	switch (t & 0x03) {
 		case M0V2_OPENBASE_LOCAL:
-			return SQLX_OPEN_LOCAL;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL;
 		case M0V2_OPENBASE_MASTERONLY:
-			return SQLX_OPEN_MASTERONLY;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_MASTERONLY;
 		case M0V2_OPENBASE_MASTERSLAVE:
-			return SQLX_OPEN_MASTERSLAVE;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_MASTERSLAVE;
 		case M0V2_OPENBASE_SLAVEONLY:
-			return SQLX_OPEN_SLAVEONLY;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_SLAVEONLY;
 	}
 	g_assert_not_reached();
-	return SQLX_OPEN_LOCAL;
+	return SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL;
 }
 
 struct meta0_backend_s *

--- a/meta1v2/meta1_backend_internals.c
+++ b/meta1v2/meta1_backend_internals.c
@@ -62,22 +62,23 @@ __exec_cid(sqlite3 *handle, const gchar *sql, const container_id_t cid)
 		sqlite3_finalize_debug(rc, stmt);
 	}
 }
+
 static int
 m1_to_sqlx(enum m1v2_open_type_e t)
 {
 	switch (t & 0x03) {
 		case M1V2_OPENBASE_LOCAL:
-			return SQLX_OPEN_LOCAL;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL;
 		case M1V2_OPENBASE_MASTERONLY:
-			return SQLX_OPEN_MASTERONLY;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_MASTERONLY;
 		case M1V2_OPENBASE_SLAVEONLY:
-			return SQLX_OPEN_SLAVEONLY;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_SLAVEONLY;
 		case M1V2_OPENBASE_MASTERSLAVE:
-			return SQLX_OPEN_MASTERSLAVE;
+			return SQLX_OPEN_CREATE|SQLX_OPEN_MASTERSLAVE;
 	}
 
 	g_assert_not_reached();
-	return SQLX_OPEN_LOCAL;
+	return SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL;
 }
 
 GError *

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -966,7 +966,7 @@ action_m2_container_destroy (struct req_args_s *args)
 	if (!err) {
 		err = _resolve_meta2 (args, CLIENT_PREFER_MASTER,
 							  sqlx_pack_FREEZE, NULL);
-		if (NULL != err) {
+		if (NULL != err && CODE_IS_NETWORK_ERROR(err->code)) {
 			/* rollback! There are chances the request made a timeout
 			 * but was actually managed by the server. */
 			_re_enable (args);
@@ -995,6 +995,8 @@ action_m2_container_destroy (struct req_args_s *args)
 		err = _m1_locate_and_action (args->url, _unlink);
 		hc_decache_reference_service (resolver, args->url, n.type);
 		if (NULL != err) {
+			/* Rolling back will be hard if there is any chance the UNLINK has
+			 * been managed by the server, despite a time-out that occured. */
 			_re_enable (args);
 			goto clean_and_exit;
 		}

--- a/proxy/reply.c
+++ b/proxy/reply.c
@@ -134,6 +134,7 @@ _reply_common_error (struct req_args_s *args, GError *err)
 		case CODE_TOOMANY_REDIRECT:
 		case CODE_UNAVAILABLE:
 		case CODE_EXCESSIVE_LOAD:
+		case CODE_CONTAINER_FROZEN:
 			return _reply_retry(args, err);
 		case CODE_CONTAINER_EXISTS:
 		case CODE_CONTENT_EXISTS:

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -102,7 +102,6 @@ struct sqlx_repository_s
 	enum sqlx_sync_mode_e sync_mode_solo;
 	enum sqlx_sync_mode_e sync_mode_repli;
 
-	gboolean flag_autocreate : 1;
 	gboolean flag_autovacuum : 1;
 	gboolean flag_delete_on : 1;
 

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1196,20 +1196,18 @@ _check_init_flag(struct sqlx_sqlite3_s *sq3, gboolean autocreate)
 static GError *
 do_query(struct gridd_reply_ctx_s *reply_ctx, sqlx_repository_t *repo,
 		struct sqlx_name_s *name,
-		TableSequence_t *params, TableSequence_t *result,
-		gboolean autocreate)
+		TableSequence_t *params, TableSequence_t *result)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
 
-	GRID_DEBUG("Opening and querying [%s][%s]%s", name->base, name->type,
-			autocreate? " (autocreate)" : "");
+	GRID_DEBUG("Opening and querying [%s][%s]", name->base, name->type);
 
-	err = _checked_open(reply_ctx, repo, name, SQLX_OPEN_MASTERSLAVE, &sq3);
+	err = _checked_open(reply_ctx, repo, name, SQLX_OPEN_CREATE|SQLX_OPEN_MASTERSLAVE, &sq3);
 	if (err != NULL)
 		return err;
 
-	err = _check_init_flag(sq3, autocreate);
+	err = _check_init_flag(sq3, TRUE);
 	if (!err)
 		err = do_query_after_open(reply_ctx, sq3, params, result);
 
@@ -2345,8 +2343,7 @@ _handler_QUERY(struct gridd_reply_ctx_s *reply,
 
 	/* execute the request now */
 	result = ASN1C_CALLOC(1, sizeof(struct TableSequence));
-	err = do_query(reply, repo, &n0, params,
-			result, flags&FLAG_AUTOCREATE);
+	err = do_query(reply, repo, &n0, params, result);
 
 	if (params)
 		asn_DEF_TableSequence.free_struct(&asn_DEF_TableSequence, params, FALSE);

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1260,7 +1260,6 @@ end_label:
 
 /* ------------------------------------------------------------------------- */
 
-#define FLAG_AUTOCREATE 0x01
 #define FLAG_LOCAL      0x02
 #define FLAG_NOCHECK    0x08
 #define FLAG_CHUNKED    0x10
@@ -1275,9 +1274,9 @@ _load_sqlx_name (struct gridd_reply_ctx_s *ctx,
 		ns[LIMIT_LENGTH_NSNAME],
 		base[LIMIT_LENGTH_BASENAME],
 		type[LIMIT_LENGTH_BASETYPE];
-	gboolean flush, nocheck, local, autocreate, chunked;
+	gboolean flush, nocheck, local, chunked;
 
-	flush = local = autocreate = nocheck = chunked = FALSE;
+	flush = local = nocheck = chunked = FALSE;
 
 	err = metautils_message_extract_string(ctx->request,
 			NAME_MSGKEY_NAMESPACE, ns, sizeof(ns));
@@ -1294,8 +1293,6 @@ _load_sqlx_name (struct gridd_reply_ctx_s *ctx,
 
 	local = metautils_message_extract_flag(ctx->request,
 			NAME_MSGKEY_LOCAL, FALSE);
-	autocreate = metautils_message_extract_flag(ctx->request,
-			NAME_MSGKEY_AUTOCREATE, FALSE);
 	nocheck = metautils_message_extract_flag(ctx->request,
 			NAME_MSGKEY_NOCHECK, FALSE);
 	chunked = metautils_message_extract_flag(ctx->request,
@@ -1312,7 +1309,6 @@ _load_sqlx_name (struct gridd_reply_ctx_s *ctx,
 
 	if (pflags) {
 		*pflags = 0;
-		*pflags |= (autocreate ? FLAG_AUTOCREATE : 0);
 		*pflags |= (local ? FLAG_LOCAL : 0);
 		*pflags |= (nocheck ? FLAG_NOCHECK : 0);
 		*pflags |= (chunked ? FLAG_CHUNKED : 0);

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1350,7 +1350,7 @@ _handler_GETVERS(struct gridd_reply_ctx_s *reply,
 	}
 
 	err = sqlx_repository_open_and_lock(repo, &n0,
-			SQLX_OPEN_LOCAL|SQLX_OPEN_URGENT, &sq3, NULL);
+			SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL|SQLX_OPEN_URGENT, &sq3, NULL);
 	if (NULL != err) {
 		g_prefix_error(&err, "Open/lock: ");
 		reply->send_error(0, err);
@@ -1751,7 +1751,7 @@ _handler_RESYNC(struct gridd_reply_ctx_s *reply,
 
 	struct sqlx_sqlite3_s *sq3 = NULL;
 	err = sqlx_repository_open_and_lock(repo, &n0,
-			SQLX_OPEN_SLAVEONLY, &sq3, NULL);
+			SQLX_OPEN_CREATE|SQLX_OPEN_SLAVEONLY, &sq3, NULL);
 	if (NULL != err) {
 		reply->send_error(0, err);
 		return TRUE;
@@ -2197,8 +2197,6 @@ _info_repository(struct sqlx_repository_s *r, GString *gstr)
 			r->hash_width, r->hash_depth);
 
 	g_string_append_static(gstr, "\tflags: ");
-	if (r->flag_autocreate)
-		_append_flag("AUTOCREATE");
 	if (r->flag_autovacuum)
 		_append_flag("AUTOVACUUM");
 	if (r->flag_delete_on)

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -321,7 +321,6 @@ sqlx_repository_init(const gchar *vol, const struct sqlx_repo_config_s *cfg,
 
 	repo->schemas = g_tree_new_full(metautils_strcmp3, NULL, g_free, g_free);
 
-	repo->flag_autocreate = BOOL(cfg->flags & SQLX_REPO_AUTOCREATE);
 	repo->flag_autovacuum = BOOL(cfg->flags & SQLX_REPO_VACUUM);
 	repo->flag_delete_on = BOOL(cfg->flags & SQLX_REPO_DELETEON);
 
@@ -641,7 +640,7 @@ retry:
 	flags |= SQLITE_OPEN_NOMUTEX;
 	flags |= SQLITE_OPEN_PRIVATECACHE;
 	flags |= SQLITE_OPEN_READWRITE;
-	if (args->create || args->repo->flag_autocreate)
+	if (args->create)
 		flags |= SQLITE_OPEN_CREATE;
 	handle = NULL;
 
@@ -654,7 +653,7 @@ retry:
 		case SQLITE_CANTOPEN:
 			GRID_DEBUG("Open soft error [%s] : (%d) %s", args->realpath,
 					rc, sqlite_strerror(rc));
-			if (attempts-- && (args->create || args->repo->flag_autocreate)) {
+			if (attempts-- && args->create) {
 				_close_handle(&handle);
 				if (!(error = __create_directory(args->realpath))) {
 					GRID_TRACE("Directory created, retrying open [%s]", args->realpath);
@@ -1039,7 +1038,7 @@ sqlx_repository_has_base2(sqlx_repository_t *repo, const struct sqlx_name_s *n,
 	REPO_CHECK(repo);
 	SQLXNAME_CHECK(n);
 
-	struct open_args_s args;
+	struct open_args_s args = {0};
 
 	if (bddname != NULL)
 		*bddname = NULL;

--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -82,7 +82,6 @@ enum sqlx_repo_flag_e
 	SQLX_REPO_NOCACHE      = 0x01,
 	SQLX_REPO_VACUUM       = 0x02,
 	SQLX_REPO_DELETEON     = 0x04,
-	SQLX_REPO_AUTOCREATE   = 0x10,
 };
 
 enum sqlx_sync_mode_e

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -557,7 +557,6 @@ _configure_backend(struct sqlx_service_s *ss)
 	repository_config.flags = 0;
 	repository_config.flags |= ss->flag_delete_on ? SQLX_REPO_DELETEON : 0;
 	repository_config.flags |= ss->flag_cached_bases ? 0 : SQLX_REPO_NOCACHE;
-	repository_config.flags |= ss->flag_autocreate ? SQLX_REPO_AUTOCREATE : 0;
 	repository_config.sync_solo = ss->sync_mode_solo;
 	repository_config.sync_repli = ss->sync_mode_repli;
 
@@ -751,7 +750,6 @@ sqlx_service_set_defaults(void)
 {
 	SRV.config_system = TRUE;
 	SRV.flag_replicable = TRUE;
-	SRV.flag_autocreate = TRUE;
 	SRV.flag_delete_on = TRUE;
 	SRV.flag_cached_bases = TRUE;
 

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -135,9 +135,6 @@ struct sqlx_service_s
 	// Are DB deletions allowed ?
 	gboolean flag_delete_on;
 
-	// Are DB autocreations enabled?
-	gboolean flag_autocreate;
-
 	// Turn to TRUE to avoid locking the repository volume
 	gboolean flag_nolock;
 


### PR DESCRIPTION
* Systematically reset a timer when restarting an election cycle, the timer that allows the client to detect the election is stalled  
* Avoid leaving uninitialized DB files, erroneously autocreated