### PR TITLE
Python API: share one logger instance between all classes instances

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -27,7 +27,7 @@ class AccountClient(HttpApi):
     """Simple client API for the account service."""
 
     def __init__(self, conf, endpoint=None, proxy_endpoint=None,
-                 refresh_delay=3600.0, **kwargs):
+                 refresh_delay=3600.0, logger=None, **kwargs):
         """
         Initialize a client for the account service.
 
@@ -40,8 +40,9 @@ class AccountClient(HttpApi):
         :type refresh_interval: `float` seconds
         """
         super(AccountClient, self).__init__(endpoint=endpoint, **kwargs)
-        self.logger = get_logger(conf)
-        self.cs = ConscienceClient(conf, endpoint=proxy_endpoint, **kwargs)
+        self.logger = logger or get_logger(conf)
+        self.cs = ConscienceClient(conf, endpoint=proxy_endpoint,
+                                   logger=self.logger, **kwargs)
         self._refresh_delay = refresh_delay if not self.endpoint else -1.0
         self._last_refresh = 0.0
 

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -30,7 +30,7 @@ from oio.api.backblaze import BackblazeWriteHandler, \
     BackblazeChunkDownloadHandler
 from oio.common import constants
 from oio.common.utils import ensure_headers, ensure_request_id, float_value, \
-    name2cid, GeneratorIO
+    name2cid, GeneratorIO, get_logger
 from oio.common.http import http_header_from_ranges
 from oio.common.storage_method import STORAGE_METHODS
 from oio.common.constants import OIO_VERSION
@@ -302,7 +302,7 @@ class ObjectStorageApi(object):
     """
     TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
 
-    def __init__(self, namespace, **kwargs):
+    def __init__(self, namespace, logger=None, **kwargs):
         """
         Initialize the object storage API.
 
@@ -318,6 +318,8 @@ class ObjectStorageApi(object):
         :type write_timeout: `float` seconds
         """
         self.namespace = namespace
+        conf = {"namespace": self.namespace}
+        self.logger = logger or get_logger(conf)
         self.timeouts = {tok: float_value(tov, None)
                          for tok, tov in kwargs.items()
                          if tok in self.__class__.TIMEOUT_KEYS}
@@ -326,16 +328,13 @@ class ObjectStorageApi(object):
         from oio.container.client import ContainerClient
         from oio.directory.client import DirectoryClient
         # FIXME: share session between all the clients
-        self.directory = DirectoryClient({"namespace": self.namespace},
-                                         **kwargs)
-        self.container = ContainerClient({"namespace": self.namespace},
-                                         **kwargs)
+        self.directory = DirectoryClient(conf, logger=self.logger, **kwargs)
+        self.container = ContainerClient(conf, logger=self.logger, **kwargs)
 
         # In AccountClient, "endpoint" is the account service, not the proxy
         acct_kwargs = kwargs.copy()
         acct_kwargs["proxy_endpoint"] = acct_kwargs.pop("endpoint", None)
-        self.account = AccountClient({"namespace": self.namespace},
-                                     **acct_kwargs)
+        self.account = AccountClient(conf, logger=self.logger, **acct_kwargs)
 
     def _patch_timeouts(self, kwargs):
         """

--- a/oio/blob/auditor.py
+++ b/oio/blob/auditor.py
@@ -36,7 +36,7 @@ class BlobAuditorWorker(object):
             conf.get('chunks_per_second'), 30)
         self.max_bytes_per_second = int_value(
             conf.get('bytes_per_second'), 10000000)
-        self.container_client = ContainerClient(conf)
+        self.container_client = ContainerClient(conf, logger=self.logger)
 
     def audit_pass(self):
         self.namespace, self.address = check_volume(self.volume)

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -29,7 +29,7 @@ class BlobIndexer(Daemon):
             conf.get('report_interval'), 3600)
         self.max_chunks_per_second = int_value(
             conf.get('chunks_per_second'), 30)
