### PR TITLE
Update the python requirements (eventlet versions)

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,5 +1,5 @@
 cliff>=2.0.0,<2.1.0
-eventlet>=0.15.2
+eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
 requests<2.13.0
 werkzeug>=0.9.1
 redis>=2.10.3

--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,4 +1,5 @@
 cliff>=2.0.0,<2.1.0
+# This can be simplified when https://github.com/eventlet/eventlet/issues/401 is fixed
 eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
 requests<2.13.0
 werkzeug>=0.9.1


### PR DESCRIPTION
Manages a known problem with python 2.7.13 and eventlet 0.21.0