### PR TITLE
Backport a fix in the generation of ID of services

### DIFF
--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -395,7 +395,7 @@ service_info_key (const struct service_info_s *si)
 	const char *explicit = service_info_get_tag_value(si, "tag.id", NULL);
 	if (explicit)
 		return oio_make_service_key(si->ns_name, si->type, explicit);
-	grid_addrinfo_to_string(&si->addr, addr, sizeof(struct addr_info_s));
+	grid_addrinfo_to_string(&si->addr, addr, sizeof(addr));
 	return oio_make_service_key(si->ns_name, si->type, addr);
 }
 

--- a/tests/unit/test_addr.c
+++ b/tests/unit/test_addr.c
@@ -46,12 +46,36 @@ test_good_connect_address(void)
 	test_on_urlv(good_urls, test);
 }
 
+#define SRV_NS "NAMESPACE"
+#define SRV_TYPE "meta2"
+
+#define TEST_IDGEN(URL) do { \
+	struct service_info_s si = {}; \
+	g_strlcpy(si.ns_name, SRV_NS, sizeof(si.ns_name)); \
+	g_strlcpy(si.type, SRV_TYPE, sizeof(si.type)); \
+	g_assert_true(grid_string_to_addrinfo(URL, &si.addr)); \
+	si.score.value = si.score.timestamp = 1; \
+	gchar *id = service_info_key(&si); \
+	g_assert_nonnull(id); \
+	g_assert_cmpstr(id, ==, SRV_NS "|" SRV_TYPE "|" URL); \
+	g_free(id); \
+} while (0)
+
+static void
+test_srvinfo_id(void)
+{
+	TEST_IDGEN("1.2.3.4:1");
+	TEST_IDGEN("127.0.0.1:6000");
+	TEST_IDGEN("254.254.254.254:60000");
+}
+
 int
 main(int argc, char **argv)
 {
 	HC_TEST_INIT(argc,argv);
 	g_test_add_func("/metautils/addr/connect/ko", test_bad_connect_address);
 	g_test_add_func("/metautils/addr/connect/ok", test_good_connect_address);
+	g_test_add_func("/metautils/srvinfo/id", test_srvinfo_id);
 	return g_test_run();
 }
 

--- a/tests/unit/test_str.c
+++ b/tests/unit/test_str.c
@@ -27,6 +27,31 @@ test_transform(gchar* (*T) (const gchar*), const gchar *s0, const gchar *sN)
 	g_free(s);
 }
 
+static void
+test_via_gba(void)
+{
+	const char *src = "255.255.255.255:6789";
+	GByteArray *gba = metautils_gba_from_string(src);
+	gchar *copy = g_strndup((gchar*)gba->data, gba->len);
+	g_assert_cmpstr(src, ==, copy);
+	g_free(copy);
+	g_byte_array_free(gba, TRUE);
+}
+
+static void
+test_via_message(void)
+{
+	const char *src = "255.255.255.255:6789";
+	MESSAGE msg = metautils_message_create_named("plop");
+	metautils_message_add_body_unref(msg, metautils_gba_from_string(src));
+	gchar *copy = NULL;
+	GError *err = metautils_message_extract_body_string(msg, &copy);
+	g_assert_no_error(err);
+	g_assert_cmpstr(src, ==, copy);
+	g_free(copy);
+	metautils_message_destroy(msg);
+}
+
 /* ------------------------------------------------------------------------- */
 
 static void
@@ -221,6 +246,8 @@ main(int argc, char **argv)
 	g_test_add_func("/core/str/strv", test_STRV_ok);
 	g_test_add_func("/core/str/autocontainer", test_autocontainer);
 
+	g_test_add_func("/metautils/str/gba", test_via_gba);
+	g_test_add_func("/metautils/str/message", test_via_message);
 	g_test_add_func("/metautils/str/clean", test_clean);
 	g_test_add_func("/metautils/str/upper", test_upper);
 	g_test_add_func("/metautils/str/lower", test_lower);


### PR DESCRIPTION
The ID of services was truncated, this is now fixed thanks to @fvennetier (commit cherry-picked from 4.x to 4.0.x)