### PR TITLE
coverage: enable it for WSGI and nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ script:
   - pwd && env && ./tools/oio-travis-tests.sh
   - make coverage
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -v -f cmake_coverage.output
+  - bash <(curl -s https://codecov.io/bash) -f cmake_coverage.output
   - codecov

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -30,10 +30,8 @@ function dump_syslog {
 
 #trap dump_syslog EXIT
 
-has_coverage () { [ -n "$COVERAGE" ] ; }
-
 is_running_test_suite () {
-    has_coverage || [ -z "$TEST_SUITE" ] || [ "${TEST_SUITE/*$1*/$1}" == "$1" ]
+    [ -z "$TEST_SUITE" ] || [ "${TEST_SUITE/*$1*/$1}" == "$1" ]
 }
 
 randomize_env () {
@@ -113,11 +111,7 @@ func_tests () {
 
 	# Run the whole suite of functional tests (Python)
     cd $SRCDIR
-    if has_coverage ; then
-		tox -e coverage && tox -e cover,func
-	else
-		tox -e func
-    fi
+    tox -e func,coverage
 
 	# Run the whole suite of functional tests (C)
     cd $WRKDIR
@@ -134,6 +128,7 @@ func_tests () {
 	test_oio_tool
 
     gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
+    sleep 0.5
 }
 
 test_meta2_filters () {
@@ -141,12 +136,11 @@ test_meta2_filters () {
     oio-reset.sh -N $OIO_NS $@
 
     cd $SRCDIR
-    if has_coverage ; then
-		tox -e coverage
-    fi
+    tox -e coverage
     ${PYTHON} $(which nosetests) tests.functional.m2_filters.test_filters
 
     gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
+    sleep 0.5
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,20 +16,13 @@ passenv = OIO_*
 [testenv:coverage]
 commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {posargs:tests/unit}
 
-[testenv:cover]
-setenv = VIRTUAL_ENV={envdir}
-         NOSE_WITH_COVERAGE=1
-         NOSE_COVER_BRANCHES=1
-         NOSE_COVER_HTML=1
-         NOSE_COVER_HTML_DIR={toxinidir}/cover
-
 [testenv:pep8]
 commands =
     flake8 oio tests setup.py
     flake8 tools/oio-rdir-harass.py  tools/oio-test-config.py  tools/zk-bootstrap.py  tools/zk-reset.py
 
 [testenv:func]
-commands = nosetests -v {env:NOSE_ARGS:} {posargs:tests/functional}
+commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional}
 
 [flake8]
 show-source = True


### PR DESCRIPTION
Command for coverage for [testenv:func] was skipped.

Also add coverage call for WSGI application but coverage stills missing for some WSGI application, at least they are now in report.

Remove the verbose mode of codecov