### PR TITLE
sqliterepo: Inhibit the test on stalled election

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -301,6 +301,11 @@
 				"descr": "In the current sqliterepo repository, sets the maximum amount of time a worker thread is allowed to wait for an election to get its final status.",
 				"def": "5s", "min": "1ms", "max": "1h" },
 
+			{ "type": "bool", "name": "oio_election_enable_nowait_pending",
+				"key": "sqliterepo.election.nowait.enable",
+				"descr": "Check of the election is pending since too long. If it is, don't way for it.",
+				"def": false },
+
 			{ "type": "monotonic", "name": "oio_election_delay_nowait_pending",
 				"key": "sqliterepo.election.nowait.after",
 				"descr": "In the current sqliterepo repository, sets the amount of time spent in an election resolution that will make a worker thread won't wait at all an consider that election is stalled.",

--- a/conf.json
+++ b/conf.json
@@ -309,7 +309,7 @@
 			{ "type": "monotonic", "name": "oio_election_delay_nowait_pending",
 				"key": "sqliterepo.election.nowait.after",
 				"descr": "In the current sqliterepo repository, sets the amount of time spent in an election resolution that will make a worker thread won't wait at all an consider that election is stalled.",
-				"def": "15s", "min": "1ms", "max": "1h" },
+				"def": "15m", "min": "1ms", "max": "max" },
 
 			{ "type": "monotonic", "name": "oio_election_delay_expire_NONE",
 				"key": "sqliterepo.election.delay.expire_none",

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1791,8 +1791,9 @@ wait_for_final_status(struct election_member_s *m, const gint64 deadline)
 		m->last_atime = now;
 		transition(m, EVT_NONE, NULL);
 
-		if (m->when_unstable > 0 && m->when_unstable <
-				OLDEST(now, oio_election_delay_nowait_pending)) {
+		if (oio_election_enable_nowait_pending &&
+				m->when_unstable > 0 && m->when_unstable < OLDEST(
+					now, oio_election_delay_nowait_pending)) {
 			GRID_WARN("TIMEOUT! (election pending for too long) [%s.%s] step=%d/%s",
 					m->inline_name.base, m->inline_name.type, m->step, _step2str(m->step));
 			return FALSE;


### PR DESCRIPTION
Can be triggered back using 'sqliterepo.election.nowait.enable' (managed configuration), false by default until we discover where the transient timer (`when_unstable`) is not reset as expected.