### PR TITLE
Requirements: add requests

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,6 +1,7 @@
 cliff>=2.0.0,<2.1.0
 # This can be simplified when https://github.com/eventlet/eventlet/issues/401 is fixed
 eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
+requests<2.13.0
 werkzeug>=0.9.1
 redis>=2.10.3
 gunicorn>=19.4.5


### PR DESCRIPTION
The commit 4e9cb87ad3 has removed requests from `all-requirements.txt` but
`oio/api/backblaze_http.py` still use it. The `test_container_backup.py`
also depends on it at this time but dependency could be moved later in `test-requirements.txt`.

It was unseen during CI as requests is a dependency of codecov.