### PR TITLE
Python API: handle ''ServiceBusy" exceptions returned by oio-proxy

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -556,6 +556,11 @@
 				"descr": "Anti-DDoS counter-mesure. In the current server, sets the maximum amount of time a queued TCP event may remain in the queue. If an event is polled and the thread sees the event stayed longer than that delay, A '503 Unavailabe' error is replied.",
 				"def": "2s", "min": "10ms", "max": "1h" },
 
+			{ "type": "int32", "name": "oio_server_request_failure_threshold",
+				"key": "enbug.server.request.failure.threshold",
+				"descr": "In testing situations, sets the average ratio of requests failing for a fake reason (from the peer). This helps testing the retrial mechanisms.",
+				"def": 30, "min": 0, "max": 100 },
+
 			{ "type": "uint", "name": "malloc_trim_size_ondemand",
 				"key": "server.malloc_trim_size.ondemand",
 				"descr": "Sets how many bytes bytes are released when the LEAN request is received by the current 'meta' service.",

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -125,10 +125,11 @@ class HttpApi(object):
         try:
             resp = self.pool_manager.request(method, url, **out_kwargs)
             body = resp.data
-            try:
-                body = jsonlib.loads(body)
-            except ValueError:
-                pass
+            if body:
+                try:
+                    body = jsonlib.loads(body)
+                except ValueError:
+                    pass
         except MaxRetryError as exc:
             if isinstance(exc.reason, NewConnectionError):
                 raise exceptions.OioNetworkException(exc), None, \

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -2,6 +2,12 @@ from oio.common.utils import get_logger
 from oio.common.utils import load_namespace_conf
 from oio.common.utils import validate_service_conf
 from oio.api.base import HttpApi
+from oio.common.exceptions import ServiceBusy
+from random import randrange
+from eventlet import sleep
+
+
+REQUEST_ATTEMPTS = 1
 
 
 class ProxyClient(HttpApi):
@@ -9,8 +15,12 @@ class ProxyClient(HttpApi):
     Client directed towards oio-proxy, with logging facility
     """
 
+    _slot_time = 0.5
+
     def __init__(self, conf, pool_manager=None, request_prefix="",
-                 no_ns_in_url=False, endpoint=None, **kwargs):
+                 no_ns_in_url=False, endpoint=None,
+                 request_attempts=REQUEST_ATTEMPTS,
+                 **kwargs):
         """
         :param pool_manager: an optional pool manager that will be reused
         :type pool_manager: `urllib3.PoolManager`
@@ -20,7 +30,13 @@ class ProxyClient(HttpApi):
         :param no_ns_in_url: do not insert namespace name between endpoint
             and `request_prefix`
         :type no_ns_in_url: `bool`
+        :param request_attempts: number of attempts for the request in case of
+            error 503
+
+        :raise oio.common.exceptions.ServiceBusy: if all attempts fail
         """
+        assert(request_attempts > 0)
+
         validate_service_conf(conf)
         self.ns = conf.get('namespace')
         self.conf = conf
@@ -41,6 +57,9 @@ class ProxyClient(HttpApi):
             ep_parts.append(self.ns)
         if request_prefix:
             ep_parts.append(request_prefix.lstrip('/'))
+
+        self._request_attempts = request_attempts
+
         super(ProxyClient, self).__init__(endpoint='/'.join(ep_parts),
                                           **kwargs)
 
@@ -52,5 +71,18 @@ class ProxyClient(HttpApi):
             headers["X-oio-action-mode"] = "autocreate"
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
-        return super(ProxyClient, self)._direct_request(
-            method, url, headers=headers, **kwargs)
+        for i in range(self._request_attempts):
+            try:
+                return super(ProxyClient, self)._direct_request(
+                    method, url, headers=headers, **kwargs)
+            except ServiceBusy:
+                if i >= self._request_attempts - 1:
+                    raise
+                # retry with exponential backoff
+                ProxyClient._exp_sleep(i + 1)
+
+    @staticmethod
+    def _exp_sleep(attempts):
+        N = pow(2, attempts)
+        k = randrange(N)
+        sleep(k * ProxyClient._slot_time)

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -183,10 +183,16 @@ class UnsatisfiableRange(ClientException):
         super(UnsatisfiableRange, self).__init__(http_status, status, message)
 
 
+class ServiceBusy(ClientException):
+    def __init__(self, http_status=503, status=None, message=None):
+        super(ServiceBusy, self).__init__(http_status, status, message)
+
+
 _http_status_map = {404: NotFound,
                     409: Conflict,
                     413: TooLarge,
-                    416: UnsatisfiableRange}
+                    416: UnsatisfiableRange,
+                    503: ServiceBusy}
 
 
 def from_status(status, reason="n/a"):

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -1096,6 +1096,12 @@ _cb_tcp_worker(struct network_client_s *clt, struct network_server_s *srv)
 	/* The event stayed *really* long in the queue of the thread pool.
 	 * Let's close the connection, and let the client retry it's request. */
 	if (clt->events & CLT_READ) {
+#ifdef HAVE_ENBUG
+		if (oio_server_request_failure_threshold >= oio_ext_rand_int_range(1,100)) {
+			_client_clean(srv, clt);
+			return;
+		}
+#endif
 		const gint64 now = oio_ext_monotonic_time();
 		if (clt->time.evt_in < OLDEST(now, server_queue_max_delay)) {
 			GRID_INFO("STARVING fd %d peer %s delay %"G_GINT64_FORMAT"ms",

--- a/tests/functional/api/test_proxy_client.py
+++ b/tests/functional/api/test_proxy_client.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2017 OpenIO SAS
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+
+from tests.utils import BaseTestCase
+from mock import MagicMock as Mock
+from oio.common.client import ProxyClient
+from urllib3 import HTTPResponse
+from oio.common.exceptions import ServiceBusy
+
+
+class TestProxyClient(BaseTestCase):
+
+    def setUp(self):
+        super(TestProxyClient, self).setUp()
+        self.proxy_client = ProxyClient({"namespace": self.ns},
+                                        request_attempts=2)
+
+    def test_error_503(self):
+        self.proxy_client.pool_manager.request = Mock(
+            return_value=HTTPResponse(status=503, reason="Service busy"))
+        self.assertRaises(ServiceBusy,
+                          self.proxy_client._direct_request, "GET", "test")


### PR DESCRIPTION
Catch error 503 from proxy and retry with exponential backoff.
If the proxy is still busy, throws the `ServiceBusy` exception.