### PR TITLE
Rawx: Add xattr oio_version and full_path fix(#948, #1020)

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -725,7 +725,13 @@
 				"key": "core.http.user_agent",
 				"limit": 64,
 				"def": "",
-				"descr": "HTTP User-Agent to be used between any C client and the proxy" }
+				"descr": "HTTP User-Agent to be used between any C client and the proxy" },
+
+			{ "type": "string", "name": "oio_sds_client_version",
+				"key": "core.sds.version",
+				"limit": 64,
+				"def": "4.0",
+				"descr": "The version of the sds. It's used to know the expected metadata of a chunk" }
 		]
 	}
 }

--- a/core/oiourl.h
+++ b/core/oiourl.h
@@ -42,6 +42,8 @@ enum oio_url_field_e
 
 	OIOURL_HEXID,     /* read-write */
 	OIOURL_CONTENTID, /* read-write */
+
+	OIOURL_FULLPATH
 };
 
 

--- a/core/sds.c
+++ b/core/sds.c
@@ -1454,6 +1454,16 @@ _sds_upload_add_headers(struct oio_sds_ul_s *ul, struct http_put_dest_s *dest)
 			"%s", escaped);
 	g_free (escaped);
 
+	gchar *full_path = g_strconcat(oio_url_get(ul->dst->url, OIOURL_ACCOUNT),
+				"/", oio_url_get(ul->dst->url, OIOURL_USER),
+				"/", oio_url_get(ul->dst->url, OIOURL_PATH), NULL);
+	escaped = g_uri_escape_string(full_path, NULL, TRUE);
+	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "full-path", "%s", escaped);
+	g_free(full_path);
+	g_free(escaped);
+
+	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "oio-version", "%s", oio_sds_client_version);
+
 	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "content-version",
 			"%" G_GINT64_FORMAT, ul->version);
 	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "content-id",

--- a/core/sds.c
+++ b/core/sds.c
@@ -1454,15 +1454,16 @@ _sds_upload_add_headers(struct oio_sds_ul_s *ul, struct http_put_dest_s *dest)
 			"%s", escaped);
 	g_free (escaped);
 
-	gchar *full_path = g_strconcat(oio_url_get(ul->dst->url, OIOURL_ACCOUNT),
-				"/", oio_url_get(ul->dst->url, OIOURL_USER),
-				"/", oio_url_get(ul->dst->url, OIOURL_PATH), NULL);
-	escaped = g_uri_escape_string(full_path, NULL, TRUE);
-	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "full-path", "%s", escaped);
-	g_free(full_path);
-	g_free(escaped);
+	const gchar *full_path = oio_url_get(ul->dst->url, OIOURL_FULLPATH);
+	if (!oio_url_has(ul->dst->url, OIOURL_VERSION))
+		http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "full-path", "%s%"
+				G_GINT64_FORMAT, full_path, ul->version);
+	else
+		http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "full-path", "%s",
+				full_path);
 
-	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "oio-version", "%s", oio_sds_client_version);
+	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "oio-version", "%s",
+			oio_sds_client_version);
 
 	http_put_dest_add_header (dest, RAWX_HEADER_PREFIX "content-version",
 			"%" G_GINT64_FORMAT, ul->version);

--- a/core/url.c
+++ b/core/url.c
@@ -36,6 +36,7 @@ struct oio_url_s
 
 	/* secondary */
 	gchar *whole;
+	gchar *fullpath;
 	guint8 id[32];
 	gchar hexid[65];
 	guint8 flags;
@@ -302,6 +303,9 @@ oio_url_set(struct oio_url_s *u, enum oio_url_field_e f, const char *v)
 		case OIOURL_WHOLE:
 			return NULL;
 
+		case OIOURL_FULLPATH:
+			return NULL;
+
 		case OIOURL_HEXID:
 			u->hexid[0] = 0;
 			if (!oio_str_ishexa(v,64) || !oio_str_hex2bin(v, u->id, 32))
@@ -341,6 +345,8 @@ oio_url_has(const struct oio_url_s *u, enum oio_url_field_e f)
 		case OIOURL_VERSION:
 			return oio_str_is_set(u->version);
 		case OIOURL_WHOLE:
+			return TRUE;
+		case OIOURL_FULLPATH:
 			return TRUE;
 		case OIOURL_HEXID:
 			return (u->ns && u->hexid[0]) || (u->ns && u->user);
@@ -402,6 +408,28 @@ _pack_url(struct oio_url_s *u)
 	return gs;
 }
 
