### PR TITLE
container sharding: step3, allocate shards in meta1

### DIFF
--- a/meta1v2/meta1_backend.h
+++ b/meta1v2/meta1_backend.h
@@ -64,8 +64,14 @@ enum m1v2_open_type_e
 
 enum m1v2_getsrv_e
 {
+	/* whatever the status of eacch service, poll a new set */
 	M1V2_GETSRV_RENEW  = 0x00,
+
+	/* Keep the serviices if they are still up. If not, apply the
+	 * service update policy. */
 	M1V2_GETSRV_REUSE  = 0x01,
+
+	/* poll, but do not save anything */
 	M1V2_GETSRV_DRYRUN = 0x02,
 };
 
@@ -114,16 +120,19 @@ GError* meta1_backend_services_list(struct meta1_backend_s *m1,
 		struct oio_url_s *url, const gchar *srvtype, gchar ***result);
 
 GError* meta1_backend_services_link (struct meta1_backend_s *m1,
-		struct oio_url_s *url, const gchar *srvtype,
-		gboolean dryrun, gboolean autocreate,
+		struct oio_url_s *url, const gchar *srvtype, const char *last,
+		gboolean autocreate,
 		gchar ***result);
 
 GError* meta1_backend_services_unlink(struct meta1_backend_s *m1,
 		struct oio_url_s *url, const gchar *srvtype, gchar **urlv);
 
-GError* meta1_backend_services_poll (struct meta1_backend_s *m1,
+/* @param last A come-separated sequence of numbers in decimal representation.
+ *             The sequence represents the 'sequence number' of the services
+ *             know by the client to be linked to the user. */
+GError* meta1_backend_services_renew (struct meta1_backend_s *m1,
 		struct oio_url_s *url, const gchar *srvtype,
-		gboolean dryrun, gboolean autocreate,
+		const char *last, gboolean autocreate,
 		gchar ***result);
 
 /* @param packedurl formatted as 'SEQ|TYPE|IP:PORT|ARGS' */

--- a/meta1v2/meta1_backend_internals.c
+++ b/meta1v2/meta1_backend_internals.c
@@ -240,7 +240,9 @@ retry:
 	return NULL;
 }
 
-void gpa_str_free(GPtrArray *gpa) {
+void
+gpa_str_free(GPtrArray *gpa)
+{
 	if (!gpa)
 		return;
 	g_ptr_array_set_free_func (gpa, g_free);

--- a/meta1v2/meta1_prefixes.c
+++ b/meta1v2/meta1_prefixes.c
@@ -63,6 +63,8 @@ _cache_is_managed(const guint8 *cache, const guint8 *prefix)
 	return BOOL(cache[ slot / 8 ] & BITPOS(slot));
 }
 
+/* NS operations ------------------------------------------------------------ */
+
 void
 meta1_prefixes_manage_all(struct meta1_prefixes_set_s *m1ps)
 {
@@ -74,9 +76,6 @@ meta1_prefixes_manage_all(struct meta1_prefixes_set_s *m1ps)
 	}
 	g_mutex_unlock(&m1ps->lock);
 }
-
-
-/* NS operations ------------------------------------------------------------ */
 
 static guint8*
 _cache_from_m0l(const GSList *l, const struct addr_info_s *ai)

