### PR TITLE
tools: fix travis test

### DIFF
--- a/oio/container/backup.py
+++ b/oio/container/backup.py
@@ -345,6 +345,7 @@ class ContainerTarFile(object):
         if self.blocks:
             self.logger.info("data not all consumed")
 
+
 def redis_cnx(f):
     def wrapper(*args):
         try:

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -52,7 +52,8 @@ func_tests () {
 	# Run the whole suite of functional tests (Python)
     cd $SRCDIR
     if has_coverage ; then
-		tox -e coverage && tox -e cover,func
+		tox -e coverage
+		tox -e cover,func
 	else
 		tox -e func
     fi
@@ -88,8 +89,11 @@ test_meta2_filters () {
 
 if is_running_test_suite "unit" ; then
 	echo -e "\n### UNIT tests"
-	cd $SRCDIR && tox -e pep8 && tox -e py27
-	cd $WRKDIR && make -C tests/unit test
+	cd $SRCDIR
+	tox -e pep8
+	tox -e py27
+	cd $WRKDIR
+	make -C tests/unit test
 fi
 
 if is_running_test_suite "repli" ; then


### PR DESCRIPTION
Fix a subtile issue with `set -e` and `&&`: some tests were launched with `&&` but `set -e` option didn't stop the script when an intermediate compound failed.