+static GString *
+_pack_fullpath(struct oio_url_s *u)
+{
+	GString *gs = g_string_new("");
+	if (u->account) {
+		g_string_append_uri_escaped(gs, u->account, NULL, TRUE);
+		if (u->user) {
+			g_string_append_c(gs, '/');
+			g_string_append_uri_escaped(gs, u->user, NULL, TRUE);
+			if (u->path) {
+				g_string_append_c(gs, '/');
+				g_string_append_uri_escaped(gs, u->path, NULL, TRUE);
+				if (u->version) {
+					g_string_append_c(gs, '/');
+					g_string_append_uri_escaped(gs, u->version, NULL, TRUE);
+				}
+			}
+		}
+	}
+	return gs;
+}
+
 const char*
 oio_url_get(struct oio_url_s *u, enum oio_url_field_e f)
 {
@@ -439,6 +467,11 @@ oio_url_get(struct oio_url_s *u, enum oio_url_field_e f)
 
 		case OIOURL_CONTENTID:
 			return u->content;
+
+		case OIOURL_FULLPATH:
+			if (!u->fullpath)
+				u->fullpath = g_string_free(_pack_fullpath(u), FALSE);
+			return u->fullpath;
 	}
 
 	g_assert_not_reached();

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -35,6 +35,7 @@ from oio.common.utils import ensure_headers, ensure_request_id, float_value, \
 from oio.common.http import http_header_from_ranges
 from oio.common.storage_method import STORAGE_METHODS
 from oio.common.constants import OIO_VERSION
+from urllib import quote_plus
 
 logger = logging.getLogger(__name__)
 
@@ -790,6 +791,12 @@ class ObjectStorageApi(object):
 
         return obj_meta, _metachunk_preparer
 
+    def _generate_fullpath(self, account, container_name, path, version):
+        return '{0}/{1}/{2}/{3}'.format(quote_plus(account),
+                                        quote_plus(container_name),
+                                        quote_plus(path),
+                                        version)
+
     def _object_create(self, account, container, obj_name, source,
                        sysmeta, properties=None, policy=None,
                        key_file=None, **kwargs):
@@ -801,7 +808,9 @@ class ObjectStorageApi(object):
         obj_meta['content_path'] = obj_name
         obj_meta['container_id'] = name2cid(account, container).upper()
         obj_meta['ns'] = self.namespace
-        obj_meta['full_path'] = ["%s/%s/%s" % (account, container, obj_name)]
+        obj_meta['full_path'] = self._generate_fullpath(account, container,
+                                                        obj_name,
+                                                        obj_meta['version'])
         obj_meta['oio_version'] = (obj_meta.get('oio_version')
                                    or OIO_VERSION)
 

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -34,7 +34,7 @@ from oio.common.utils import ensure_headers, ensure_request_id, float_value, \
     name2cid, GeneratorIO
 from oio.common.http import http_header_from_ranges
 from oio.common.storage_method import STORAGE_METHODS
