### PR TITLE
Improve exception handling in HttpApi and event-agent

### DIFF
--- a/oio/event/filters/volume_index.py
+++ b/oio/event/filters/volume_index.py
@@ -1,7 +1,7 @@
 from oio.event.evob import Event
 from oio.event.consumer import EventTypes
 from oio.event.filters.base import Filter
-from urllib3.exceptions import ConnectionError
+from oio.common.exceptions import OioNetworkException
 
 
 CHUNK_EVENTS = [EventTypes.CHUNK_DELETED, EventTypes.CHUNK_NEW]
@@ -18,7 +18,7 @@ class VolumeIndexFilter(Filter):
             try:
                 return self.app.rdir.chunk_delete(
                         volume_id, container_id, content_id, chunk_id)
-            except ConnectionError:
+            except OioNetworkException:
                 # TODO(jfs): detect the case of a connection timeout
                 if i >= self.__class__._attempts_delete - 1:
                     raise
@@ -33,7 +33,7 @@ class VolumeIndexFilter(Filter):
             try:
                 return self.app.rdir.chunk_push(
                         volume_id, container_id, content_id, chunk_id, **args)
-            except ConnectionError:
+            except OioNetworkException:
                 # TODO(jfs): detect the case of a connection timeout
                 if i >= self.__class__._attempts_push - 1:
                     raise

--- a/oio/event/filters/volume_index.py
+++ b/oio/event/filters/volume_index.py
@@ -1,7 +1,7 @@
-from oio.event.evob import Event
+from oio.event.evob import Event, EventError
 from oio.event.consumer import EventTypes
 from oio.event.filters.base import Filter
-from oio.common.exceptions import OioNetworkException
+from oio.common.exceptions import OioNetworkException, OioException
 
 
 CHUNK_EVENTS = [EventTypes.CHUNK_DELETED, EventTypes.CHUNK_NEW]
@@ -47,15 +47,20 @@ class VolumeIndexFilter(Filter):
             container_id = data.get('container_id')
             content_id = data.get('content_id')
             chunk_id = data.get('chunk_id')
-            if event.event_type == EventTypes.CHUNK_DELETED:
-                self._chunk_delete(
-                    volume_id, container_id, content_id, chunk_id)
-            else:
-                args = {
-                    'mtime': event.when / 1000000,  # seconds
-                }
-                self._chunk_push(
-                    volume_id, container_id, content_id, chunk_id, args)
+            try:
+                if event.event_type == EventTypes.CHUNK_DELETED:
+                    self._chunk_delete(
+                        volume_id, container_id, content_id, chunk_id)
+                else:
+                    args = {
+                        'mtime': event.when / 1000000,  # seconds
+                    }
+                    self._chunk_push(
+                        volume_id, container_id, content_id, chunk_id, args)
+            except OioException as exc:
+                resp = EventError(event=event,
+                                  body="rdir update error: %s" % exc)
+                return resp(env, cb)
         return self.app(env, cb)
 
 


### PR DESCRIPTION
I change exceptions of `HttpApi` to have a better trace

```
OioNetworkException: HTTPConnectionPool(host=u'127.0.0.1', port=6028): Max retries exceeded with url: /v1/rdir/push?vol=127.0.0.1%3A6022&create=1 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f5eda0d9850>: Failed to establish a new connection: [Errno 111] ECONNREFUSED',))
```