### PR TITLE
oio/api: Fix invalid ranges

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,6 +1,7 @@
 cliff>=2.0.0,<2.1.0
-eventlet>=0.15.2
-requests>=2.6.0
+# This can be simplified when https://github.com/eventlet/eventlet/issues/401 is fixed
+eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
+requests<2.13.0
 werkzeug>=0.9.1
 redis>=2.10.3
 gunicorn>=19.4.5

--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -83,7 +83,7 @@ def obj_range_to_meta_chunk_range(obj_start, obj_end, meta_sizes):
         obj_start = total_size - min(total_size, obj_end)
         obj_end = total_size - 1
 
-    meta_chunk_ranges = {}
+    meta_chunk_ranges = collections.OrderedDict()
     for pos, meta_size in enumerate(meta_sizes):
         if meta_size <= 0:
             continue


### PR DESCRIPTION
When computing range download to chunks, results was stored inside
a Dict. This result was used with an iterator and order of chunks was lost.
The fix replace this Dict by a OrderectDict.