--- a/meta1v2/meta1_remote.c
+++ b/meta1v2/meta1_remote.c
@@ -82,16 +82,13 @@ meta1v2_remote_delete_reference (const char *to, struct oio_url_s *url,
 
 GError *
 meta1v2_remote_link_service(const char *to, struct oio_url_s *url,
-		const char *srvtype, gboolean dryrun, gboolean ac,
-		gchar ***result)
+		const char *srvtype, gboolean ac, gchar ***result)
 {
 	EXTRA_ASSERT(url != NULL);
 	EXTRA_ASSERT(srvtype != NULL);
 	MESSAGE req = metautils_message_create_named(NAME_MSGNAME_M1V2_SRVLINK);
 	metautils_message_add_url_no_type (req, url);
 	metautils_message_add_field_str (req, NAME_MSGKEY_TYPENAME, srvtype);
-	if (dryrun)
-		metautils_message_add_field_str (req, NAME_MSGKEY_DRYRUN, "1");
 	if (ac)
 		metautils_message_add_field_str (req, NAME_MSGKEY_AUTOCREATE, "1");
 	return STRV_request(to, message_marshall_gba_and_clean(req), result);
@@ -139,7 +136,7 @@ meta1v2_remote_unlink_one_service(const char *to, struct oio_url_s *url,
 
 GError *
 meta1v2_remote_renew_reference_service(const char *to, struct oio_url_s *url,
-		const char *srvtype, gboolean dryrun, gboolean autocreate,
+		const char *srvtype, const char *last, gboolean autocreate,
 		gchar ***result)
 {
 	EXTRA_ASSERT(url != NULL);
@@ -147,8 +144,8 @@ meta1v2_remote_renew_reference_service(const char *to, struct oio_url_s *url,
 	MESSAGE req = metautils_message_create_named(NAME_MSGNAME_M1V2_SRVRENEW);
 	metautils_message_add_url_no_type (req, url);
 	metautils_message_add_field_str (req, NAME_MSGKEY_TYPENAME, srvtype);
-	if (dryrun)
-		metautils_message_add_field_str (req, NAME_MSGKEY_DRYRUN, "1");
+	if (oio_str_is_set(last))
+		metautils_message_add_field_str(req, NAME_MSGKEY_LAST, last);
 	if (autocreate)
 		metautils_message_add_field_str (req, NAME_MSGKEY_AUTOCREATE, "1");
 	return STRV_request(to, message_marshall_gba_and_clean(req), result);

--- a/meta1v2/meta1_remote.h
+++ b/meta1v2/meta1_remote.h
@@ -39,7 +39,7 @@ GError * meta1v2_remote_list_reference_services(const char *m1,
 		struct oio_url_s *url, const char *srvtype, gchar ***out);
 
 GError * meta1v2_remote_link_service(const char *m1, struct oio_url_s *url,
-		const char *srvtype, gboolean dryrun, gboolean ac, gchar ***out);
+		const char *srvtype, gboolean ac, gchar ***out);
 
 GError * meta1v2_remote_unlink_service(const char *m1, struct oio_url_s *url,
 		const char *srvtype);
@@ -48,7 +48,7 @@ GError * meta1v2_remote_unlink_one_service(const char *m1, struct oio_url_s *url
 		const char *srvtype, gint64 seqid);
 
 GError * meta1v2_remote_renew_reference_service(const char *m1, struct oio_url_s *url,
-		const char *srvtype, gboolean dryrun, gboolean ac, gchar ***out);
+		const char *srvtype, const char *last, gboolean ac, gchar ***out);
 
 GError * meta1v2_remote_force_reference_service(const char *m1, struct oio_url_s *url,
 		const char *m1url, gboolean ac, gboolean force);

--- a/proxy/dir_actions.c
+++ b/proxy/dir_actions.c
@@ -154,12 +154,10 @@ action_dir_srv_link (struct req_args_s *args, struct json_object *jargs)
 	if (!type)
 		return _reply_format_error (args, BADREQ("No service type provided"));
 	gboolean autocreate = _request_get_flag (args, "autocreate");
-	gboolean dryrun = _request_get_flag (args, "dryrun");
 
 	gchar **urlv = NULL;
 	GError *hook (const char * m1) {
-		return meta1v2_remote_link_service (m1, args->url, type, dryrun,
-				autocreate, &urlv);
+		return meta1v2_remote_link_service (m1, args->url, type, autocreate, &urlv);
 	}
 
 	GError *err = _m1_locate_and_action (args->url, hook);
@@ -228,12 +226,11 @@ action_dir_srv_renew (struct req_args_s *args, struct json_object *jargs)
 	if (!type)
 		return _reply_format_error (args, BADREQ("No service type provided"));
 	gboolean autocreate = _request_get_flag (args, "autocreate");
-	gboolean dryrun = _request_get_flag (args, "dryrun");
 
 	gchar **urlv = NULL;
 	GError *hook (const char * m1) {
 		return meta1v2_remote_renew_reference_service (
-				m1, args->url, type, dryrun, autocreate, &urlv);
+				m1, args->url, type, NULL, autocreate, &urlv);
 	}
 
 	GError *err = _m1_locate_and_action (args->url, hook);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -909,7 +909,7 @@ retry:
 				gchar **urlv = NULL, realtype[64];
 				_get_meta2_realtype (args, realtype, sizeof(realtype));
 				GError *e = meta1v2_remote_link_service (
-						m1, args->url, realtype, FALSE, TRUE, &urlv);
+						m1, args->url, realtype, TRUE, &urlv);
 				if (!e && urlv && *urlv) {
 					/* Explicitely feeding the meta1 avoids a subsequent
 					   call to meta1 to locate the meta2 */

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -4,7 +4,7 @@ import logging
 import random
 import simplejson as json
 import struct
-from tests.utils import BaseTestCase
+from tests.utils import BaseTestCase, random_id
 
 
 def random_content():
@@ -42,7 +42,8 @@ class TestMeta2Containers(BaseTestCase):
 
     def setUp(self):
         super(TestMeta2Containers, self).setUp()
-        self.ref = 'Ça ne marchera jamais !'
+        self.account = random_id(16)
+        self.ref = random_id(16) + '-' + 'Ça ne marchera jamais !'
 
     def tearDown(self):
         super(TestMeta2Containers, self).tearDown()
@@ -279,7 +280,7 @@ class TestMeta2Containers(BaseTestCase):
 class TestMeta2Contents(BaseTestCase):
     def setUp(self):
         super(TestMeta2Contents, self).setUp()
-        self.ref = 'plop-0'
+        self.ref = random_id(16)
         self._reload()
 
     def tearDown(self):

--- a/tests/functional/reference/test_directory.py
+++ b/tests/functional/reference/test_directory.py
@@ -1,4 +1,3 @@
-import logging
 import simplejson as json
 from tests.utils import BaseTestCase
 
@@ -33,7 +32,6 @@ class TestDirectoryFunctional(BaseTestCase):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertIsInstance(body, dict)
-        logging.debug("Got services %s", repr(body))
         self.assertIn(srv0['addr'], [x['host']
                       for x in body['srv'] if x['type'] == 'echo'])
 
@@ -111,8 +109,8 @@ class TestDirectoryFunctional(BaseTestCase):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertIsInstance(body, dict)
-        self.assertEqual(len(body['srv']), 2)
-        self.assertEqual(body['srv'][0]['host'], srv1['addr'])
+        self.assertItemsEqual((srv0['addr'], srv1['addr']), [x['host']
+                              for x in body['srv'] if x['type'] == 'echo'])
 
         # Force without header while linked
         enforced = {'host': self._addr(), 'type': 'echo',

--- a/tests/functional/reference/test_directory.py
+++ b/tests/functional/reference/test_directory.py
@@ -82,6 +82,9 @@ class TestDirectoryFunctional(BaseTestCase):
         # Renew while not linked
         resp = self.session.post(self._url_ref('renew'), params=params)
         self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIsInstance(body, list)
+        self.assertEqual(len(body), 1)
 
         resp = self.session.get(self._url_ref('show'), params=params)
         self.assertEqual(resp.status_code, 200)
@@ -100,12 +103,15 @@ class TestDirectoryFunctional(BaseTestCase):
 
         resp = self.session.post(self._url_ref('renew'), params=params)
         self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIsInstance(body, list)
+        self.assertEqual(len(body), 2)
 
         resp = self.session.get(self._url_ref('show'), params=params)
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertIsInstance(body, dict)
-        self.assertEqual(len(body['srv']), 1)
+        self.assertEqual(len(body['srv']), 2)
         self.assertEqual(body['srv'][0]['host'], srv1['addr'])
 
         # Force without header while linked


### PR DESCRIPTION
* backend: Implement the idempotent variant of M1_LINK
* backend: Simplifies the logic
* backend: Drop the support of the DRYRUN flag where it is useless
* remote: adapt to the backend options
* proxy: adapt to the meta2 remote
* test: Add a unit test for the backend
* test: Alter a test to match the new meta1 API (link calls return the
  whole set of services,no tthe addition)
* test: More random ids, for less collisions