### PR TITLE
cli: Efficiently unlock batches of services

### DIFF
--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -176,10 +176,12 @@ class ClusterUnlockAll(lister.Lister):
             all_descr = self.app.client_manager.admin.cluster_list(type_)
             for descr in all_descr:
                 descr['type'] = type_
-                try:
-                    self.app.client_manager.admin.cluster_unlock_score(descr)
+            try:
+                self.app.client_manager.admin.cluster_unlock_score(all_descr)
+                for descr in all_descr:
                     yield type_, descr['addr'], "unlocked"
-                except Exception as exc:
+            except Exception as exc:
+                for descr in all_descr:
                     yield type_, descr['addr'], str(exc)
 
     def take_action(self, parsed_args):

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -274,11 +274,10 @@ class ClusterLock(ClusterUnlock):
         return parser
 
     def _lock_one(self, type_, addr, score):
-        service_info = {'type': type_, 'addr': addr, 'score': score}
+        si = {'type': type_, 'addr': addr, 'score': score}
         try:
-            svc = self.app.client_manager.admin.cluster_lock_score(
-                    service_info)
-            yield type_, addr, "locked to %d" % int(svc.get("score", score))
+            self.app.client_manager.admin.cluster_lock_score(si)
+            yield type_, addr, "locked to %d" % int(score)
         except Exception as exc:
             yield type_, addr, str(exc)
 

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -154,6 +154,17 @@ class ClusterUnlock(lister.Lister):
                 self._unlock_one(parsed_args.srv_type, parsed_args.srv_addr))
 
 
+def _batches_boundaries(srclen, size):
+    for start in range(0, srclen, size):
+        end = min(srclen, start + size)
+        yield start, end
+
+
+def _bounded_batches(src, size):
+    for start, end in _batches_boundaries(len(src), size):
+        yield src[start:end]
+
+
 class ClusterUnlockAll(lister.Lister):
     """Unlock all services of the cluster"""
 
@@ -176,13 +187,14 @@ class ClusterUnlockAll(lister.Lister):
             all_descr = self.app.client_manager.admin.cluster_list(type_)
             for descr in all_descr:
                 descr['type'] = type_
-            try:
-                self.app.client_manager.admin.cluster_unlock_score(all_descr)
-                for descr in all_descr:
-                    yield type_, descr['addr'], "unlocked"
-            except Exception as exc:
-                for descr in all_descr:
-                    yield type_, descr['addr'], str(exc)
+            for batch in _bounded_batches(all_descr, 4096):
+                try:
+                    self.app.client_manager.admin.cluster_unlock_score(batch)
+                    for descr in batch:
+                        yield type_, descr['addr'], "unlocked"
+                except Exception as exc:
+                    for descr in batch:
+                        yield type_, descr['addr'], str(exc)
 
     def take_action(self, parsed_args):
         columns = ('Type', 'Service', 'Result')

--- a/tests/functional/conscience/test_conscience.py
+++ b/tests/functional/conscience/test_conscience.py
@@ -53,7 +53,7 @@ class TestConscienceFunctional(BaseTestCase):
             del s[d]
             logging.debug("Trying without [%s]", d)
             resp = self.session.post(self._url_cs('register'), json.dumps(s))
-            self.assertEqual(resp.status_code, 200)
+            self.assertIn(resp.status_code, (200, 204))
 
     def test_service_pool_delete(self):
         self._flush_cs('echo')
@@ -70,15 +70,12 @@ class TestConscienceFunctional(BaseTestCase):
     def test_service_pool_actions_lock(self):
         srv = self._srv('echo')
         resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
-        srvout = resp.json()
-        self.assertIsInstance(srvout, dict)
-        self.assertDictEqual(srvout, srv)
+        self.assertIn(resp.status_code, (200, 204))
 
     def test_service_pool_actions_lock_and_reput(self):
         srv = self._srv('echo')
         resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
@@ -105,7 +102,7 @@ class TestConscienceFunctional(BaseTestCase):
     def test_service_pool_actions_lock_and_relock(self):
         srv = self._srv('echo')
         resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
@@ -114,7 +111,7 @@ class TestConscienceFunctional(BaseTestCase):
 
         srv['score'] = 0
         resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
@@ -124,9 +121,9 @@ class TestConscienceFunctional(BaseTestCase):
     def test_services_pool_actions_unlock(self):
         srv = self._srv('echo')
         resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.post(self._url_cs("unlock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
@@ -138,7 +135,7 @@ class TestConscienceFunctional(BaseTestCase):
         srv = self._srv('echo')
         srv['score'] = -1
         resp = self.session.post(self._url_cs('unlock'), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
         body = resp.json()
         self.assertIsInstance(body, list)
@@ -156,7 +153,7 @@ class TestConscienceFunctional(BaseTestCase):
         # register the service with a positive score
         srv['score'] = 1
         resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         # Ensure the proxy reloads its LB pool
         self._reload()
         # check it appears
@@ -174,7 +171,7 @@ class TestConscienceFunctional(BaseTestCase):
         # register the service locked to 0
         srv['score'] = 0
         resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
         # Ensure the proxy reloads its LB pool
         self._reload()
         # check it appears

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -139,15 +139,15 @@ class BaseTestCase(testtools.TestCase):
 
     def _register_srv(self, srv):
         resp = self.session.post(self._url_cs("register"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
 
     def _lock_srv(self, srv):
         resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
 
     def _unlock_srv(self, srv):
         resp = self.session.post(self._url_cs("unlock"), json.dumps(srv))
-        self.assertEqual(resp.status_code, 200)
+        self.assertIn(resp.status_code, (200, 204))
 
     def _flush_proxy(self):
         url = self.uri + '/v3.0/cache/flush/local'


### PR DESCRIPTION
Fix #1091 
Unlocks services 4096 by 4096 (instead of 1 by 1, instead of all at once).