### PR TITLE
Python API: Add consistency to the endpoint

### DIFF
--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -28,13 +28,12 @@ class ProxyClient(HttpApi):
 
         ep_parts = list()
         if endpoint:
-            self.proxy_netloc = endpoint[7:]  # skip "http://"
-            ep_parts.append(endpoint)
+            self.proxy_netloc = endpoint.lstrip("http://")
         else:
             ns_conf = load_namespace_conf(self.ns)
             self.proxy_netloc = ns_conf.get('proxy')
-            ep_parts.append("http:/")
-            ep_parts.append(self.proxy_netloc)
+        ep_parts.append("http:/")
+        ep_parts.append(self.proxy_netloc)
 
         ep_parts.append("v3.0")
         if not no_ns_in_url:

--- a/tests/unit/common/test_client.py
+++ b/tests/unit/common/test_client.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2017 OpenIO SAS
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+
+import unittest
+
+from oio.common.client import ProxyClient
+
+
+class ProxyClientTest(unittest.TestCase):
+
+    def test_endpoint(self):
+        proxy_client = ProxyClient({"namespace": "OPENIO"},
+                                   endpoint="127.0.0.1:4444")
+        self.assertEqual(proxy_client.proxy_netloc, "127.0.0.1:4444")
+        self.assertEqual(proxy_client.endpoint,
+                         "http://127.0.0.1:4444/v3.0/OPENIO")
+        proxy_client = ProxyClient({"namespace": "OPENIO"},
+                                   endpoint="http://127.0.0.1:4444")
+        self.assertEqual(proxy_client.proxy_netloc, "127.0.0.1:4444")
+        self.assertEqual(proxy_client.endpoint,
+                         "http://127.0.0.1:4444/v3.0/OPENIO")


### PR DESCRIPTION
See #1151

```
>>> from oio import ObjectStorageApi
>>> storage = ObjectStorageApi("OPENIO", endpoint="127.0.0.1:6000")
>>> storage.container_create("myaccount", "test")
True
>>> storage.object_list("myaccount", "test")
{'prefixes': [], 'objects': [], 'properties': {}, 'system': {'sys.m2.usage': '0', 'sys.peers': '127.0.0.1:6016,127.0.0.1:6015,127.0.0.1:6018', 'sys.type': 'meta2', 'sys.m2.version': '0', 'sys.name': '0A826191AEA91051840F917C5AB84187594E012BB33FD600259D271ADBA1B296.1', 'sys.m2.init': '1', 'sys.ns': 'OPENIO', 'sys.user.name': 'test', 'sys.m2.ctime': '1504172359662371', 'sys.m2.objects': '0', 'sys.account': 'myaccount'}}
>>> storage.container_list("myaccount")
[['06EE0', 0, 0, 0], ['ff54f3f94ea54506a4ffe81b24a8841e', 0, 0, 0], ['test', 0, 0, 0]]
>>> storage.object_create("myaccount", "test", data="Hello World!", obj_name="test")
([{'url': 'http://127.0.0.1:6024/F9C93080347FFB2486737E80974A3C6A3DF2330491B54E0484339A5E5B6DC119', 'score': 83, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}, {'url': 'http://127.0.0.1:6022/8FEF69B349DB847F78201DE389781DBED32D4147A30F6897C4A1BF41886A3F2E', 'score': 83, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}, {'url': 'http://127.0.0.1:6023/15D6010DD5A8C9ED1B230C621363DB93CD8EB9005A4AB1F17EFA26C905A7D58D', 'score': 83, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}], 12, 'ed076287532e86365e841e92bfc50d8c')
>>> 
>>> storage = ObjectStorageApi("OPENIO", endpoint="http://127.0.0.1:6000")
>>> storage.container_create("myaccount", "test2")
True
>>> storage.object_list("myaccount", "test2")
{'prefixes': [], 'objects': [], 'properties': {}, 'system': {'sys.m2.usage': '0', 'sys.peers': '127.0.0.1:6018,127.0.0.1:6015,127.0.0.1:6016', 'sys.type': 'meta2', 'sys.m2.version': '0', 'sys.name': '901C19C8D5E7B921EA392B468C5784C4B761C4E331B4FF50EB1A63C44607DD0B.1', 'sys.m2.init': '1', 'sys.ns': 'OPENIO', 'sys.user.name': 'test2', 'sys.m2.ctime': '1504172562140904', 'sys.m2.objects': '0', 'sys.account': 'myaccount'}}
>>> storage.container_list("myaccount")
[['06EE0', 0, 0, 0], ['ff54f3f94ea54506a4ffe81b24a8841e', 0, 0, 0], ['test', 1, 12, 0], ['test2', 0, 0, 0]]
>>> storage.object_create("myaccount", "test2", data="Hello World!", obj_name="test")
([{'url': 'http://127.0.0.1:6024/5E22E41AD5A3EEA4ED74BE12ADEA28BC9F52F692AA9647015647B13E5066FD14', 'score': 84, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}, {'url': 'http://127.0.0.1:6022/DEF6BB05F070360BFBAD8C7DC26D20EE3D2747597FFED8320A2FC7509ED7C17C', 'score': 84, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}, {'url': 'http://127.0.0.1:6023/ADBAA91F352141777E9C71E1929179DFFC2E215002C38848B8E85F62CBBD429E', 'score': 84, 'hash': 'ed076287532e86365e841e92bfc50d8c', 'pos': '0', 'size': 12}], 12, 'ed076287532e86365e841e92bfc50d8c')
```