### PR TITLE
Print lighter warnings on network errors

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -69,6 +69,12 @@ class AccountClient(HttpApi):
             if now - self._last_refresh > self._refresh_delay:
                 try:
                     self._refresh_endpoint(now)
+                except OioNetworkException as exc:
+                    if not self.endpoint:
+                        # Cannot use the previous one
+                        raise
+                    self.logger.warn(
+                            "Failed to refresh account endpoint: %s", exc)
                 except ClientException:
                     if not self.endpoint:
                         # Cannot use the previous one

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -24,6 +24,7 @@ from oio.common.daemon import Daemon
 from oio.common import exceptions as exc
 from oio.common.utils import get_logger, int_value, paths_gen
 from oio.common.green import ratelimit
+from oio.common.exceptions import OioNetworkException
 
 
 class BlobIndexer(Daemon):
@@ -55,6 +56,9 @@ class BlobIndexer(Daemon):
                 self.update_index(path)
                 self.successes += 1
                 self.logger.debug('Updated %s', path)
+            except OioNetworkException as exc:
+                self.errors += 1
+                self.logger.warn('ERROR while updating %s: %s', path, exc)
             except Exception:
                 self.errors += 1
                 self.logger.exception('ERROR while updating %s', path)

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -22,6 +22,7 @@ import sys
 import greenlet
 import eventlet
 from eventlet import Timeout, greenthread
+from oio.common.exceptions import OioNetworkException
 
 from oio.conscience.client import ConscienceClient
 from oio.rdir.client import RdirClient
@@ -221,6 +222,9 @@ class EventWorker(Worker):
                 try:
                     event = self.safe_decode_job(job_id, data)
                     self.process_event(job_id, event, beanstalk)
+                except OioNetworkException as e:
+                    self.logger.warn("handling event %s (bury): %s", job_id, e)
+                    beanstalk.bury(job_id)
                 except Exception:
                     self.logger.exception("handling event %s (bury)", job_id)
                     beanstalk.bury(job_id)


### PR DESCRIPTION
Avoid polluting the log when OioNetworkError exceptions are raised. All the useful information is container in the message (which peer, which protocol library)