### PR TITLE
Fix load balancing on tight platforms

### DIFF
--- a/core/lb.c
+++ b/core/lb.c
@@ -128,6 +128,9 @@ struct oio_lb_slot_s
 	 * We do not use level 0 at the moment. */
 	GData *items_by_loc[OIO_LB_LOC_LEVELS];
 
+	/* Total number of different locations for each level. */
+	guint locs_by_level[OIO_LB_LOC_LEVELS];
+
 	gchar *name;
 
 	generation_t generation;
@@ -197,10 +200,24 @@ struct polling_ctx_s
 	const oio_location_t * avoids;
 	const oio_location_t * polled;
 	oio_location_t *next_polled;
-	gint n_targets;
+	guint n_targets;
 
+	/* Count how often each location has been chosen. */
 	GData *counters[OIO_LB_LOC_LEVELS];
-	gboolean fallback_used;
+
+	/* Did we use a fallback slot while polling? */
+	gboolean fallback_used : 8;
+
+	/* Shall we check the distance requirements? This will be disabled
+	 * automagically if we detect a case where it is not possible to
+	 * strictly meet the requirements. */
+	gboolean check_distance : 8;
+
+	/* Shall we check the "popularity" of locations when picking
+	 * a new item? This is useful to ensure a good balancing on
+	 * platforms where there is less locations than targets
+	 * (for the specified distance). */
+	gboolean check_popularity : 8;
 };
 
 static void _local__destroy (struct oio_lb_pool_s *self);
@@ -250,6 +267,19 @@ oio_lb_world__get_slot_unlocked(struct oio_lb_world_s *world, const char *name)
 
 static guint _search_first_at_location(GArray *tab, const oio_location_t needle,
 		const guint start, const guint end);
+
+/** Gets the number of elements in a GData. */
+static guint
+oio_ext_gdatalist_length(GData **datalist)
+{
+	guint counter = 0;
+	void _datalist_count(GQuark key_id UNUSED,
+			gpointer data UNUSED, gpointer udata UNUSED) {
+		counter++;
+	}
+	g_datalist_foreach(datalist, _datalist_count, NULL);
+	return counter;
+}
 
 /* Take djb2 hash of each part of the '.'-separated string,
  * keep the 16 LSB of each hash to build a 64b integer. */
@@ -428,6 +458,10 @@ _slot_rehash (struct oio_lb_slot_s *slot)
 			struct _slot_item_s *si = &SLOT_ITEM(slot, i);
 			_level_datalist_incr_loc(slot->items_by_loc, si->item->location);
 		}
