### PR TITLE
cmake: Get rid of the configurable prefix to CLI tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,7 @@ macro (option_or_system _PREFIX _LIB)
 endmacro ()
 
 macro(bin_prefix T N)
-	if (NOT DEFINED EXE_PREFIX)
-		set(EXE_PREFIX "oio")
-	endif ()
-	set_target_properties(${T} PROPERTIES OUTPUT_NAME ${EXE_PREFIX}${N})
+	set_target_properties(${T} PROPERTIES OUTPUT_NAME "oio${N}")
 endmacro ()
 
 ###-------------------------------------------------------------------------###

--- a/cache/cache_memcached.c
+++ b/cache/cache_memcached.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/cache/cache_memcached.h
+++ b/cache/cache_memcached.h
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/cache/cache_multilayer.c
+++ b/cache/cache_multilayer.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/cache/cache_redis.c
+++ b/cache/cache_redis.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/cache/cache_redis.h
+++ b/cache/cache_redis.h
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/tests/common/test_cache_abstract.c
+++ b/tests/common/test_cache_abstract.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS cache
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tests/func/test_cache_memcached.c
+++ b/tests/func/test_cache_memcached.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS functional tests
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tests/func/test_cache_redis.c
+++ b/tests/func/test_cache_redis.c
@@ -1,6 +1,7 @@
 /*
 OpenIO SDS functional tests
 Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015 Vincent Vinel
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -23,56 +23,29 @@ target_link_libraries(oio-tool
 	meta2v2utils
 	${GLIB2_LIBRARIES})
 
-
-set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/.timestamp")
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-unlock-all.sh
-        ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-unlock-all.sh
-        @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-flush-all.sh
-                ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-flush-all.sh
-        @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-wait-scored.sh
-        ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-wait-scored.sh
-        @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-reset.sh
-        ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-reset.sh
-        @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-bootstrap.py
-        ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-bootstrap.py
-        @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-sds.pc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc
-        @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-test-config.py
-        ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-test-config.py
-        @ONLY)
+	${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc @ONLY)
 
-add_custom_command(OUTPUT ${OUTPUT}
-                   COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
-                   DEPENDS ${DEPS})
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-bootstrap.py
+	${CMAKE_CURRENT_BINARY_DIR}/oio-bootstrap.py @ONLY)
 
-add_custom_target(tools ALL DEPENDS ${OUTPUT})
-
-install(FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc
-        DESTINATION ${PKGCONFIG_DIRECTORY}
-        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc
+		DESTINATION ${PKGCONFIG_DIRECTORY}
+		PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 install(TARGETS oio-tool DESTINATION bin)
 
 install(PROGRAMS
-            zk-bootstrap.py
-            zk-reset.py
-            oio-election-reset.py
-            oio-election-smudge.py
-            oio-election-stat.py
-            oio-election-dump.py
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-unlock-all.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-flush-all.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-wait-scored.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-bootstrap.py
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-test-config.py
-            ${CMAKE_CURRENT_BINARY_DIR}/${EXE_PREFIX}-reset.sh
-        DESTINATION bin)
-
+			zk-bootstrap.py
+			zk-reset.py
+			oio-election-reset.py
+			oio-election-smudge.py
+			oio-election-stat.py
+			oio-election-dump.py
+			oio-unlock-all.sh
+			oio-flush-all.sh
+			oio-wait-scored.sh
+			${CMAKE_CURRENT_BINARY_DIR}/oio-bootstrap.py
+			oio-test-config.py
+			oio-reset.sh
+		DESTINATION bin)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -2,6 +2,7 @@
 
 # oio-bootstrap.py
 # Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015 Conrad Kleinespel
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/oio-flush-all.sh
+++ b/tools/oio-flush-all.sh
@@ -18,7 +18,6 @@
 
 set -e
 
-PREFIX="@EXE_PREFIX@"
 NS=
 
 list () {

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -e
-
-set -e
 set -x
 export COLUMNS=512 LANG= LANGUAGE=
 
@@ -184,6 +182,8 @@ test_cli () {
     gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
     sleep 0.5
 }
+
+/sbin/sysctl net.ipv4.ip_local_port_range
 
 if is_running_test_suite "copyright" ; then
 	echo -e "\n### Checking the presence of Copyright mentions"

--- a/tools/oio-unlock-all.sh
+++ b/tools/oio-unlock-all.sh
@@ -17,16 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -e
 
-PREFIX="@EXE_PREFIX@"
 LOCAL=
 NS=
 SRVTYPE=
 
 list () {
 	if [ -n "$SRVTYPE" ] ; then
-		${PREFIX}-cluster -r "$NS" | egrep -E -e "|${SRVTYPE}|"
+		oio-cluster -r "$NS" | egrep -E -e "|${SRVTYPE}|"
 	else
-		${PREFIX}-cluster -r "$NS"
+		oio-cluster -r "$NS"
 	fi
 }
 
@@ -45,6 +44,6 @@ if [ -z "$NS" ] ; then
 fi
 
 list | while read S ; do
-	${PREFIX}-cluster --unlock-score -S "$S"
+	oio-cluster --unlock-score -S "$S"
 done
 


### PR DESCRIPTION
* Remove the useless management of a configurable prefix to the binary tools
* Fix missing copyright mentions:
  * Adds Vincent Vinel in cache related elements.
  * Adds Conrad Kleinespel in oio-bootstrap.py