### PR TITLE
HttpApi: Remove 'requests' to use 'urllib3' directly

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -10,3 +10,4 @@ plyvel>=0.9
 PyYAML>=3.10
 PyECLib>=1.2.0
 futures>=3.0.5
+urllib3>=1.13.1

--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -105,7 +105,7 @@ class AccountClient(HttpApi):
         :returns: `True` if the account has been created
         """
         resp, _body = self.account_request(account, 'PUT', 'create', **kwargs)
-        return resp.status_code == 201
+        return resp.status == 201
 
     def account_delete(self, account, **kwargs):
         """

--- a/oio/cli/admin/client.py
+++ b/oio/cli/admin/client.py
@@ -11,7 +11,7 @@ API_NAME = 'admin'
 
 
 class AdminClient(object):
-    def __init__(self, namespace, session=None, **kwargs):
+    def __init__(self, namespace, pool_manager=None, **kwargs):
         self.conf = {'namespace': namespace}
         self.conf.update(kwargs)
         self._rdir = None
@@ -19,18 +19,19 @@ class AdminClient(object):
         self._event = None
         self._cluster = None
         self._meta0 = None
-        self.session = session
+        self.pool_manager = pool_manager
 
     @property
     def volume(self):
         if not self._rdir:
-            self._rdir = RdirClient(self.conf, session=self.session)
+            self._rdir = RdirClient(self.conf, pool_manager=self.pool_manager)
         return self._rdir
 
     @property
     def rdir_lb(self):
         if not self._rdir_lb:
-            self._rdir_lb = RdirDispatcher(self.conf, session=self.session)
+            self._rdir_lb = RdirDispatcher(self.conf,
+                                           pool_manager=self.pool_manager)
         return self._rdir_lb
 
     @property
@@ -42,13 +43,15 @@ class AdminClient(object):
     @property
     def cluster(self):
         if not self._cluster:
-            self._cluster = ConscienceClient(self.conf, session=self.session)
+            self._cluster = ConscienceClient(self.conf,
+                                             pool_manager=self.pool_manager)
         return self._cluster
 
     @property
     def meta0(self):
         if not self._meta0:
-            self._meta0 = Meta0Client(self.conf, session=self.session)
+            self._meta0 = Meta0Client(self.conf,
+                                      pool_manager=self.pool_manager)
         return self._meta0
 
     def event_stats(self, tube=None):

--- a/oio/cli/admin/directory.py
+++ b/oio/cli/admin/directory.py
@@ -75,7 +75,7 @@ class DirectoryInit(DirectoryCmd):
 
         if checked:
             self.log.info("Saving...")
-            mapping.force(timeout=(5.0, 30.0))
+            mapping.force(connection_timeout=5.0, read_timeout=30.0)
 
         if parsed_args.rdir:
             self.log.info("Assigning rdir services to rawx services...")

--- a/oio/cli/shell.py
+++ b/oio/cli/shell.py
@@ -43,6 +43,13 @@ class OpenIOShell(cliff.app.App):
         else:
             requests_log.setLevel(logging.ERROR)
 
+        urllib3_log = logging.getLogger('urllib3')
+
+        if self.options.debug:
+            urllib3_log.setLevel(logging.DEBUG)
+        else:
+            urllib3_log.setLevel(logging.WARNING)
+
         cliff_log = logging.getLogger('cliff')
         cliff_log.setLevel(logging.ERROR)
 

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -9,11 +9,11 @@ class ProxyClient(HttpApi):
     Client directed towards oio-proxy, with logging facility
     """
 
-    def __init__(self, conf, session=None, request_prefix="",
+    def __init__(self, conf, pool_manager=None, request_prefix="",
                  no_ns_in_url=False, endpoint=None, **kwargs):
         """
-        :param session: an optional session that will be reused
-        :type session: `requests.Session`
+        :param pool_manager: an optional pool manager that will be reused
+        :type pool_manager: `urllib3.PoolManager`
         :param request_prefix: text to insert in between endpoint and
             requested URL
         :type request_prefix: `str`
