### PR TITLE
bootstrap: increase MaxRequestsWorkers

### DIFF
--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -264,6 +264,7 @@ class TestContainerDownload(BaseTestCase):
         for idx in xrange(0, int(org.headers['content-length']), 512):
             ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' %
                                                             (idx, idx+511)})
+            self.assertIn(ret.status_code, [200, 206])
             data.append(ret.content)
 
         data = "".join(data)
@@ -349,6 +350,7 @@ class TestContainerDownload(BaseTestCase):
         for idx in xrange(0, int(org.headers['content-length']), 512):
             ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' %
                                                             (idx, idx+511)})
+            self.assertIn(ret.status_code, [200, 206])
             data.append(ret.content)
 
         data = "".join(data)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -199,6 +199,7 @@ MaxSpareServers 40
 <IfModule worker.c>
 StartServers 2
 MaxClients 40
+MaxRequestWorkers 100
 MinSpareThreads 2
 MaxSpareThreads 40
 ThreadsPerChild 20


### PR DESCRIPTION
During tests of range download, Apache configuration was
too short to handle lot of small requests.

oio-bootstrap now add MaxRequestsWorkers to allow Apache to spawn
new children to support charge.

This patch also enforce test by testing HTTP return code when
downloading range.