### PR TITLE
[wip] Add ASAN compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(FORBID_SLICE "Forbid playing with GLib2's slice allocators" OFF)
 option(ALLOW_BACKTRACE "Attempt to compute backtraces when errors occur" OFF)
 option(FORBID_DEPRECATED "Avoid the deprecated symbols of the GLib2" OFF)
 option(ENABLE_CODECOVERAGE "Enable code coverage testing support" OFF)
+option(ASAN "Compile with ASAN" OFF)
 
 include(CheckIncludeFile)
 include(CheckLibraryExists)
@@ -122,12 +123,19 @@ endif()
 
 MESSAGE("OPTIONS:"
 	" ENBUG=${ENBUG}"
+    " ASAN=${ASAN}"
 	" SOCKET_OPTIMIZED=${SOCKET_OPTIMIZED}"
 	" FORBID_SLICE=${FORBID_SLICE}"
 	" STACK_PROTECTOR=${STACK_PROTECTOR}"
 	" FORBID_DEPRECATED=${FORBID_DEPRECATED}"
 	" ALLOW_BACKTRACE=${ALLOW_BACKTRACE}"
 	" ENABLE_CODECOVERAGE=${ENABLE_CODECOVERAGE}")
+
+if (ASAN)
+    MESSAGE(WARNING "ASAN MODE : NOT FOR PRODUCTION USE")
+    # use ASAN as static, still requires LD_PRELOAD for Apache
+    set(CMAKE_C_FLAGS "-static-libasan ${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+endif()
 
 if (ENBUG)
 	MESSAGE(WARNING "ENBUGED MODE : NOT FOR PRODUCTION USE")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,15 +34,32 @@ add_custom_command(
 		"client"
 		${CMAKE_SOURCE_DIR}/conf.json)
 
+add_library(asan STATIC IMPORTED)
+set_property(TARGET asan PROPERTY IMPORTED_LOCATION /usr/lib/gcc/x86_64-linux-gnu/7/libasan.a)
+
 add_library(oiocore SHARED url.c cfg.c str.c ext.c log.c lb.c var.c
 	${CMAKE_CURRENT_BINARY_DIR}/client_variables.h
 	${CMAKE_CURRENT_BINARY_DIR}/client_variables.c)
 
 target_link_libraries(oiocore
 		${JSONC_LIBRARIES} ${GLIB2_LIBRARIES})
+
 set_target_properties(oiocore PROPERTIES
 		PUBLIC_HEADER "oio_core.h"
 		SOVERSION ${ABI_VERSION})
+
+if (ASAN)
+    add_library(oiocore-asan SHARED url.c cfg.c str.c ext.c log.c lb.c var.c
+        ${CMAKE_CURRENT_BINARY_DIR}/client_variables.h
+        ${CMAKE_CURRENT_BINARY_DIR}/client_variables.c)
+
+    target_link_libraries(oiocore-asan
+            ${JSONC_LIBRARIES} ${GLIB2_LIBRARIES} asan)
+
+    set_target_properties(oiocore-asan PROPERTIES
+            PUBLIC_HEADER "oio_core.h"
+            SOVERSION ${ABI_VERSION})
+endif()
 
 add_library(oiosds SHARED
 	http_put.c
@@ -50,6 +67,7 @@ add_library(oiosds SHARED
 	headers.c
 	proxy.c
 	sds.c dir.c cs.c)
+
 target_link_libraries(oiosds oiocore
 		${GLIB2_LIBRARIES} ${CURL_LIBRARIES} ${JSONC_LIBRARIES})
 set_target_properties(oiosds PROPERTIES

--- a/oio/common/autocontainer.py
+++ b/oio/common/autocontainer.py
@@ -63,7 +63,11 @@ class HashedContainerBuilder(ContainerBuilder):
 
     def __call__(self, path):
         if self.lib is None:
-            self.lib = CDLL('liboiocore.so.0')
+            # Try of load debug liboiocore first
+            try:
+                self.lib = CDLL('liboiocore-asan.so.0')
+            except OSError:
+                self.lib = CDLL('liboiocore.so.0')
             self.func = self.lib.oio_str_autocontainer
             self.func.argtypes = [c_char_p, c_uint, c_char_p, c_uint]
             self.func.restype = c_char_p

--- a/oio/conscience/stats/system.py
+++ b/oio/conscience/stats/system.py
@@ -42,6 +42,8 @@ class SystemStat(BaseStat):
     def get_stats(self):
         # TODO maybe cache these results
         if not self.__class__.oio_sys_cpu_idle:
+            self._load_lib("liboiocore-asan.so.0")
+        if not self.__class__.oio_sys_cpu_idle:
             self._load_lib()
         if not self.__class__.oio_sys_cpu_idle:
             return {}

--- a/oio/conscience/stats/volume.py
+++ b/oio/conscience/stats/volume.py
@@ -48,6 +48,8 @@ class VolumeStat(BaseStat):
 
     def get_stats(self):
         if not self.__class__.oio_sys_space_idle:
+            self._load_lib("liboiocore-asan.so.0")
+        if not self.__class__.oio_sys_space_idle:
             self._load_lib()
         if not self.__class__.oio_sys_space_idle:
             return {}

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -700,6 +700,10 @@ start_at_boot=false
 on_die=respawn
 """
 
+template_gridinit_asan = """
+env.LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so
+"""
+
 template_local_header = """
 [default]
 """
@@ -951,6 +955,7 @@ TMPDIR = '/tmp'
 CODEDIR = '@CMAKE_INSTALL_PREFIX@'
 LIBDIR = CODEDIR + '/@LD_LIBDIR@'
 PATH = HOME+"/.local/bin:@CMAKE_INSTALL_PREFIX@/bin:/usr/sbin"
+ASAN = "@ASAN@"
 
 # Constants for the configuration of oio-bootstrap
 NS = 'ns'
@@ -1287,7 +1292,8 @@ def generate(options):
                           })
             add_service(env)
             # gridinit (rawx)
-            tpl = Template(template_gridinit_httpd)
+            asan = template_gridinit_asan if ASAN else ""
+            tpl = Template(template_gridinit_httpd + asan)
             with open(gridinit(env), 'a+') as f:
                 f.write(tpl.safe_substitute(env))
             # service
@@ -1439,7 +1445,8 @@ def generate(options):
 
     # gridinit header
     with open(gridinit(ENV), 'a+') as f:
-        tpl = Template(template_gridinit_ns)
+        asan = template_gridinit_asan if ASAN else ""
+        tpl = Template(template_gridinit_ns + asan)
         f.write(tpl.safe_substitute(ENV))
     # system config
     with open('{OIODIR}/sds.conf'.format(**ENV), 'w+') as f:

--- a/tools/oio-tool.c
+++ b/tools/oio-tool.c
@@ -189,6 +189,7 @@ _info(const char *dest)
 		return 0;
 	}
 	if (out) g_byte_array_free(out, TRUE);
+    return 0;
 }
 
 static int


### PR DESCRIPTION
To enable it, run cmake with -DASAN=ON

You may have to fix path for libasan.so in oio-bootstrap.py regarding
your OS and/or your compiler.

Clang is not used as compiler as it doesn't support nested C functions but it still needed for report.

Please note that Python tests are not yet fixed to work with this
compilation mode.

Don't forget to insert in PATH your version of clang if you are using not default version on your system for human readable report:
```
$ export ASAN_OPTIONS=symbolize=1 
$ export PATH=$PATH:/usr/lib/llvm-4.0/bin/
$ export ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer)
```