### PR TITLE
oio/backup: fix invalid restore

### DIFF
--- a/oio/container/backup.py
+++ b/oio/container/backup.py
@@ -769,7 +769,8 @@ class ContainerBackup(RedisConn, WerkzeugApp):
                         file_or_path=LimitedStream(req.stream, inf.size),
                         **kwargs)
                     if size != inf.size:
-                        raise UnprocessableEntity()
+                        raise UnprocessableEntity(
+                            "Object created is smaller than expected")
                     r['consumed'] += size
                     if hdrs:
                         self.proxy.object_set_properties(account, container,
@@ -782,7 +783,8 @@ class ContainerBackup(RedisConn, WerkzeugApp):
                 read(BLOCKSIZE - inf.size % BLOCKSIZE)
 
         if req_size != r['consumed']:
-            raise UnprocessableEntity()
+            raise UnprocessableEntity(
+                "Invalid length of data consumed by restoration")
 
         if mode == 'full' or end_block == cur_state['last_block']:
             code = 201

--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -375,6 +375,7 @@ class TestContainerDownload(BaseTestCase):
         self.assertNotIn('x-object-sysmeta-slo-size', props)
         self.assertNotIn('x-object-sysmeta-slo-etag', props)
 
+    @attr('simple')
     def test_simple_restore(self):
         self._create_data(metadata=gen_metadata)
         org = requests.get(self.make_uri('dump'))
@@ -383,12 +384,15 @@ class TestContainerDownload(BaseTestCase):
                            data=org.content)
         self.assertEqual(res.status_code, 201)
         ret = self.conn.object_list(account=self.account, container=cnt)
+        names = self._data.keys()
         for obj in ret['objects']:
             name = obj['name']
             self.assertIn(name, self._data)
             self.assertEqual(obj['size'], len(self._data[name]['data']))
             meta = self.conn.object_get_properties(self.account, cnt, name)
             self.assertEqual(meta['properties'], self._data[name]['meta'])
+            names.remove(name)
+        self.assertEqual(len(names), 0)
 
     @attr('restore')
     def test_multipart_restore(self):


### PR DESCRIPTION
A regression was introduced during f616a41ec as same var size was
used to store HTTP Content-Length and object uploaded to SDS.

This commit fix that by introducing new variable name (req_size) for
HTTP Content-Length and enforce that total data consumed are now
same size as HTTP.

It also enforce test to ensure all objects put are really restored.

This PR will closes #1143 