@@ -44,7 +44,7 @@ class ProxyClient(HttpApi):
         super(ProxyClient, self).__init__(endpoint='/'.join(ep_parts),
                                           **kwargs)
 
-    def _direct_request(self, method, url, session=None, headers=None,
+    def _direct_request(self, method, url, headers=None,
                         **kwargs):
         if kwargs.get("autocreate"):
             if not headers:
@@ -53,4 +53,4 @@ class ProxyClient(HttpApi):
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
         return super(ProxyClient, self)._direct_request(
-            method, url, session=session, headers=headers, **kwargs)
+            method, url, headers=headers, **kwargs)

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -195,7 +195,10 @@ def from_status(status, reason="n/a"):
 
 
 def from_response(resp, body=None):
-    http_status = resp.status_code
+    try:
+        http_status = resp.status
+    except AttributeError:
+        http_status = resp.status_code
     cls = _http_status_map.get(http_status, ClientException)
     if body:
         message = "n/a"

--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -10,6 +10,7 @@ from oio.common.constants import chunk_headers
 
 requests = patcher.import_patched('requests.__init__')
 requests_adapters = patcher.import_patched('requests.adapters')
+urllib3 = patcher.import_patched('urllib3.__init__')
 
 CONNECTION_TIMEOUT = 2.0
 READ_TIMEOUT = 30.0

--- a/oio/conscience/checker/http.py
+++ b/oio/conscience/checker/http.py
@@ -18,7 +18,7 @@ class HttpChecker(BaseChecker):
         self.name = '%s|http|%s|%s|%s' % \
             (self.srv_type, self.host, self.port, self.path)
         self.netloc = '%s:%s' % (self.host, self.port)
-        self.session = self.agent.session
+        self.pool_manager = self.agent.pool_manager
 
     def check(self):
         success = False

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -22,7 +22,7 @@ class LbClient(ProxyClient):
         params = {'type': pool}
         params.update(kwargs)
         resp, body = self._request('GET', '/choose', params=params)
