### PR TITLE
Refactor backup restoration code

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -684,7 +684,7 @@ class ObjectStorageApi(object):
                         version=None, size=None, **kwargs):
         """
         Truncate object at specified size. Only shrink is supported.
-        A download may occurs if size is not on chunk boundaries.
+        A download may occur if size is not on chunk boundaries.
 
         :param account: name of the account in which the object is stored
         :param container: name of the container in which the object is stored
@@ -709,7 +709,6 @@ class ObjectStorageApi(object):
             raise exc.OioException("No chunk found at position %d" % size)
 
         if chunk['offset'] != size:
-            props = self.object_show(account, container, obj)
             # retrieve partial chunk
             ret = self.object_fetch(account, container, obj,
                                     version=version,
@@ -718,7 +717,7 @@ class ObjectStorageApi(object):
             pos = int(chunk['pos'].split('.')[0])
             self.object_create(account, container, obj_name=obj,
                                data=ret[1], meta_pos=pos,
-                               content_id=props['id'])
+                               content_id=meta['id'])
 
         return self.container.content_truncate(account, container, obj,
                                                version=version, size=size,

--- a/oio/container/backup.py
+++ b/oio/container/backup.py
@@ -521,7 +521,7 @@ class ContainerRestore(object):
             for entry in self.cur_state['manifest']:
                 if entry['name'] == self.inf.name:
                     break
-            else:  # it should not happens
+            else:  # it should not happen
                 raise BadRequest("Invalid internal state")
             self.cur_state['end'] = (entry['start_block']
                                      + self.cur_state['offset'])
@@ -530,7 +530,7 @@ class ContainerRestore(object):
                            ex=ContainerBackup.REDIS_TIMEOUT)
             raise
 
-        # save properties before checking size, otherwise they'll lost
+        # save properties before checking size, otherwise they'll be lost
         if hdrs:
             self.proxy.object_set_properties(account, container,
                                              self.inf.name,

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -510,11 +510,10 @@ class ContainerClient(ProxyClient):
         return body
 
     def content_truncate(self, account=None, reference=None, path=None,
-                         cid=None, size=None, **kwargs):
+                         cid=None, size=0, **kwargs):
         uri = self._make_uri('content/truncate')
         params = self._make_params(account, reference, path, cid=cid)
-        if size:
-            params['size'] = size
+        params['size'] = size
         _resp, body = self._direct_request(
             'POST', uri, params=params, **kwargs)
         return body

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -330,6 +330,10 @@ class ContainerClient(ProxyClient):
         params = self._make_params(account, reference, path, cid=cid)
         if append:
             params['append'] = '1'
+        if kwargs.get('meta_pos') is not None:
+            data = data['chunks']
+            params['id'] = content_id
+            uri = self._make_uri('content/update')
         # TODO(FVE): implement 'force' parameter
         if not isinstance(data, dict):
             warnings.simplefilter('once')
@@ -503,4 +507,14 @@ class ContainerClient(ProxyClient):
         data = json.dumps(data)
         _resp, body = self._direct_request(
             'POST', uri, data=data, params=params, **kwargs)
+        return body
+
+    def content_truncate(self, account=None, reference=None, path=None,
+                         cid=None, size=None, **kwargs):
+        uri = self._make_uri('content/truncate')
+        params = self._make_params(account, reference, path, cid=cid)
+        if size:
+            params['size'] = size
+        _resp, body = self._direct_request(
+            'POST', uri, params=params, **kwargs)
         return body

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -417,3 +417,41 @@ class TestObjectStorageAPI(BaseTestCase):
 
         meta = self.api.object_get_properties(self.account, name, name)
         self.assertEqual(meta.get('hash', "").lower(), checksum.lower())
+
+    def test_object_create_then_truncate(self):
+        """Create an object then truncate data"""
+        name = random_str(16)
+        self.api.object_create(self.account, name, data="1"*128, obj_name=name)
+        self.api.object_truncate(self.account, name, name, size=64)
+        _, data = self.api.object_fetch(self.account, name, name)
+        data = "".join(data)
+        self.assertEqual(len(data), 64)
+        self.assertEqual(data, "1" * 64)
+
+    def test_object_create_append_then_truncate(self):
+        """Create an object, append data then truncate on chunk boundary"""
+        name = random_str(16)
+        self.api.object_create(self.account, name, data="1"*128, obj_name=name)
+        _, size, _ = self.api.object_create(
+            self.account, name, data="2"*128, obj_name=name, append=True)
+        self.assertEqual(size, 128)
+
+        self.api.object_truncate(self.account, name, name, size=128)
+        _, data = self.api.object_fetch(self.account, name, name)
+        data = "".join(data)
+        self.assertEqual(len(data), 128)
+        self.assertEqual(data, "1" * 128)
+
+        self.api.object_truncate(self.account, name, name, size=128)
+
+    def test_object_create_then_invalid_truncate(self):
+        """Create an object, append data then try to truncate outside object
+           range"""
+        name = random_str(16)
+        self.api.object_create(self.account, name, data="1"*128, obj_name=name)
+        self.assertRaises(
+            exc.OioException, self.api.object_truncate, self.account, name,
+            name, size=-1)
+        self.assertRaises(
+            exc.OioException, self.api.object_truncate, self.account, name,
+            name, size=129)

--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -534,7 +534,7 @@ class TestContainerDownload(BaseTestCase):
         cnt = rand_str(20)
 
         class FakeStream(object):
-            """Sending data and simulate connectivity issue"""
+            """Send data and simulate a connectivity issue"""
 
             def __init__(self, data, size):
                 self._count = 0
@@ -554,7 +554,7 @@ class TestContainerDownload(BaseTestCase):
                 raise Exception("break connection")
 
         def wait_lock():
-            """When no lock is go away, return current consumed size"""
+            """When the lock is gone, return current consumed size"""
             nb = 0
             while True:
                 time.sleep(0.1)

--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -185,6 +185,24 @@ class TestContainerDownload(BaseTestCase):
         self.conn.object_update(self.account, self._cnt, _name,
                                 self._data[_name]['meta'])
 
+    def _check_tar(self, data):
+        raw = BytesIO(data)
+        tar = tarfile.open(fileobj=raw, ignore_zeros=True)
+        info = self._data.keys()
+        for entry in tar.getnames():
+            if entry == CONTAINER_MANIFEST:
+                # skip special entry
+                continue
+
+            self.assertIn(entry, info)
+
+            tmp = tar.extractfile(entry)
+            self.assertEqual(self._data[entry]['data'], tmp.read())
+            info.remove(entry)
+
+        self.assertEqual(info, [])
+        return tar
+
     def _simple_download(self, name=gen_names, metadata=None):
         self._create_data(name, metadata)
 
@@ -195,7 +213,8 @@ class TestContainerDownload(BaseTestCase):
 
         with TemporaryFile() as tmpfile:
             tmpfile.write(self.raw)
-
+        return self._check_tar(ret.content)
+        """
         raw = BytesIO(ret.content)
         tar = tarfile.open(fileobj=raw, ignore_zeros=True)
         info = self._data.keys()