+		for (int level = 1; level < OIO_LB_LOC_LEVELS; level++) {
+			slot->locs_by_level[level] =
+					oio_ext_gdatalist_length(&(slot->items_by_loc[level]));
+		}
 
 # ifdef HAVE_EXTRA_DEBUG
 		if (unlikely(GRID_TRACE_ENABLED())) {
@@ -498,9 +532,11 @@ _accept_item(struct oio_lb_slot_s *slot, const guint16 bit_shift,
 			return FALSE;
 	} else {
 		// Check the item is not too close to already polled items
-		if (_item_is_too_close(ctx->polled, loc, bit_shift))
+		if (_item_is_too_close(ctx->polled, loc,
+				ctx->check_distance? bit_shift : 0))
 			return FALSE;
-		if (_item_is_too_popular(ctx, loc, slot))
+		// Check the item has not been chosen too much already
+		if (ctx->check_popularity && _item_is_too_popular(ctx, loc, slot))
 			return FALSE;
 	}
 	GRID_TRACE("Accepting item %s (0x%"OIO_LOC_FORMAT") from slot %s",
@@ -538,6 +574,23 @@ _local_slot__poll(struct oio_lb_slot_s *slot, const guint16 bit_shift,
 	if (slot->sum_weight == 0) {
 		GRID_TRACE2("%s no service available", __FUNCTION__);
 		return FALSE;
+	}
+
+	/* If we need to pick more items than the number of different locations,
+	 * we can disable the distance checks, and rely only on the "popularity"
+	 * mechanism.
+	 * XXX: here we compare the overall number of targets to the number
+	 * of different locations IN THE CURRENT SLOT. We bet that in most
+	 * pools there will be only one targetted slot. */
+	if (!reversed && ctx->check_distance &&
+			bit_shift >= OIO_LB_BITS_PER_LOC_LEVEL) {
+		guint16 level = bit_shift / OIO_LB_BITS_PER_LOC_LEVEL;
+		if (ctx->n_targets > slot->locs_by_level[level]) {
+			GRID_TRACE("%u targets and %u locations at level %u: "
+					"disabling distance check",
+					ctx->n_targets, slot->locs_by_level[level], level);
+			ctx->check_distance = FALSE;
+		}
 	}
 
 	/* get the closest */
@@ -660,14 +713,14 @@ _local__patch(struct oio_lb_pool_s *self,
 
 	/* Count the expected targets to build a temp storage for
 	 * polled locations */
-	int count_targets = 0;
+	guint count_targets = 0;
 	for (gchar **ptarget = lb->targets; *ptarget; ++ptarget)
 		count_targets++;
 
 	/* Copy the array of known locations because we don't know
 	 * if its allocated length is big enough */
 	oio_location_t polled[count_targets+1];
-	int i = 0;
+	guint i = 0;
 	for (; known && known[i]; i++)
 		polled[i] = known[i];
 	for (; i < count_targets; i++)
@@ -679,6 +732,8 @@ _local__patch(struct oio_lb_pool_s *self,
 		.polled = (const oio_location_t *) polled,
 		.next_polled = polled,
 		.n_targets = count_targets,
+		.check_distance = TRUE,
+		.check_popularity = TRUE,
 	};
 
 	for (int level = 1; level < OIO_LB_LOC_LEVELS; level++) {
@@ -1176,9 +1231,9 @@ oio_lb_world__feed_slot_unlocked(struct oio_lb_world_s *self,
 # ifdef __GNUC__
 	// Actual number of bits used by the location.
 	const int n_bits = sizeof(oio_location_t) * 8 -
-		(item->location ? __builtin_clzll(item->location) : 0);
+			__builtin_clzll(item->location? : 1u);
 	// Maximum distance between items with this number of bits.
-	guint16 max_dist = 1 + n_bits / OIO_LB_BITS_PER_LOC_LEVEL;
+	guint16 max_dist = 1 + (n_bits - 1) / OIO_LB_BITS_PER_LOC_LEVEL;
 	if (self->abs_max_dist < max_dist) {
 		self->abs_max_dist = max_dist;
 		GRID_DEBUG("Absolute max_dist set to %u", max_dist);

--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -6,6 +6,7 @@ from io import BytesIO
 import itertools
 import json
 import string
+from tempfile import TemporaryFile
 import unittest
 
 import requests
@@ -190,7 +191,8 @@ class TestContainerDownload(BaseTestCase):
         self.assertEqual(ret.status_code, 200)
         self.raw = ret.content
 
-        open("_.tar", "w").write(self.raw)
+        with TemporaryFile() as tmpfile:
+            tmpfile.write(self.raw)
 
         raw = BytesIO(ret.content)
         tar = tarfile.open(fileobj=raw, ignore_zeros=True)

--- a/tests/unit/test_lb.c
+++ b/tests/unit/test_lb.c
@@ -347,7 +347,7 @@ _test_repartition_by_loc_level(const char **locations, int targets)
 	}
 	GRID_INFO("%d unbalanced situations on %d shots", unbalanced, shots);
 
-	// FIXME(FVE): there should be NO unbalanced situation
+	// FIXME(FVE): add a boolean, some configuration are voluntarily unbalanced
 	g_assert_cmpint(unbalanced, <, shots);
 
 	int ideal_count = targets * shots / services;
@@ -1088,6 +1088,7 @@ main(int argc, char **argv)
 	_add_level_repartition_test(lrt5, "6x30", 15); // 12+3
 	_add_level_repartition_test(lrt5, "6x30", 18); // 14+4
 
+	// Balanced platform: 3 racks, 5 host in each
 	const char *lrt6[16] = {
 			"rack0.srv0", "rack0.srv1", "rack0.srv2", "rack0.srv3", "rack0.srv4",
 			"rack1.srv4", "rack1.srv5", "rack1.srv6", "rack1.srv7", "rack1.srv5",
@@ -1095,6 +1096,23 @@ main(int argc, char **argv)
 			NULL
 	};
 	_add_level_repartition_test(lrt6, "3x5", 12); // 7+5
+
+	/* Unbalanced platform: 3 hosts in each rack except the last one. */
+	const char *lrt7[26] = {
+			"rack0.srv0", "rack0.srv1", "rack0.srv2",
+			"rack1.srv0", "rack1.srv1", "rack1.srv2",
+			"rack2.srv0", "rack2.srv1", "rack2.srv2",
+			"rack3.srv0", "rack3.srv1", "rack3.srv2",
+			"rack4.srv0", "rack4.srv1", "rack4.srv2",
+			"rack5.srv0", "rack5.srv1", "rack5.srv2",
+			"rack6.srv0", "rack6.srv1", "rack6.srv2",
+			"rack7.srv0", "rack7.srv1", "rack7.srv2",
+			"rack8.srv0",
+			NULL,
+	};
+	_add_level_repartition_test(lrt7, "8x3+1x1", 15); // 12+3
+	_add_level_repartition_test(lrt7, "8x3+1x1", 16); // 12+4
+	_add_level_repartition_test(lrt7, "8x3+1x1", 18); // 14+4
 
 	return g_test_run();
 };


### PR DESCRIPTION
Detect when we are in a "tight" situation, where we need to pick more
services than the number of different locations. In such case, disable
the distance checks, and rely only on the theoretical maximum number of
services per location.