-        if resp.status_code == 200:
+        if resp.status == 200:
             return body
         else:
             raise OioException(
@@ -46,7 +46,7 @@ class LbClient(ProxyClient):
         ibody.update(kwargs)
         resp, obody = self._request('POST', '/poll', params=params,
                                     data=json.dumps(ibody))
-        if resp.status_code == 200:
+        if resp.status == 200:
             return obody
         else:
             raise OioException("Failed to poll %s: %s" % (pool, resp.text))
@@ -76,8 +76,8 @@ class ConscienceClient(ProxyClient):
         super(ConscienceClient, self).__init__(
             conf, request_prefix="/conscience", **kwargs)
         lb_kwargs = dict(kwargs)
-        lb_kwargs.pop("session", None)
-        self.lb = LbClient(conf, session=self.session, **lb_kwargs)
+        lb_kwargs.pop("pool_manager", None)
+        self.lb = LbClient(conf, pool_manager=self.pool_manager, **lb_kwargs)
 
     def next_instances(self, pool, **kwargs):
         """
@@ -110,7 +110,7 @@ class ConscienceClient(ProxyClient):
         if full:
             params['full'] = '1'
         resp, body = self._request('GET', '/list', params=params)
-        if resp.status_code == 200:
+        if resp.status == 200:
             return body
         else:
             raise OioException("failed to get list of %s services: %s"
@@ -118,7 +118,7 @@ class ConscienceClient(ProxyClient):
 
     def local_services(self):
         resp, body = self._request('GET', '/list')
-        if resp.status_code == 200:
+        if resp.status == 200:
             return body
         else:
             raise OioException("failed to get list of local services: %s" %
@@ -127,7 +127,7 @@ class ConscienceClient(ProxyClient):
     def service_types(self):
         params = {'what': 'types'}
         resp, body = self._request('GET', '/info', params=params)
-        if resp.status_code == 200:
+        if resp.status == 200:
             return body
         else:
             raise OioException("ERROR while getting services types: %s" %

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -79,9 +79,9 @@ class ContainerClient(ProxyClient):
         resp, body = self._request('POST', '/create', params=params,
                                    data=data, autocreate=True,
                                    **kwargs)
-        if resp.status_code not in (204, 201):
+        if resp.status not in (204, 201):
             raise exceptions.from_response(resp, body)
-        return resp.status_code == 201
+        return resp.status == 201
 
     def container_create_many(self, account, containers, properties=None,
                               **kwargs):
@@ -109,7 +109,7 @@ class ContainerClient(ProxyClient):
             resp, body = self._request('POST', '/create_many', params=params,
                                        data=data, autocreate=True,
                                        **kwargs)
-            if resp.status_code not in (204, 201):
+            if resp.status not in (204, 201):
                 raise exceptions.from_response(resp, body)
             for container in json.loads(body)["containers"]:
                 results.append((container["name"], container["status"] == 201))
@@ -348,7 +348,7 @@ class ContainerClient(ProxyClient):
                                    version=version)
         resp, _ = self._direct_request('POST', uri,
                                        params=params, **kwargs)
-        return resp.status_code == 204
+        return resp.status == 204
 
     def content_delete_many(self, account=None, reference=None, paths=None,
                             cid=None, **kwargs):
@@ -360,9 +360,9 @@ class ContainerClient(ProxyClient):
         data = json.dumps({"contents": unformatted_data})
         results = list()
         try:
-            resp, _ = self._direct_request(
+            _, resp_body = self._direct_request(
                 'POST', uri, data=data, params=params, **kwargs)
-            for obj in resp.json()["contents"]:
+            for obj in resp_body["contents"]:
                 results.append((obj["name"], obj["status"] == 204))
             return results
         except exceptions.NotFound:

--- a/oio/directory/client.py
+++ b/oio/directory/client.py
@@ -41,9 +41,9 @@ class DirectoryClient(ProxyClient):
         data = json.dumps({'properties': properties})
         resp, body = self._request('POST', '/create', params=params,
                                    data=data, **kwargs)
-        if resp.status_code not in (201, 202):
+        if resp.status not in (201, 202):
             raise exceptions.from_response(resp, body)
-        return resp.status_code == 201
+        return resp.status == 201
 
     def has(self, account=None, reference=None, cid=None, **kwargs):
         params = self._make_params(account, reference, cid=cid)

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -10,7 +10,6 @@ from eventlet import Timeout, greenthread
 from oio.conscience.client import ConscienceClient
 from oio.rdir.client import RdirClient
 from oio.event.beanstalk import Beanstalk, ConnectionError
-from oio.common.http import requests
 from oio.common.utils import true_value, drop_privileges, \
         json, int_value
 from oio.event.evob import is_success, is_error
@@ -122,7 +121,6 @@ class EventWorker(Worker):
     def init(self):
         eventlet.monkey_patch(os=False)
         self.tube = self.conf.get("tube", DEFAULT_TUBE)
-        self.session = requests.Session()
         self.cs = ConscienceClient(self.conf)
         self.rdir = RdirClient(self.conf)
         self._acct_addr = None

--- a/oio/event/filters/volume_index.py
+++ b/oio/event/filters/volume_index.py
@@ -1,7 +1,7 @@
 from oio.event.evob import Event
 from oio.event.consumer import EventTypes
 from oio.event.filters.base import Filter
-from requests.exceptions import ConnectionError
+from urllib3.exceptions import ConnectionError
 
 
 CHUNK_EVENTS = [EventTypes.CHUNK_DELETED, EventTypes.CHUNK_NEW]

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -242,7 +242,6 @@ class RdirClient(HttpApi):
         while True:
             resp, resp_body = self._rdir_request(volume, 'POST', 'fetch',
                                                  json=req_body)
-            resp.raise_for_status()
             if len(resp_body) == 0:
                 break
             for (key, value) in resp_body:

--- a/tests/unit/api/__init__.py
+++ b/tests/unit/api/__init__.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from eventlet import sleep
-from oio.common.http import HeadersDict, requests
+from oio.common.http import HeadersDict, urllib3
 from oio.api.object_storage import ObjectStorageApi
 from oio.directory.client import DirectoryClient
 
@@ -13,7 +13,7 @@ class FakeAPI(object):
         pass
 
 
-class FakeAPIResponse(requests.Response):
+class FakeAPIResponse(urllib3.HTTPResponse):
     pass
 
 

--- a/tests/unit/api/test_directory.py
+++ b/tests/unit/api/test_directory.py
@@ -31,7 +31,7 @@ class DirectoryTest(unittest.TestCase):
     def test_create(self):
         api = self.api
         resp = FakeAPIResponse()
-        resp.status_code = 201
+        resp.status = 201
         api._direct_request = Mock(return_value=(resp, None))
         api.create(self.account, self.name)
         uri = "%s/reference/create" % self.uri_base
@@ -44,7 +44,7 @@ class DirectoryTest(unittest.TestCase):
     def test_create_already_exists(self):
         api = self.api
         resp = FakeAPIResponse()
-        resp.status_code = 202
+        resp.status = 202
         api._direct_request = Mock(return_value=(resp, None))
         api.create(self.account, self.name)
         uri = "%s/reference/create" % self.uri_base
@@ -57,7 +57,7 @@ class DirectoryTest(unittest.TestCase):
     def test_create_metadata(self):
         api = self.api
         resp = FakeAPIResponse()
-        resp.status_code = 201
+        resp.status = 201
         api._direct_request = Mock(return_value=(resp, None))
 
         metadata = {}

--- a/tests/unit/api/test_objectstorage.py
+++ b/tests/unit/api/test_objectstorage.py
@@ -128,7 +128,7 @@ class ObjectStorageTest(unittest.TestCase):
     def test_container_create(self):
         api = self.api
         resp = FakeAPIResponse()
-        resp.status_code = 201
+        resp.status = 201
         api.container._direct_request = Mock(return_value=(resp, None))
 
         name = random_str(32)
@@ -146,7 +146,7 @@ class ObjectStorageTest(unittest.TestCase):
     def test_container_create_exist(self):
         api = self.api
         resp = FakeAPIResponse()
-        resp.status_code = 204
+        resp.status = 204
         api.container._direct_request = Mock(return_value=(resp, None))
 
         name = random_str(32)

--- a/tests/unit/common/test_exceptions.py
+++ b/tests/unit/common/test_exceptions.py
@@ -7,20 +7,20 @@ from tests.unit.api import FakeAPIResponse
 class ExceptionsTest(unittest.TestCase):
     def test_from_response(self):
         fake_resp = FakeAPIResponse()
-        fake_resp.status_code = 500
+        fake_resp.status = 500
         exc = exceptions.from_response(fake_resp, None)
         self.assertTrue(isinstance(exc, exceptions.ClientException))
-        self.assertEqual(exc.http_status, fake_resp.status_code)
+        self.assertEqual(exc.http_status, fake_resp.status)
         self.assertEqual(exc.message, "n/a")
         self.assertTrue("HTTP 500" in str(exc))
 
     def test_from_response_with_body(self):
         fake_resp = FakeAPIResponse()
-        fake_resp.status_code = 500
+        fake_resp.status = 500
         body = {"status": 300, "message": "Fake error"}
         exc = exceptions.from_response(fake_resp, body)
         self.assertTrue(isinstance(exc, exceptions.ClientException))
-        self.assertEqual(exc.http_status, fake_resp.status_code)
+        self.assertEqual(exc.http_status, fake_resp.status)
         self.assertEqual(exc.status, 300)
         self.assertEqual(exc.message, "Fake error")
         self.assertTrue("HTTP 500" in str(exc))
@@ -28,9 +28,9 @@ class ExceptionsTest(unittest.TestCase):
 
     def test_from_response_http_status(self):
         fake_resp = FakeAPIResponse()
-        fake_resp.status_code = 404
+        fake_resp.status = 404
         exc = exceptions.from_response(fake_resp, None)
         self.assertTrue(isinstance(exc, exceptions.NotFound))
-        fake_resp.status_code = 409
+        fake_resp.status = 409
         exc = exceptions.from_response(fake_resp, None)
         self.assertTrue(isinstance(exc, exceptions.Conflict))


### PR DESCRIPTION
To improve the event agent, I change `HttpApi` class. Because `HttpApi` use `requests` only for connections pools. To manage connections pools, `requests` use `urllib3` with `PoolManager`. Now, I call `PoolManager` directly.

With the benchmark `oio-event-benchmark`, we increase the speed by more than 60%.
- before:
```shell
$ ./build/tools/event-benchmark/oio-event-benchmark OPENIO CHUNK_NEW -q
Linking fake rawx address with the fake service address...
Starting the fake service...
Sending 100 fake events
100 events sent (errors: 0) in 0.105229 seconds, 950.308375 events/sec
Sending 950 fake events
950 events sent (errors: 0) in 0.641872 seconds, 1480.045866 events/sec
Sending 1480 fake events
1480 events sent (errors: 0) in 1.021468 seconds, 1448.895120 events/sec
Sending 1448 fake events
1448 events sent (errors: 0) in 1.007678 seconds, 1436.966968 events/sec
Sending 1436 fake events
1436 events sent (errors: 0) in 1.010318 seconds, 1421.334669 events/sec
Sending 1421 fake events
1421 events sent (errors: 0) in 0.981576 seconds, 1447.671907 events/sec
Sending 1447 fake events
1447 events sent (errors: 0) in 1.039129 seconds, 1392.512383 events/sec
Sending 1392 fake events
1392 events sent (errors: 0) in 0.964230 seconds, 1443.638966 events/sec
Sending 1443 fake events
^CStopping the fake service...
1443 events sent (errors: 0) in 0.991372 seconds, 1455.558559 events/sec
Cleaning...
```
- after:
```shell
$ ./build/tools/event-benchmark/oio-event-benchmark OPENIO CHUNK_NEW -q
Linking fake rawx address with the fake service address...
Starting the fake service...
Sending 100 fake events
100 events sent (errors: 0) in 0.064317 seconds, 1554.798887 events/sec
Sending 1554 fake events
1554 events sent (errors: 0) in 0.651858 seconds, 2383.954788 events/sec
Sending 2383 fake events
2383 events sent (errors: 0) in 1.044297 seconds, 2281.917884 events/sec
Sending 2281 fake events
2281 events sent (errors: 0) in 0.946070 seconds, 2411.026668 events/sec
Sending 2411 fake events
2411 events sent (errors: 0) in 1.036022 seconds, 2327.170659 events/sec
Sending 2327 fake events
2327 events sent (errors: 0) in 0.967479 seconds, 2405.220165 events/sec
Sending 2405 fake events
2405 events sent (errors: 0) in 0.995019 seconds, 2417.039273 events/sec
Sending 2417 fake events
2417 events sent (errors: 0) in 1.018104 seconds, 2374.020729 events/sec
Sending 2374 fake events
2374 events sent (errors: 0) in 1.033525 seconds, 2296.993300 events/sec
Sending 2296 fake events
2296 events sent (errors: 0) in 0.955092 seconds, 2403.956896 events/sec
Sending 2403 fake events
^CStopping the fake service...
2403 events sent (errors: 0) in 1.044140 seconds, 2301.415519 events/sec
Cleaning...
```