-        self.index_client = RdirClient(conf)
+        self.index_client = RdirClient(conf, logger=self.logger)
         self.namespace, self.volume_id = check_volume(self.volume)
 
     def index_pass(self):

--- a/oio/blob/mover.py
+++ b/oio/blob/mover.py
@@ -41,7 +41,7 @@ class BlobMoverWorker(object):
         self.max_bytes_per_second = int_value(
             conf.get('bytes_per_second'), 10000000)
         self.blob_client = BlobClient()
-        self.container_client = ContainerClient(conf)
+        self.container_client = ContainerClient(conf, logger=self.logger)
         self.content_factory = ContentFactory(conf)
 
     def mover_pass(self):

--- a/oio/blob/rebuilder.py
+++ b/oio/blob/rebuilder.py
@@ -55,7 +55,7 @@ class BlobRebuilderWorker(object):
         self.allow_same_rawx = true_value(
             conf.get('allow_same_rawx'))
         self.input_file = input_file
-        self.rdir_client = RdirClient(conf)
+        self.rdir_client = RdirClient(conf, logger=self.logger)
         self.content_factory = ContentFactory(conf)
         self.try_chunk_delete = try_chunk_delete
         self.beanstalkd_addr = beanstalkd_addr

--- a/oio/blob/registrator.py
+++ b/oio/blob/registrator.py
@@ -36,7 +36,7 @@ class BlobRegistratorWorker(object):
         self.volume_ns, self.volume_id = check_volume(self.volume)
         c = dict()
         c['namespace'] = self.namespace
