### PR TITLE
Python API: allow to set "request_attempts" for each request

### DIFF
--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -2,7 +2,7 @@ from oio.common.utils import get_logger
 from oio.common.utils import load_namespace_conf
 from oio.common.utils import validate_service_conf
 from oio.api.base import HttpApi
-from oio.common.exceptions import ServiceBusy
+from oio.common.exceptions import ServiceBusy, OioException
 from random import randrange
 from eventlet import sleep
 
@@ -63,20 +63,25 @@ class ProxyClient(HttpApi):
         super(ProxyClient, self).__init__(endpoint='/'.join(ep_parts),
                                           **kwargs)
 
-    def _direct_request(self, method, url, headers=None,
+    def _direct_request(self, method, url, headers=None, request_attempts=None,
                         **kwargs):
+        if not request_attempts:
+            request_attempts = self._request_attempts
+        if request_attempts <= 0:
+            raise OioException("Negative request attempts: %d"
+                               % request_attempts)
         if kwargs.get("autocreate"):
             if not headers:
                 headers = dict()
             headers["X-oio-action-mode"] = "autocreate"
             kwargs = kwargs.copy()
             kwargs.pop("autocreate")
-        for i in range(self._request_attempts):
+        for i in range(request_attempts):
             try:
                 return super(ProxyClient, self)._direct_request(
                     method, url, headers=headers, **kwargs)
             except ServiceBusy:
-                if i >= self._request_attempts - 1:
+                if i >= request_attempts - 1:
                     raise
                 # retry with exponential backoff
                 ProxyClient._exp_sleep(i + 1)

--- a/tests/functional/api/test_proxy_client.py
+++ b/tests/functional/api/test_proxy_client.py
@@ -16,7 +16,7 @@ from tests.utils import BaseTestCase
 from mock import MagicMock as Mock
 from oio.common.client import ProxyClient
 from urllib3 import HTTPResponse
-from oio.common.exceptions import ServiceBusy
+from oio.common.exceptions import ServiceBusy, OioException
 
 
 class TestProxyClient(BaseTestCase):
@@ -31,3 +31,8 @@ class TestProxyClient(BaseTestCase):
             return_value=HTTPResponse(status=503, reason="Service busy"))
         self.assertRaises(ServiceBusy,
                           self.proxy_client._direct_request, "GET", "test")
+
+    def test_negative_requests_attempts(self):
+        self.assertRaises(OioException,
+                          self.proxy_client._direct_request, "GET", "test",
+                          request_attempts=-1)


### PR DESCRIPTION
Add number of attempts for each request in the event of `ServiceBusy`
