### PR TITLE
Tests, BlobClient: replace requests by urllib3

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,7 +1,6 @@
 cliff>=2.0.0,<2.1.0
 # This can be simplified when https://github.com/eventlet/eventlet/issues/401 is fixed
 eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
-requests<2.13.0
 werkzeug>=0.9.1
 redis>=2.10.3
 gunicorn>=19.4.5

--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -24,8 +24,6 @@ from eventlet.green.httplib import HTTPConnection, HTTPResponse, _UNKNOWN, \
         CONTINUE, HTTPMessage
 from oio.common.constants import chunk_headers
 
-requests = patcher.import_patched('requests.__init__')
-requests_adapters = patcher.import_patched('requests.adapters')
 urllib3 = patcher.import_patched('urllib3.__init__')
 
 CONNECTION_TIMEOUT = 2.0

--- a/tests/functional/conscience/test_conscience.py
+++ b/tests/functional/conscience/test_conscience.py
@@ -23,20 +23,22 @@ import simplejson as json
 class TestConscienceFunctional(BaseTestCase):
 
     def test_namespace_get(self):
-        resp = self.session.get(self._url_cs('info'))
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsInstance(resp.json(), dict)
-        resp = self.session.get(self._url_cs('info/anything'))
+        resp = self.request('GET', self._url_cs('info'))
+        self.assertEqual(resp.status, 200)
+        self.assertIsInstance(self.json_loads(resp.data), dict)
+        resp = self.request('GET', self._url_cs('info/anything'))
         self.assertError(resp, 404, 404)
 
     def test_service_pool_get(self):
-        resp = self.session.get(self._url_cs('list'), params={'type': 'echo'})
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsInstance(resp.json(), list)
-        self.assertEqual(len(resp.json()), 0)
-        resp = self.session.get(self._url_cs('list'), params={'type': 'error'})
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'echo'})
+        self.assertEqual(resp.status, 200)
+        self.assertIsInstance(self.json_loads(resp.data), list)
+        self.assertEqual(len(self.json_loads(resp.data)), 0)
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'error'})
         self.assertError(resp, 404, CODE_SRVTYPE_NOTMANAGED)
-        resp = self.session.get(self._url_cs('list'))
+        resp = self.request('GET', self._url_cs('list'))
         self.assertError(resp, 400, 400)
 
     def test_service_pool_put_replace(self):
@@ -44,16 +46,18 @@ class TestConscienceFunctional(BaseTestCase):
         self._register_srv(srvin)
         srvin = self._srv('echo')
         self._register_srv(srvin)
-        resp = self.session.get(self._url_cs('list'), params={'type': 'echo'})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'echo'})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(srvin['addr'], (x['addr'] for x in body))
 
     def test_service_pool_put_invalid_addr(self):
         srvin = self._srv('echo')
         srvin['addr'] = 'kqjljqdk'
-        resp = self.session.post(self._url_cs('register'), json.dumps(srvin))
+        resp = self.request('POST', self._url_cs('register'),
+                            json.dumps(srvin))
         self.assertError(resp, 400, 400)
 
     def test_service_pool_put_missing_info(self):
@@ -61,87 +65,96 @@ class TestConscienceFunctional(BaseTestCase):
             s = self._srv('echo')
             del s[d]
             logging.debug("Trying without [%s]", d)
-            resp = self.session.post(self._url_cs('register'), json.dumps(s))
+            resp = self.request('POST', self._url_cs('register'),
+                                json.dumps(s))
             self.assertError(resp, 400, 400)
         for d in ('ns', 'tags', ):
             s = self._srv('echo')
             del s[d]
             logging.debug("Trying without [%s]", d)
-            resp = self.session.post(self._url_cs('register'), json.dumps(s))
-            self.assertIn(resp.status_code, (200, 204))
+            resp = self.request('POST', self._url_cs('register'),
+                                json.dumps(s))
+            self.assertIn(resp.status, (200, 204))
 
     def test_service_pool_delete(self):
         self._flush_cs('echo')
-        resp = self.session.get(self._url_cs('list'), params={'type': 'echo'})
-        self.assertEqual(resp.status_code, 200)
-        services = resp.json()
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'echo'})
+        self.assertEqual(resp.status, 200)
+        services = self.json_loads(resp.data)
         self.assertListEqual(services, [])
 
     def test_service_pool_delete_wrong(self):
         params = {'type': 'error'}