-        self.client = ContainerClient(c)
+        self.client = ContainerClient(c, logger=self.logger)
         self.report_interval = conf.get(
                 "report_period", default_report_interval)
 

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -20,7 +20,7 @@ class ProxyClient(HttpApi):
     def __init__(self, conf, pool_manager=None, request_prefix="",
                  no_ns_in_url=False, endpoint=None,
                  request_attempts=REQUEST_ATTEMPTS,
-                 **kwargs):
+                 logger=None, **kwargs):
         """
         :param pool_manager: an optional pool manager that will be reused
         :type pool_manager: `urllib3.PoolManager`
@@ -40,7 +40,7 @@ class ProxyClient(HttpApi):
         validate_service_conf(conf)
         self.ns = conf.get('namespace')
         self.conf = conf
-        self.logger = get_logger(conf)
+        self.logger = logger or get_logger(conf)
 
         ep_parts = list()
         if endpoint:

--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -44,10 +44,11 @@ class ServiceWatcher(object):
 
         self.logger = get_logger(self.conf)
         self.pool_manager = get_pool_manager()
-        self.cs = ConscienceClient(self.conf, pool_manager=self.pool_manager)
+        self.cs = ConscienceClient(self.conf, pool_manager=self.pool_manager,
+                                   logger=self.logger)
         # FIXME: explain that
         self.client = ProxyClient(self.conf, pool_manager=self.pool_manager,
-                                  no_ns_in_url=True)
+                                  no_ns_in_url=True, logger=self.logger)
         self.last_status = False
         self.failed = False
         self.service_definition = {

--- a/oio/container/backup.py
+++ b/oio/container/backup.py
@@ -395,13 +395,14 @@ class ContainerBackup(RedisConn, WerkzeugApp):
                                   section_name="admin-server")
         else:
             self.conf = {}
+        self.logger = get_logger(self.conf, name="ContainerBackup")
 
-        self.proxy = ObjectStorageApi(self.conf.get("namespace", NS))
+        self.proxy = ObjectStorageApi(self.conf.get("namespace", NS),
+                                      logger=self.logger)
         self.url_map = Map([
             Rule('/v1.0/container/dump', endpoint='dump'),
             Rule('/v1.0/container/restore', endpoint='restore'),
         ])
-        self.logger = get_logger(self.conf, name="ContainerBackup")
         self.REDIS_TIMEOUT = self.conf.get("redis_cache_timeout",
                                            self.REDIS_TIMEOUT)
 

--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -34,7 +34,9 @@ class Content(object):
         self.storage_method = storage_method
         self.logger = get_logger(self.conf)
         self.blob_client = BlobClient()
-        self.container_client = container_client or ContainerClient(self.conf)
+        self.container_client = (container_client
+                                 or ContainerClient(self.conf,
+                                                    logger=self.logger))
         self.content_id = self.metadata["id"]
         self.stgpol = self.metadata["policy"]
         self.path = self.metadata["name"]

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -29,7 +29,8 @@ class ContentFactory(object):
     def __init__(self, conf, **kwargs):
         self.conf = conf
         self.logger = get_logger(conf)
-        self.container_client = ContainerClient(conf, **kwargs)
+        self.container_client = ContainerClient(conf, logger=self.logger,
+                                                **kwargs)
 
     def get(self, container_id, content_id, account=None,
             container_name=None):

--- a/oio/crawler/storage_tierer.py
+++ b/oio/crawler/storage_tierer.py
@@ -22,8 +22,8 @@ class StorageTiererWorker(object):
         self.conf = conf
         self.logger = logger
         self.account = conf[CONF_ACCOUNT]
-        self.container_client = ContainerClient(self.conf)
-        self.account_client = AccountClient(self.conf)
+        self.container_client = ContainerClient(self.conf, logger=self.logger)
+        self.account_client = AccountClient(self.conf, logger=self.logger)
         self.content_factory = ContentFactory(self.conf)
         self.passes = 0
         self.errors = 0

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -121,8 +121,8 @@ class EventWorker(Worker):
     def init(self):
         eventlet.monkey_patch(os=False)
         self.tube = self.conf.get("tube", DEFAULT_TUBE)
-        self.cs = ConscienceClient(self.conf)
-        self.rdir = RdirClient(self.conf)
+        self.cs = ConscienceClient(self.conf, logger=self.logger)
+        self.rdir = RdirClient(self.conf, logger=self.logger)
         self._acct_addr = None
         self.acct_update = 0
         self.graceful_timeout = 1

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -15,6 +15,7 @@
 
 from eventlet import Timeout
 from oio.common.exceptions import ClientException
+from oio.common.utils import get_logger
 from oio.account.client import AccountClient
 from oio.event.evob import Event, EventError
 from oio.event.consumer import EventTypes
@@ -32,8 +33,10 @@ CONTAINER_EVENTS = [
 class AccountUpdateFilter(Filter):
 
     def __init__(self, app, conf, **kwargs):
-        super(AccountUpdateFilter, self).__init__(app, conf, **kwargs)
-        self.account = AccountClient(conf)
+        self.logger = get_logger(conf)
+        super(AccountUpdateFilter, self).__init__(app, conf,
+                                                  logger=self.logger, **kwargs)
+        self.account = AccountClient(conf, logger=self.logger)
 
     def process(self, env, cb):
         event = Event(env)

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -25,14 +25,14 @@ class RdirDispatcher(object):
         self.conf = conf
         self.ns = conf['namespace']
         self.logger = get_logger(conf)
-        self.directory = DirectoryClient(conf, **kwargs)
-        self.rdir = RdirClient(conf, **kwargs)
+        self.directory = DirectoryClient(conf, logger=self.logger, **kwargs)
+        self.rdir = RdirClient(conf, logger=self.logger, **kwargs)
         self._cs = None
 
     @property
     def cs(self):
         if not self._cs:
-            self._cs = ConscienceClient(self.conf)
+            self._cs = ConscienceClient(self.conf, logger=self.logger)
         return self._cs
 
     def get_assignation(self):


### PR DESCRIPTION
Manage loggers to not recreate a logger unnecessarily and to share a logger