### PR TITLE
CLI: Make 'account/container show' human readable

### DIFF
--- a/oio/cli/admin/volume.py
+++ b/oio/cli/admin/volume.py
@@ -113,7 +113,7 @@ class IncidentAdminVolume(lister.Lister):
             default=[],
             type=int,
             action='append',
-            help='Incident date to set')
+            help='Incident date to set (seconds)')
         return parser
 
     def take_action(self, parsed_args):

--- a/oio/cli/storage/account.py
+++ b/oio/cli/storage/account.py
@@ -39,6 +39,12 @@ class ShowAccount(show.ShowOne):
         )
         data['account'] = data['id']
         del data['id']
+        if parsed_args.formatter == 'table':
+            from oio.common.utils import convert_size
+
+            data['ctime'] = int(float(data.get('ctime', 0)))
+            data['bytes'] = convert_size(int(data.get('bytes', 0)), unit="B")
+            data['objects'] = convert_size(int(data.get('objects', 0)))
         return zip(*sorted(data.iteritems()))
 
 

--- a/oio/cli/storage/container.py
+++ b/oio/cli/storage/container.py
@@ -228,13 +228,22 @@ class ShowContainer(show.ShowOne):
         )
 
         sys = data['system']
+        ctime = float(sys['sys.m2.ctime']) / 1000000.
+        bytes_usage = sys.get('sys.m2.usage', 0)
+        objects = sys.get('sys.m2.objects', 0)
+        if parsed_args.formatter == 'table':
+            from oio.common.utils import convert_size
+
+            ctime = int(ctime)
+            bytes_usage = convert_size(int(bytes_usage), unit="B")
+            objects = convert_size(int(objects))
         info = {'account': sys['sys.account'],
                 'base_name': sys['sys.name'],
                 'container': sys['sys.user.name'],
-                'ctime': sys['sys.m2.ctime'],
-                'bytes_usage': sys.get('sys.m2.usage', 0),
+                'ctime': ctime,
+                'bytes_usage': bytes_usage,
                 'quota': sys.get('sys.m2.quota', "Namespace default"),
-                'objects': sys.get('sys.m2.objects', 0),
+                'objects': objects,
                 'storage_policy': sys.get('sys.m2.policy.storage',
                                           "Namespace default"),
                 'max_versions': sys.get('sys.m2.policy.version',

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -40,6 +40,8 @@ from functools import wraps
 import codecs
 from oio.common.exceptions import OioException
 
+import math
+
 xattr = None
 try:
     # try python-pyxattr
@@ -589,3 +591,16 @@ def ensure_request_id(func):
             headers['X-oio-req-id'] = request_id()
         return func(*args, **kwargs)
     return ensure_request_id_wrapper
+
+
+METRIC_SYMBOLS = ("", "K", "M", "G", "T", "P", "E", "Z", "Y")
+
+
+def convert_size(size, unit=""):
+    if size == 0:
+        return "0%s" % unit
+    i = int(math.log(size, 1000))
+    if i != 0:
+        p = math.pow(1000, i)
+        size = round(size / p, 3)
+    return "%s%s%s" % (size, METRIC_SYMBOLS[i], unit)

--- a/tests/functional/cli/storage/test_account.py
+++ b/tests/functional/cli/storage/test_account.py
@@ -14,6 +14,7 @@
 # License along with this library.
 
 import uuid
+import re
 from tests.functional.cli import CliTestCase
 from testtools.matchers import Equals
 
@@ -49,6 +50,14 @@ class AccountTest(CliTestCase):
         self.assertThat(data['metadata']['test'], Equals('1'))
         output = self.openio('account delete ' + self.NAME)
         self.assertOutput('', output)
+
+    def test_account_show_table(self):
+        self.openio('account create ' + self.NAME)
+        opts = self.get_opts([], 'table')
+        output = self.openio('account show ' + self.NAME + opts)
+        regex = "|\s*%s\s*|\s*%s\s*|"
+        self.assertIsNotNone(re.match(regex % ("bytes", "0B"), output))
+        self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
 
     def test_account_refresh(self):
         self.openio('account create ' + self.NAME)

--- a/tests/functional/cli/storage/test_container.py
+++ b/tests/functional/cli/storage/test_container.py
@@ -14,6 +14,7 @@
 # License along with this library.
 
 import uuid
+import re
 from tests.functional.cli import CliTestCase
 
 
@@ -36,6 +37,13 @@ class ContainerTest(CliTestCase):
         opts = self.get_opts(['container'])
         output = self.openio('container show ' + self.NAME + opts)
         self.assertEqual(self.NAME + '\n', output)
+
+    def test_container_show_table(self):
+        opts = self.get_opts([], 'table')
+        output = self.openio('container show ' + self.NAME + opts)
+        regex = "|\s*%s\s*|\s*%s\s*|"
+        self.assertIsNotNone(re.match(regex % ("bytes_usage", "0B"), output))
+        self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
 
     def test_container_list(self):
         opts = self.get_opts(['Name'])

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -16,7 +16,7 @@
 import unittest
 import logging
 from cStringIO import StringIO
-from oio.common.utils import get_logger
+from oio.common.utils import get_logger, convert_size
 
 
 class TestUtils(unittest.TestCase):
@@ -33,3 +33,13 @@ class TestUtils(unittest.TestCase):
         logger = get_logger(conf, 'test')
         logger.debug('msg3')
         self.assertEqual(sio.getvalue(), 'msg1\nmsg3\n')
+
+    def test_convert_size(self):
+        size = convert_size(0)
+        self.assertEqual(size, "0")
+        size = convert_size(42)
+        self.assertEqual(size, "42")
+        size = convert_size(1000)
+        self.assertEqual(size, "1.0K")
+        size = convert_size(0, unit="B")
+        self.assertEqual(size, "0B")


### PR DESCRIPTION
See #1140 

```
$ openio account show myaccount
+------------+------------+
| Field      | Value      |
+------------+------------+
| account    | myaccount  |
| bytes      | 354.605KB  |
| containers | 7          |
| ctime      | 1503937834 |
| metadata   | {}         |
| objects    | 1          |
+------------+------------+
$ openio container show test
+----------------+--------------------------------------------------------------------+
| Field          | Value                                                              |
+----------------+--------------------------------------------------------------------+
| account        | myaccount                                                          |
| base_name      | 0A826191AEA91051840F917C5AB84187594E012BB33FD600259D271ADBA1B296.1 |
| bytes_usage    | 354.605KB                                                          |
| container      | test                                                               |
| ctime          | 1503992822                                                         |
| max_versions   | Namespace default                                                  |
| objects        | 1                                                                  |
| quota          | Namespace default                                                  |
| storage_policy | Namespace default                                                  |
+----------------+--------------------------------------------------------------------+
```