-        resp = self.session.post(self._url_cs('deregister'), params=params)
-        self.assertEqual(resp.status_code, 404)
+        resp = self.request('POST', self._url_cs('deregister'), params=params)
+        self.assertEqual(resp.status, 404)
 
     def test_service_pool_actions_lock(self):
         srv = self._srv('echo')
-        resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
+        resp = self.request('POST', self._url_cs('lock'), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
 
     def test_service_pool_actions_lock_and_reput(self):
         srv = self._srv('echo')
-        resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('POST', self._url_cs('lock'), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(srv['addr'], [x['addr'] for x in body])
 
         self._register_srv(srv)
-        resp = self.session.get(self._url_cs('list'), params={'type': 'echo'})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'echo'})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(srv['addr'], [x['addr'] for x in body])
 
         srv2 = dict(srv)
         srv2['score'] = -1
         self._register_srv(srv2)
-        self.assertEqual(resp.status_code, 200)
-        resp = self.session.get(self._url_cs('list'), params={'type': 'echo'})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        self.assertEqual(resp.status, 200)
+        resp = self.request('GET', self._url_cs('list'),
+                            params={'type': 'echo'})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(srv['addr'], [x['addr'] for x in body])
 
     def test_service_pool_actions_lock_and_relock(self):
         srv = self._srv('echo')
-        resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('POST', self._url_cs("lock"), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(srv['addr'], [x['addr'] for x in body])
 
         srv['score'] = 0
-        resp = self.session.post(self._url_cs('lock'), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('POST', self._url_cs('lock'), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertIn(str(srv['addr']), [x['addr'] for x in body])
 
     def test_services_pool_actions_unlock(self):
         srv = self._srv('echo')
-        resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.post(self._url_cs("unlock"), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('POST', self._url_cs("lock"), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('POST', self._url_cs("unlock"), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
 
     def test_service_unlock_no_register(self):
@@ -149,10 +162,11 @@ class TestConscienceFunctional(BaseTestCase):
         self._reload()
         srv = self._srv('echo')
         srv['score'] = -1
-        resp = self.session.post(self._url_cs('unlock'), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        body = resp.json()
+        resp = self.request('POST', self._url_cs('unlock'), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        body = self.json_loads(resp.data)
         self.assertIsInstance(body, list)
         self.assertListEqual(body, [])
         self._flush_cs('echo')
@@ -167,34 +181,36 @@ class TestConscienceFunctional(BaseTestCase):
 
         # register the service with a positive score
         srv['score'] = 1
-        resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
+        resp = self.request('POST', self._url_cs("lock"), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
         # Ensure the proxy reloads its LB pool
         self._reload()
         # check it appears
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         check_service_known(body)
         # check it is polled
-        resp = self.session.post(
-                self._url_lb('poll'), params={"pool": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('POST', self._url_lb('poll'),
+                            params={"pool": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         check_service_known(body)
 
         # register the service locked to 0
         srv['score'] = 0
-        resp = self.session.post(self._url_cs("lock"), json.dumps(srv))
-        self.assertIn(resp.status_code, (200, 204))
+        resp = self.request('POST', self._url_cs("lock"), json.dumps(srv))
+        self.assertIn(resp.status, (200, 204))
         # Ensure the proxy reloads its LB pool
         self._reload()
         # check it appears
-        resp = self.session.get(self._url_cs('list'), params={"type": "echo"})
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
+        resp = self.request('GET', self._url_cs('list'),
+                            params={"type": "echo"})
+        self.assertEqual(resp.status, 200)
+        body = self.json_loads(resp.data)
         check_service_known(body)
         # the service must not be polled
-        resp = self.session.post(
-                self._url_lb('poll'), params={"pool": "echo"})
+        resp = self.request('POST', self._url_lb('poll'),
+                            params={"pool": "echo"})
         self.assertError(resp, 500, 481)

--- a/tests/functional/conscience/test_lb.py
+++ b/tests/functional/conscience/test_lb.py
@@ -39,36 +39,34 @@ class BaseLbTest(BaseTestCase):
 class TestLbChoose(BaseLbTest):
 
     def test_choose_1(self):
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'rawx'})
-        self.assertEqual(resp.status_code, 200)
-        parsed = resp.json()
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'rawx'})
+        self.assertEqual(resp.status, 200)
+        parsed = self.json_loads(resp.data)
         self.assertIsInstance(parsed, list)
         self.assertIsInstance(parsed[0], dict)
-        resp = self.session.get(self._url_lb('nothing'),
-                                params={'type': 'rawx'})
+        resp = self.request('GET', self._url_lb('nothing'),
+                            params={'type': 'rawx'})
         self.assertError(resp, 404, 404)
 
     def test_choose_2(self):
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'rawx',
-                                        'size': 2})
-        self.assertEqual(resp.status_code, 200)
-        parsed = resp.json()
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'rawx', 'size': 2})
+        self.assertEqual(resp.status, 200)
+        parsed = self.json_loads(resp.data)
         self.assertIsInstance(parsed, list)
         self.assertEqual(2, len(parsed))
 
     def test_choose_too_much(self):
         if len(self.conf['services']['rawx']) >= 10000:
             self.skipTest("need less than 10000 rawx to run")
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'rawx',
-                                        'size': 10000})
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'rawx', 'size': 10000})
         self.assertError(resp, 500, CODE_POLICY_NOT_SATISFIABLE)
 
     def test_choose_wrong_type(self):
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'rowix'})
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'rowix'})
         self.assertError(resp, 404, CODE_SRVTYPE_NOTMANAGED)
 
     def test_choose_1_slot(self):