-
+from oio.common.constants import OIO_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +238,6 @@ class ObjectStorageApi(object):
         - `read_timeout`: `float`
         - `write_timeout`: `float`
     """
-
     TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
 
     def __init__(self, namespace, **kwargs):
@@ -802,6 +801,9 @@ class ObjectStorageApi(object):
         obj_meta['content_path'] = obj_name
         obj_meta['container_id'] = name2cid(account, container).upper()
         obj_meta['ns'] = self.namespace
+        obj_meta['full_path'] = ["%s/%s/%s" % (account, container, obj_name)]
+        obj_meta['oio_version'] = (obj_meta.get('oio_version')
+                                   or OIO_VERSION)
 
         storage_method = STORAGE_METHODS.load(obj_meta['chunk_method'])
         if storage_method.ec:

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -5,7 +5,7 @@ from oio.common.constants import chunk_headers, chunk_xattr_keys_optional
 from oio.api.io import ChunkReader
 from oio.api.replication import ReplicatedMetachunkWriter, FakeChecksum
 from oio.common.storage_method import STORAGE_METHODS
-
+from urllib import unquote_plus
 
 READ_BUFFER_SIZE = 65535
 
@@ -18,6 +18,9 @@ def extract_headers_meta(headers):
         except KeyError as e:
             if k not in chunk_xattr_keys_optional:
                 raise e
+    if meta['full_path']:
+        meta['full_path'] = [unquote_plus(x)
+                             for x in meta['full_path'].split(',')]
 
     return meta
 

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -5,7 +5,6 @@ from oio.common.constants import chunk_headers, chunk_xattr_keys_optional
 from oio.api.io import ChunkReader
 from oio.api.replication import ReplicatedMetachunkWriter, FakeChecksum
 from oio.common.storage_method import STORAGE_METHODS
-from urllib import unquote_plus
 
 READ_BUFFER_SIZE = 65535
 
@@ -19,8 +18,7 @@ def extract_headers_meta(headers):
             if k not in chunk_xattr_keys_optional:
                 raise e
     if meta['full_path']:
-        meta['full_path'] = [unquote_plus(x)
-                             for x in meta['full_path'].split(',')]
+        meta['full_path'] = meta['full_path'].split(',')
 
     return meta
 

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -21,6 +21,8 @@ CHUNK_METADATA_PREFIX = "x-oio-chunk-meta-"
 CONTAINER_USER_METADATA_PREFIX = CONTAINER_METADATA_PREFIX + 'user-'
 
 
+OIO_VERSION = '4.0'
+
 container_headers = {
     "size": "%ssys-m2-usage" % CONTAINER_METADATA_PREFIX,
     "ns": "%ssys-ns" % CONTAINER_METADATA_PREFIX
@@ -50,7 +52,9 @@ chunk_headers = {
     "content_path": "%scontent-path" % CHUNK_METADATA_PREFIX,
     "content_version": "%scontent-version" % CHUNK_METADATA_PREFIX,
     "metachunk_size": "%smetachunk-size" % CHUNK_METADATA_PREFIX,
-    "metachunk_hash": "%smetachunk-hash" % CHUNK_METADATA_PREFIX
+    "metachunk_hash": "%smetachunk-hash" % CHUNK_METADATA_PREFIX,
+    "full_path": "%sfull-path" % CHUNK_METADATA_PREFIX,
+    "oio_version": "%soio-version" % CHUNK_METADATA_PREFIX,
 }
 
 chunk_xattr_keys = {
@@ -66,6 +70,7 @@ chunk_xattr_keys = {
     'content_version': 'grid.content.version',
     'metachunk_hash': 'grid.metachunk.hash',
     'metachunk_size': 'grid.metachunk.size',
+    'oio_version': 'grid.oio.version'
 }
 
 chunk_xattr_keys_optional = {
@@ -73,7 +78,9 @@ chunk_xattr_keys_optional = {
         'chunk_hash': True,
         'chunk_size': True,
         'metachunk_size': True,
-        'metachunk_hash': True}
+        'metachunk_hash': True,
+        'oio_version': True,
+        'full_path': True}
 
 
 volume_xattr_keys = {

--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -218,13 +218,17 @@ def headers_from_object_metadata(metadata):
     out[chunk_headers["content_chunkmethod"]] = metadata['chunk_method']
     out[chunk_headers["content_policy"]] = metadata['policy']
     out[chunk_headers["container_id"]] = metadata['container_id']
+    out[chunk_headers["oio_version"]] = metadata["oio_version"]
 
     for key in ['metachunk_hash', 'metachunk_size', 'chunk_hash']:
         val = metadata.get(key)
         if val is not None:
             out[chunk_headers[key]] = metadata[key]
 
-    return {k: quote_plus(str(v)) for (k, v) in out.iteritems()}
+    header = {k: quote_plus(str(v)) for (k, v) in out.iteritems()}
+    header[chunk_headers["full_path"]] = ','.join([quote_plus(x) for x
+                                                  in metadata['full_path']])
+    return header
 
 
 class HeadersDict(dict):

--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -226,8 +226,7 @@ def headers_from_object_metadata(metadata):
             out[chunk_headers[key]] = metadata[key]
 
     header = {k: quote_plus(str(v)) for (k, v) in out.iteritems()}
-    header[chunk_headers["full_path"]] = ','.join([quote_plus(x) for x
-                                                  in metadata['full_path']])
+    header[chunk_headers["full_path"]] = ','.join(metadata['full_path'])
     return header
 
 

--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -22,8 +22,9 @@ from oio.container.client import ContainerClient
 
 
 class Content(object):
+
     def __init__(self, conf, container_id, metadata, chunks, storage_method,
-                 container_client=None):
+                 account, container_name, container_client=None):
         self.conf = conf
         self.container_id = container_id
         self.metadata = metadata
@@ -40,6 +41,8 @@ class Content(object):
         self.checksum = self.metadata["hash"]
         self.mime_type = self.metadata["mime_type"]
         self.chunk_method = self.metadata["chunk_method"]
+        self.account = account
+        self.container_name = container_name
 
     def _get_spare_chunk(self, chunks_notin, chunks_broken):
         spare_data = {

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -76,8 +76,7 @@ class ECContent(Content):
 
         meta['metachunk_hash'] = current_chunk.checksum
         meta['metachunk_size'] = current_chunk.size
-        meta['full_path'] = ['%s/%s/%s' % (self.account,
-                                           self.container_name, self.path)]
+        meta['full_path'] = self.full_path
         meta['oio_version'] = OIO_VERSION
         self.blob_client.chunk_put(spare_url[0], meta, GeneratorIO(stream))
         if chunk_id is None:
@@ -91,19 +90,8 @@ class ECContent(Content):
         return stream
 
     def create(self, stream, **kwargs):
-        sysmeta = {}
-        sysmeta['id'] = self.content_id
-        sysmeta['version'] = self.version
-        sysmeta['policy'] = self.stgpol
-        sysmeta['mime_type'] = self.mime_type
-        sysmeta['chunk_method'] = self.chunk_method
-        sysmeta['chunk_size'] = self.metadata['chunk_size']
-        sysmeta['oio_version'] = OIO_VERSION
-        sysmeta['full_path'] = ['%s/%s/%s' % (self.account,
-                                              self.container_name, self.path)]
+        sysmeta = self._generate_sysmeta()
         chunks = _sort_chunks(self.chunks.raw(), self.storage_method.ec)
-        sysmeta['content_path'] = self.path
-        sysmeta['container_id'] = self.container_id
 
         headers = {}
         handler = ECWriteHandler(

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -19,6 +19,7 @@ from oio.content.content import Content, Chunk
 from oio.api.ec import ECWriteHandler, ECRebuildHandler
 from oio.api.object_storage import _sort_chunks, fetch_stream_ec
 from oio.common.utils import GeneratorIO
+from oio.common.constants import OIO_VERSION
 
 
 class ECContent(Content):
@@ -75,6 +76,9 @@ class ECContent(Content):
 
         meta['metachunk_hash'] = current_chunk.checksum
         meta['metachunk_size'] = current_chunk.size
+        meta['full_path'] = ['%s/%s/%s' % (self.account,
+                                           self.container_name, self.path)]
+        meta['oio_version'] = OIO_VERSION
         self.blob_client.chunk_put(spare_url[0], meta, GeneratorIO(stream))
         if chunk_id is None:
             self._add_raw_chunk(current_chunk, spare_url[0])
@@ -94,7 +98,9 @@ class ECContent(Content):
         sysmeta['mime_type'] = self.mime_type
         sysmeta['chunk_method'] = self.chunk_method
         sysmeta['chunk_size'] = self.metadata['chunk_size']
-
+        sysmeta['oio_version'] = OIO_VERSION
+        sysmeta['full_path'] = ['%s/%s/%s' % (self.account,
+                                              self.container_name, self.path)]
         chunks = _sort_chunks(self.chunks.raw(), self.storage_method.ec)
         sysmeta['content_path'] = self.path
         sysmeta['container_id'] = self.container_id

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -56,22 +56,22 @@ class ContentFactory(object):
                    container_client=self.container_client)
 
     def new(self, container_id, path, size, policy, account=None,
-            c_name=None):
+            container_name=None):
         meta, chunks = self.container_client.content_prepare(
             cid=container_id, path=path, size=size, stgpol=policy)
 
         chunk_method = meta['chunk_method']
         storage_method = STORAGE_METHODS.load(chunk_method)
-        if not account or not c_name:
+        if not account or not container_name:
             container_info = self.container_client.container_get_properties(
                 cid=container_id)['system']
             if not account:
                 account = container_info['sys.account']
-            if not c_name:
-                c_name = container_info['sys.user.name']
+            if not container_name:
+                container_name = container_info['sys.user.name']
         cls = ECContent if storage_method.ec else PlainContent
         return cls(self.conf, container_id, meta, chunks, storage_method,
-                   account, c_name)
+                   account, container_name)
 
     def change_policy(self, container_id, content_id, new_policy):
         old_content = self.get(container_id, content_id)

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -21,7 +21,6 @@ from oio.common.storage_method import STORAGE_METHODS
 from oio.content.content import Content, Chunk
 from oio.common import exceptions as exc
 from oio.common.exceptions import UnrecoverableContent
-from oio.common.constants import OIO_VERSION
 
 
 class PlainContent(Content):
@@ -32,23 +31,9 @@ class PlainContent(Content):
         return stream
 
     def create(self, stream, **kwargs):
-        sysmeta = {}
-        sysmeta['id'] = self.content_id
-        sysmeta['version'] = self.version
-        sysmeta['policy'] = self.stgpol
-        sysmeta['mime_type'] = self.mime_type
-        sysmeta['chunk_method'] = self.chunk_method
-        sysmeta['chunk_size'] = self.metadata['chunk_size']
-        sysmeta['full_path'] = ['{0}/{1}/{2}'.format(self.account,
-                                                     self.container_name,
-                                                     self.path)]
-        sysmeta['oio_version'] = OIO_VERSION
         storage_method = STORAGE_METHODS.load(self.chunk_method)
-
+        sysmeta = self._generate_sysmeta()
         chunks = _sort_chunks(self.chunks.raw(), storage_method.ec)
-
-        sysmeta['content_path'] = self.path
-        sysmeta['container_id'] = self.container_id
 
         # TODO deal with headers
         headers = {}

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -21,6 +21,7 @@ from oio.common.storage_method import STORAGE_METHODS
 from oio.content.content import Content, Chunk
 from oio.common import exceptions as exc
 from oio.common.exceptions import UnrecoverableContent
+from oio.common.constants import OIO_VERSION
 
 
 class PlainContent(Content):
@@ -38,7 +39,10 @@ class PlainContent(Content):
         sysmeta['mime_type'] = self.mime_type
         sysmeta['chunk_method'] = self.chunk_method
         sysmeta['chunk_size'] = self.metadata['chunk_size']
-
+        sysmeta['full_path'] = ['{0}/{1}/{2}'.format(self.account,
+                                                     self.container_name,
+                                                     self.path)]
+        sysmeta['oio_version'] = OIO_VERSION
         storage_method = STORAGE_METHODS.load(self.chunk_method)
 
         chunks = _sort_chunks(self.chunks.raw(), storage_method.ec)

--- a/oio/ecd/app.py
+++ b/oio/ecd/app.py
@@ -25,6 +25,8 @@ sys_headers = {
     'content_version': '%scontent-version' % SYS_PREFIX,
     'content_policy': '%scontent-storage-policy' % SYS_PREFIX,
     'container_id': '%scontainer-id' % SYS_PREFIX,
+    'oio_version': '%soio-version' % SYS_PREFIX,
+    'full_path': '%sfull-path' % SYS_PREFIX
 }
 
 
@@ -42,6 +44,9 @@ def load_sysmeta(request):
         sysmeta['content_chunksnb'] = h.get(sys_headers['content_chunksnb'],
                                             "1")
         sysmeta['container_id'] = h[sys_headers['container_id']]
+        sysmeta['full_path'] = h[sys_headers['full_path']]
+        sysmeta['oio_version'] = h[sys_headers['oio_version']]
+
         return sysmeta
     except KeyError:
         print h

--- a/rawx-apache2/src/rawx_chunk_update.c
+++ b/rawx-apache2/src/rawx_chunk_update.c
@@ -230,6 +230,10 @@ _load_in_place_chunk_info(const dav_resource *r, const char *path, struct chunk_
 	str_replace_by_pooled_str(p, &(chunk->chunk_position));
 	str_replace_by_pooled_str(p, &(chunk->chunk_hash));
 
+	str_replace_by_pooled_str(p, &(chunk->oio_version));
+	str_replace_by_pooled_str(p, &(chunk->oio_full_path));
+
+
 	if (!get_compression_info_in_attr(path, &ge, comp_opt)){
 		if(NULL != ge) {
 			e = server_create_and_stat_error(conf, p, HTTP_CONFLICT,

--- a/rawx-apache2/src/rawx_internals.c
+++ b/rawx-apache2/src/rawx_internals.c
@@ -147,6 +147,10 @@ send_chunk_event(const char *type, const dav_resource *resource)
 	_PAIR_AND_COMMA("chunk_position", resource->info->chunk.chunk_position);
 	_PAIR_AND_COMMA("chunk_hash", resource->info->chunk.chunk_hash);
 
+	_PAIR_AND_COMMA("oio_version", resource->info->chunk.oio_version);
+
+	_PAIR_AND_COMMA("full_path", resource->info->chunk.oio_full_path);
+
 	g_string_append_c(json, '}');
 
 	const gint64 pre = oio_ext_monotonic_time ();

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -245,7 +245,7 @@ _load_field(apr_pool_t *pool, apr_table_t *table, const char *name, char **dst)
 }
 
 static int
-_load_fields(apr_pool_t *pool, apr_table_t *table, const char *name, char ** dst)
+_load_raw_field(apr_pool_t *pool, apr_table_t *table, const char *name, char ** dst)
 {
 	const char *value = apr_table_get(table, name);
 	if (!value)
@@ -333,7 +333,7 @@ request_load_chunk_info_from_headers(request_rec *request,
 	LAZY_LOAD_FIELD(oio_version,            "oio-version");
 
 	if (!cti->oio_full_path) {
-		_load_fields(pool, src, RAWX_HEADER_PREFIX  "full-path", &(cti->oio_full_path));
+		_load_raw_field(pool, src, RAWX_HEADER_PREFIX  "full-path", &(cti->oio_full_path));
 	}
 }
 

--- a/rawx-lib/src/rawx.h
+++ b/rawx-lib/src/rawx.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define ATTR_NAME_MAX_LENGTH 64
 
 # define ATTR_DOMAIN "user.grid"
+# define ATTR_OIO_DOMAIN "user.oio"
 
 # define ATTR_NAME_CONTENT_CONTAINER "content.container"
 
@@ -48,6 +49,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # define ATTR_NAME_CHUNK_METADATA_COMPRESS "compression.metadata"
 # define ATTR_NAME_CHUNK_COMPRESSED_SIZE   "compression.size"
+
+# define ATTR_NAME_OIO_VERSION "oio.version"
+
+# define ATTR_NAME_OIO_USER_PATH "oio.user"
+
 
 #define NS_RAWX_BUFSIZE_OPTION "rawx_bufsize"
 
@@ -83,6 +89,10 @@ typedef struct chunk_textinfo_s
 
 	gchar *compression_metadata;
 	gchar *compression_size;
+
+	gchar *oio_version;
+
+	gchar *oio_full_path;
 
 } chunk_textinfo_t;
 

--- a/rawx-lib/src/rawx.h
+++ b/rawx-lib/src/rawx.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define ATTR_NAME_MAX_LENGTH 64
 
 # define ATTR_DOMAIN "user.grid"
-# define ATTR_OIO_DOMAIN "user.oio"
+# define ATTR_DOMAIN_OIO "user.oio"
 
 # define ATTR_NAME_CONTENT_CONTAINER "content.container"
 

--- a/tests/functional/audit/test_audit_storage.py
+++ b/tests/functional/audit/test_audit_storage.py
@@ -9,6 +9,7 @@ from oio.container.client import ContainerClient
 from oio.blob.client import BlobClient
 from oio.common.constants import chunk_xattr_keys
 from tests.utils import BaseTestCase, random_str, random_id
+from oio.common.constants import OIO_VERSION
 
 
 class TestContent(object):
@@ -77,6 +78,9 @@ class TestBlobAuditorFunctional(BaseTestCase):
                       'chunk_id': self.chunk.id_chunk,
                       'chunk_pos': self.chunk.pos,
                       'chunk_hash': self.chunk.md5,
+                      'full_path': ['%s/%s/%s' % (self.account, self.ref,
+                                                  self.content.path)],
+                      'oio_version': OIO_VERSION
                       }
         self.blob_c.chunk_put(self.chunk_url, chunk_meta, self.data)
 

--- a/tests/functional/blob/test_blob.py
+++ b/tests/functional/blob/test_blob.py
@@ -4,7 +4,9 @@ import os
 import os.path
 from hashlib import md5
 from urlparse import urlparse
+from urllib import quote_plus
 from oio.common.http import http_connect
+from oio.common.constants import OIO_VERSION
 
 from tests.utils import BaseTestCase
 
@@ -37,6 +39,10 @@ class TestBlobFunctional(BaseTestCase):
             'x-oio-chunk-meta-chunk-size': len(data),
             'x-oio-chunk-meta-chunk-hash': md5(data).hexdigest().upper(),
             'x-oio-chunk-meta-chunk-pos': 0,
+            'x-oio-chunk-meta-full-path': quote_plus(('test/test/test' +
+                                                      ',test1/test1/test1'),
+                                                     ","),
+            'x-oio-chunk-meta-oio-version': OIO_VERSION
         }
 
     def _rawx_url(self, chunkid):

--- a/tests/functional/content/test_content.py
+++ b/tests/functional/content/test_content.py
@@ -88,7 +88,10 @@ class TestContentFactory(BaseTestCase):
             "mime_type": "application/octet-stream",
             "name": "tox.ini",
             "policy": self.stgpol_ec,
-            "version": "1450176946676289"
+            "version": "1450176946676289",
+            "full_path": ["%s/%s/%s" % (self.account, self.container_name,
+                                        "tox.ini")],
+            "oio_version": "4.0",
         }
         chunks = [
             {
@@ -110,7 +113,9 @@ class TestContentFactory(BaseTestCase):
         ]
         self.content_factory.container_client.content_locate = Mock(
             return_value=(meta, chunks))
-        c = self.content_factory.get("xxx_container_id", "xxx_content_id")
+        c = self.content_factory.get("xxx_container_id", "xxx_content_id",
+                                     account=self.account,
+                                     container_name=self.container_name)
         self.assertEqual(type(c), ECContent)
         self.assertEqual(c.content_id, "3FA2C4A1ED2605005335A276890EC458")
         self.assertEqual(c.length, 658)
@@ -135,7 +140,10 @@ class TestContentFactory(BaseTestCase):
             "mime_type": "application/octet-stream",
             "name": "tox.ini",
             "policy": self.stgpol_twocopies,
-            "version": "1450176946676289"
+            "version": "1450176946676289",
+            "full_path": ["%s/%s/%s" % (self.account, self.container_name,
+                                        "tox.ini")],
+            "oio_version": "4.0",
         }
         chunks = [
             {
@@ -149,7 +157,9 @@ class TestContentFactory(BaseTestCase):
         ]
         self.content_factory.container_client.content_locate = Mock(
             return_value=(meta, chunks))
-        c = self.content_factory.get("xxx_container_id", "xxx_content_id")
+        c = self.content_factory.get("xxx_container_id", "xxx_content_id",
+                                     account=self.account,
+                                     container_name=self.container_name)
         self.assertEqual(type(c), PlainContent)
         self.assertEqual(c.content_id, "3FA2C4A1ED2605005335A276890EC458")
         self.assertEqual(c.length, 658)
@@ -176,7 +186,10 @@ class TestContentFactory(BaseTestCase):
             "mime_type": "application/octet-stream",
             "name": "titi",
             "policy": self.stgpol_ec,
-            "version": "1450341162332663"
+            "version": "1450341162332663",
+            "full_path": ["%s/%s/%s" % (self.account, self.container_name,
+                                        "titi")],
+            "oio_version": "4.0",
         }
         chunks = [
             {
@@ -199,7 +212,9 @@ class TestContentFactory(BaseTestCase):
         self.content_factory.container_client.content_prepare = Mock(
             return_value=(meta, chunks))
         c = self.content_factory.new("xxx_container_id", "titi",
-                                     1000, self.stgpol_ec)
+                                     1000, self.stgpol_ec,
+                                     account=self.account,
+                                     c_name=self.container_name)
         self.assertEqual(type(c), ECContent)
         self.assertEqual(c.content_id, "F4B1C8DD132705007DE8B43D0709DAA2")
         self.assertEqual(c.length, 1000)
@@ -367,6 +382,7 @@ class TestContentFactory(BaseTestCase):
                 "I\\put\\backslashes\\and$dollar$signs$in$file$names",
                 "Je suis tombé sur la tête, mais ça va bien.",
                 "%s%f%u%d%%",
+                "{1},{0},{3}",
                 "carriage\rreturn",
                 "line\nfeed",
                 "ta\tbu\tla\ttion",

--- a/tests/functional/content/test_ec.py
+++ b/tests/functional/content/test_ec.py
@@ -32,6 +32,7 @@ from oio.content.ec import ECContent
 from tests.functional.content.test_content import md5_stream, random_data, \
             md5_data
 from tests.utils import BaseTestCase, random_str
+from urllib import quote_plus
 
 
 DAT_LEGIT_SIZE = 1024
@@ -65,6 +66,12 @@ class TestECContent(BaseTestCase):
 
     def tearDown(self):
         super(TestECContent, self).tearDown()
+
+    def _generate_fullpath(self, account, container_name, path, version):
+        return ['{0}/{1}/{2}/{3}'.format(quote_plus(account),
+                                         quote_plus(container_name),
+                                         quote_plus(path),
+                                         version)]
 
     def random_chunks(self, nb):
         l = random.sample(xrange(self.k + self.m), nb)
@@ -113,9 +120,11 @@ class TestECContent(BaseTestCase):
                 self.assertEqual(meta['chunk_id'], chunk.id)
                 self.assertEqual(meta['chunk_pos'], chunk.pos)
                 self.assertEqual(meta['chunk_hash'], md5_stream(stream))
-                self.assertEqual(meta['full_path'], ['%s/%s/%s' %
-                                 (self.account, self.container_name,
-                                  self.content)])
+                full_path = self._generate_fullpath(self.account,
+                                                    self.container_name,
+                                                    self.content,
+                                                    meta['content_version'])
+                self.assertEqual(meta['full_path'], full_path)
                 self.assertEqual(meta['oio_version'], '4.0')
                 self.assertEqual(metachunk_hash, chunk.checksum)
 

--- a/tests/functional/content/test_ec.py
+++ b/tests/functional/content/test_ec.py
@@ -113,6 +113,10 @@ class TestECContent(BaseTestCase):
                 self.assertEqual(meta['chunk_id'], chunk.id)
                 self.assertEqual(meta['chunk_pos'], chunk.pos)
                 self.assertEqual(meta['chunk_hash'], md5_stream(stream))
+                self.assertEqual(meta['full_path'], ['%s/%s/%s' %
+                                 (self.account, self.container_name,
+                                  self.content)])
+                self.assertEqual(meta['oio_version'], '4.0')
                 self.assertEqual(metachunk_hash, chunk.checksum)
 
             offset += metachunk_size

--- a/tests/functional/content/test_plain.py
+++ b/tests/functional/content/test_plain.py
@@ -106,6 +106,10 @@ class TestPlainContent(BaseTestCase):
                 self.assertEqual(meta['chunk_hash'], chunk_hash)
                 # Check that chunk data matches chunk hash from database
                 self.assertEqual(chunk.checksum, chunk_hash)
+                self.assertEqual(meta['full_path'], ['%s/%s/%s' %
+                                 (self.account, self.container_name,
+                                  self.content)])
+                self.assertEqual(meta['oio_version'], '4.0')
 
     def test_twocopies_create_0_byte(self):
         self._test_create(self.stgpol_twocopies, 0)

--- a/tests/functional/content/test_plain.py
+++ b/tests/functional/content/test_plain.py
@@ -29,6 +29,7 @@ from oio.content.factory import ContentFactory
 from tests.functional.content.test_content import random_data, md5_data, \
     md5_stream
 from tests.utils import BaseTestCase, random_str
+from urllib import quote_plus
 
 
 class TestPlainContent(BaseTestCase):
@@ -55,6 +56,12 @@ class TestPlainContent(BaseTestCase):
         self.stgpol = "SINGLE"
         self.stgpol_twocopies = "TWOCOPIES"
         self.stgpol_threecopies = "THREECOPIES"
+
+    def _generate_fullpath(self, account, container_name, path, version):
+        return ['{0}/{1}/{2}/{3}'.format(quote_plus(account),
+                                         quote_plus(container_name),
+                                         quote_plus(path),
+                                         version)]
 
     def _test_create(self, stgpol, data_size):
         data = random_data(data_size)
@@ -106,9 +113,11 @@ class TestPlainContent(BaseTestCase):
                 self.assertEqual(meta['chunk_hash'], chunk_hash)
                 # Check that chunk data matches chunk hash from database
                 self.assertEqual(chunk.checksum, chunk_hash)
-                self.assertEqual(meta['full_path'], ['%s/%s/%s' %
-                                 (self.account, self.container_name,
-                                  self.content)])
+                full_path = self._generate_fullpath(self.account,
+                                                    self.container_name,
+                                                    self.content,
+                                                    meta['content_version'])
+                self.assertEqual(meta['full_path'], full_path)
                 self.assertEqual(meta['oio_version'], '4.0')
 
     def test_twocopies_create_0_byte(self):

--- a/tests/functional/crawler/test_storage_tierer.py
+++ b/tests/functional/crawler/test_storage_tierer.py
@@ -80,7 +80,7 @@ class TestStorageTierer(BaseTestCase):
         data = random_data(10)
         content = self.content_factory.new(container_id, content_name,
                                            len(data), stgpol, account=account,
-                                           c_name=reference)
+                                           container_name=reference)
 
         content.create(BytesIO(data))
         return content

--- a/tests/functional/crawler/test_storage_tierer.py
+++ b/tests/functional/crawler/test_storage_tierer.py
@@ -58,7 +58,8 @@ class TestStorageTierer(BaseTestCase):
             account=self.test_account, reference=self.container_1_name)
         self.container_1_content_0_name = "container_1_content_0"
         self.container_1_content_0 = self._new_content(
-            self.container_1_id, self.container_1_content_0_name, "SINGLE")
+            self.container_1_id, self.container_1_content_0_name, "SINGLE",
+            self.test_account, self.container_0_name)
 
         self.container_2_name = "container_with_2_contents"
         self.container_2_id = cid_from_name(
@@ -67,15 +68,19 @@ class TestStorageTierer(BaseTestCase):
             account=self.test_account, reference=self.container_2_name)
         self.container_2_content_0_name = "container_2_content_0"
         self.container_2_content_0 = self._new_content(
-            self.container_2_id, self.container_2_content_0_name, "SINGLE")
+            self.container_2_id, self.container_2_content_0_name, "SINGLE",
+            self.test_account, self.container_0_name)
         self.container_2_content_1_name = "container_2_content_1"
         self.container_2_content_1 = self._new_content(
-            self.container_2_id, self.container_2_content_1_name, "TWOCOPIES")
+            self.container_2_id, self.container_2_content_1_name, "TWOCOPIES",
+            self.test_account, self.container_0_name)
 
-    def _new_content(self, container_id, content_name, stgpol):
+    def _new_content(self, container_id, content_name, stgpol, account,
+                     reference):
         data = random_data(10)
         content = self.content_factory.new(container_id, content_name,
-                                           len(data), stgpol)
+                                           len(data), stgpol, account=account,
+                                           c_name=reference)
 
         content.create(BytesIO(data))
         return content
@@ -117,7 +122,8 @@ class TestStorageTierer(BaseTestCase):
         # add a new content created after the three previous contents
         now = int(time.time())
         time.sleep(2)
-        self._new_content(self.container_2_id, "titi", "TWOCOPIES")
+        self._new_content(self.container_2_id, "titi", "TWOCOPIES",
+                          self.test_account, self.container_2_name)
 
         self.gridconf["outdated_threshold"] = 2
         worker = StorageTiererWorker(self.gridconf, Mock())

--- a/tests/functional/rdir/test_indexer.py
+++ b/tests/functional/rdir/test_indexer.py
@@ -8,6 +8,7 @@ from oio.blob.utils import chunk_xattr_keys
 from oio.common.exceptions import FaultyChunk
 from oio.rdir.client import RdirClient
 from tests.utils import BaseTestCase, random_id
+from oio.common.constants import OIO_VERSION
 
 
 class TestIndexerCrawler(BaseTestCase):
@@ -60,6 +61,8 @@ class TestIndexerCrawler(BaseTestCase):
             'plain/nb_copy=3')
         xattr.setxattr(
             chunk_path, 'user.' + chunk_xattr_keys['content_version'], '0')
+        xattr.setxattr(
+            chunk_path, 'user.' + chunk_xattr_keys['oio_version'], OIO_VERSION)
 
         return chunk_path, container_id, content_id, chunk_id
 

--- a/tests/unit/api/test_ec.py
+++ b/tests/unit/api/test_ec.py
@@ -13,6 +13,7 @@ from oio.common.constants import chunk_headers
 from tests.unit.api import empty_stream, decode_chunked_body, \
     FakeResponse, CHUNK_SIZE, EMPTY_CHECKSUM
 from tests.unit import set_http_connect, set_http_requests
+from oio.common.constants import OIO_VERSION
 
 
 class TestEC(unittest.TestCase):
@@ -29,6 +30,8 @@ class TestEC(unittest.TestCase):
             'container_id': self.cid,
             'policy': 'EC',
             'content_path': 'test',
+            'full_path': ['account/container/test'],
+            'oio_version': OIO_VERSION
         }
         self._meta_chunk = [
                 {'url': 'http://127.0.0.1:7000/0', 'pos': '0.0', 'num': 0},

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -11,6 +11,7 @@ from tests.unit.api import CHUNK_SIZE, EMPTY_CHECKSUM, empty_stream, \
     decode_chunked_body, FakeResponse
 from oio.api import io
 from tests.unit import set_http_connect, set_http_requests
+from oio.common.constants import OIO_VERSION
 
 
 class TestReplication(unittest.TestCase):
@@ -27,6 +28,8 @@ class TestReplication(unittest.TestCase):
             'container_id': self.cid,
             'policy': 'REPLI3',
             'content_path': 'test',
+            'full_path': ['account/container/test'],
+            'oio_version': OIO_VERSION,
         }
 
         self._meta_chunk = [


### PR DESCRIPTION
Modify the client to send the header X-oio-chunk-meta-full-path:Acct/Container/Name
Convert the header to the xattr oio.user:Acct/Container/Name=""