@@ -212,6 +231,7 @@ class TestContainerDownload(BaseTestCase):
 
         self.assertEqual(info, [])
         return tar
+        """
 
     def _check_metadata(self, tar):
         for entry in tar.getnames():
@@ -506,3 +526,77 @@ class TestContainerDownload(BaseTestCase):
                 thr.join()
                 self.assertIn(thr._ret.status_code, [201, 206])
             start += len(part)
+
+    @attr('disconnected')
+    def test_broken_connectivity(self):
+        self._create_data(metadata=gen_metadata, size=1025*1024)
+        org = requests.get(self.make_uri('dump'))
+        cnt = rand_str(20)
+
+        class FakeStream(object):
+            """Sending data and simulate connectivity issue"""
+
+            def __init__(self, data, size):
+                self._count = 0
+                self._data = data
+                self._size = size
+
+            def __len__(self):
+                return len(self._data)
+
+            def read(self, *args):
+                if self._count < self._size:
+                    data = self._data[self._count:self._count+size/3]
+                    self._count += len(data)
+                    return data
+                if self._count == len(self._data):
+                    return ""
+                raise Exception("break connection")
+
+        def wait_lock():
+            """When no lock is go away, return current consumed size"""
+            nb = 0
+            while True:
+                time.sleep(0.1)
+                req = requests.head(uri)
+                if (req.status_code == 200
+                        and req.headers.get('X-Upload-In-Progress',
+                                            '1') == '0'):
+                    print("Tried before lock free", nb)
+                    print("Got consumed-size", req.headers['X-Consumed-Size'])
+                    return int(req.headers['X-Consumed-Size'])
+                nb += 1
+                self.assertLess(nb, 10)
+
+        uri = self.make_uri('restore', container=cnt)
+        block = 1000 * 512
+        start = 0
+        cut = False
+        while True:
+            if start:
+                start = wait_lock()
+
+            stop = min(len(org.content), start + block)
+            hdrs = {'Range': 'bytes=%d-%d' % (start, stop-1)}
+            size = stop - start
+            if cut:
+                size = block / 2
+            cut = not cut
+
+            try:
+                ret = requests.put(uri, headers=hdrs,
+                                   data=FakeStream(org.content[start:stop],
+                                                   size))
+            except:
+                pass
+            else:
+                self.assertIn(
+                    ret.status_code, (201, 206),
+                    "Unexpected %d HTTP response: %s" % (ret.status_code,
+                                                         ret.content))
+                start += size
+                if ret.status_code == 201:
+                    break
+
+        result = requests.get(self.make_uri('dump', container=cnt))
+        self._check_tar(result.content)

--- a/tests/functional/container/test_container_backup.py
+++ b/tests/functional/container/test_container_backup.py
@@ -266,6 +266,9 @@ class TestContainerDownload(BaseTestCase):
         for idx in xrange(0, int(org.headers['content-length']), 512):
             ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' %
                                                             (idx, idx+511)})
+            self.assertEqual(ret.status_code, 206)
+            self.assertEqual(len(ret.content), 512)
+            self.assertEqual(ret.content, org.content[idx:idx+512])
             data.append(ret.content)
 
         data = "".join(data)
@@ -346,11 +349,15 @@ class TestContainerDownload(BaseTestCase):
     def test_s3_range_download(self):
         self._create_s3_slo()
         org = requests.get(self._uri)
+        self.assertEqual(org.status_code, 200)
 
         data = []
         for idx in xrange(0, int(org.headers['content-length']), 512):
             ret = requests.get(self._uri, headers={'Range': 'bytes=%d-%d' %
                                                             (idx, idx+511)})
+            self.assertEqual(ret.status_code, 206)
+            self.assertEqual(len(ret.content), 512)
+            self.assertEqual(ret.content, org.content[idx:idx+512])
             data.append(ret.content)
 
         data = "".join(data)


### PR DESCRIPTION
- Rework restore code (split code in several methods of a dedicated object)
- Enforce Unit Test to detect 500 errors when no RAWX is available
- Add lock to avoid concurrency restoration requests
- In case of connectivity issues, store position to allow continue restoration at last know position (more test needed to cover all cases)
- Add support of truncate for Python API
- Add support to overwrite a chunk for Python API (used at this time for truncate use)