@@ -76,11 +74,10 @@ class TestLbChoose(BaseLbTest):
         self.fill_slots(["fast"], 3, 8000)
         self.fill_slots(["slow"], 3, 7000)
         self._reload()
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'echo',
-                                        'slot': 'fast'})
-        self.assertEqual(resp.status_code, 200)
-        parsed = resp.json()
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'echo', 'slot': 'fast'})
+        self.assertEqual(resp.status, 200)
+        parsed = self.json_loads(resp.data)
         self.assertIsInstance(parsed, list)
         self.assertEqual(1, len(parsed))
         self.assertGreaterEqual(parsed[0]["addr"].split(':')[1], 8000)
@@ -90,12 +87,12 @@ class TestLbChoose(BaseLbTest):
         self.fill_slots(["fast"], 3, 8000)
         self.fill_slots(["slow"], 3, 7000)
         self._reload()
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'echo',
-                                        'slot': 'fast',
-                                        'size': 4})
-        self.assertEqual(resp.status_code, 200)
-        parsed = resp.json()
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'echo',
+                                    'slot': 'fast',
+                                    'size': 4})
+        self.assertEqual(resp.status, 200)
+        parsed = self.json_loads(resp.data)
         self.assertIsInstance(parsed, list)
         self.assertEqual(4, len(parsed))
         fast_count = 0
@@ -121,13 +118,12 @@ class TestLbChoose(BaseLbTest):
         self._reload()
         self.fill_sameport(3)
         self._reload()
-        resp = self.session.get(self._url_lb('choose'),
-                                params={'type': 'echo',
-                                        'size': 3})
-        if resp.status_code != 200:
-            print resp.json()
-            self.assertEqual(resp.status_code, 200)
-        parsed = resp.json()
+        resp = self.request('GET', self._url_lb('choose'),
+                            params={'type': 'echo', 'size': 3})
+        if resp.status != 200:
+            print self.json_loads(resp.data)
+            self.assertEqual(resp.status, 200)
+        parsed = self.json_loads(resp.data)
         self.assertIsInstance(parsed, list)
         self.assertEqual(3, len(parsed))
 
@@ -135,16 +131,15 @@ class TestLbChoose(BaseLbTest):
 class TestLbPoll(BaseLbTest):
 
     def test_poll_invalid(self):
-        resp = self.session.post(self._url_lb('poll'),
-                                 params={'policy': 'invalid'})
+        resp = self.request('POST', self._url_lb('poll'),
+                            params={'policy': 'invalid'})
         self.assertError(resp, 500, CODE_POLICY_NOT_SATISFIABLE)
 
     def _test_poll_policy(self, pol_name, count, json=None):
-        resp = self.session.post(self._url_lb('poll'),
-                                 params={'policy': pol_name},
-                                 json=json)
-        parsed = resp.json()
-        self.assertEqual(resp.status_code, 200)
+        resp = self.request('POST', self._url_lb('poll'),
+                            params={'policy': pol_name}, json=json)
+        parsed = self.json_loads(resp.data)
+        self.assertEqual(resp.status, 200)
         self.assertIsInstance(parsed, list)
         self.assertEqual(count, len(parsed))
         self.assertIsInstance(parsed[0], dict)


### PR DESCRIPTION
The requests module in `BlobClient`  is  replaced by urllib3.
 It should have been replaced by the `httplib` used by `ChunkReader` but for a first step it was replaced by `urllib3`