### PR TITLE
Fix the management of the return of g_thread_pool_push()

### DIFF
--- a/metautils/lib/metautils_containers.h
+++ b/metautils/lib/metautils_containers.h
@@ -94,4 +94,8 @@ void metautils_gpa_reverse (GPtrArray *gpa);
  * <v> is NULL-terminated. <v> is not freed. */
 void metautils_gvariant_unrefv (GVariant **v);
 
+/* Wrapper around g_thread_pool_push() that throttle-logs the error */
+void metautils_gthreadpool_push(const char *tag,
+		GThreadPool *pool, gpointer p);
+
 #endif /*OIO_SDS__metautils__lib__metautils_containers_h*/

--- a/metautils/lib/utils_containers.c
+++ b/metautils/lib/utils_containers.c
@@ -19,7 +19,7 @@ License along with this library.
 
 #include <stdlib.h>
 
-#include "metautils_containers.h"
+#include "metautils.h"
 
 void
 gslist_free_element(gpointer d, gpointer u)
@@ -253,6 +253,21 @@ metautils_gvariant_unrefv(GVariant **v)
 	for (; *v ;v++) {
 		g_variant_unref(*v);
 		*v = NULL;
+	}
+}
+
+void
+metautils_gthreadpool_push(const char *tag, GThreadPool *pool, gpointer p)
+{
+	static gint64 last_log = 0;
+	GError *err = NULL;
+	if (!g_thread_pool_push(pool, p, &err)) {
+		const gint64 now = oio_ext_monotonic_time();
+		if (last_log <= OLDEST(now, G_TIME_SPAN_MINUTE)) {
+			last_log = now;
+			GRID_WARN("%s pool error: (%d) %s", tag, err->code, err->message);
+		}
+		g_clear_error(&err);
 	}
 }
 

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -87,14 +87,6 @@ static void _cb_stats(struct server_stat_msg_s *msg,
 static void _manage_udp_task(struct network_client_s *clt,
 		struct network_server_s *srv);
 
-static void _pool_push(const char *tag, GThreadPool *pool, gpointer p) {
-	GError *err = NULL;
-	if (!g_thread_pool_push(pool, p, &err)) {
-		GRID_WARN("%s pool error: (%d) %s", tag, err->code, err->message);
-		g_clear_error(&err);
-	}
-}
-
 static void
 _client_sock_name(int fd, gchar *dst, gsize dst_size)
 {
@@ -190,7 +182,7 @@ network_server_stat_push4 (struct network_server_s *srv, gboolean increment,
 	m->which[0] = k1, m->which[1] = k2, m->which[2] = k3, m->which[3] = k4;
 	m->value[0] = v1, m->value[1] = v2, m->value[2] = v3, m->value[3] = v4;
 	m->increment = BOOL(increment);
-	_pool_push("STAT", srv->pool_stats, m);
+	metautils_gthreadpool_push("STAT", srv->pool_stats, m);
 }
 
 GArray*
@@ -546,7 +538,7 @@ _manage_client_event(struct network_server_s *srv,
 
 	if (clt->events & CLT_ERROR)
 		ARM_CLIENT(srv, clt, EPOLL_CTL_DEL);
-	_pool_push("TCP", srv->pool_tcp, clt);
+	metautils_gthreadpool_push("TCP", srv->pool_tcp, clt);
 }
 
 static void
@@ -762,7 +754,7 @@ _manage_udp_event(struct network_server_s *srv, struct endpoint_s *e,
 		if (unprocessed > server_udp_queue_maxlen) {
 			GRID_DEBUG("UDP dropped %s -> %s", clt->peer_name, clt->local_name);
 		} else {
-			_pool_push("UDP", srv->pool_udp, clt);
+			metautils_gthreadpool_push("UDP", srv->pool_udp, clt);
 		}
 	}
 }

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1254,11 +1254,10 @@ election_manager_whatabout (struct election_manager_s *m,
 	} else { \
 		/* Try to defer, if error, then do immediately */ \
 		GError *_e = NULL; \
-		gboolean rc = g_thread_pool_push((M)->completions, (Ctx), &_e); \
-		if (rc) return; \
-		GRID_WARN("Completion queue error: (%d) %s", _e->code, _e->message); \
-		if (_e) g_error_free(_e); \
-		return _completion_router((Ctx), (M)); \
+		if (!g_thread_pool_push((M)->completions, (Ctx), &_e)) { \
+			GRID_WARN("ZK pool error: (%d) %s", _e->code, _e->message); \
+			g_error_free(_e); \
+		} \
 	} \
 } while (0)
 

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1252,12 +1252,7 @@ election_manager_whatabout (struct election_manager_s *m,
 	if ((M)->synchronous_completions) { \
 		return _completion_router((Ctx), (M)); \
 	} else { \
-		/* Try to defer, if error, then do immediately */ \
-		GError *_e = NULL; \
-		if (!g_thread_pool_push((M)->completions, (Ctx), &_e)) { \
-			GRID_WARN("ZK pool error: (%d) %s", _e->code, _e->message); \
-			g_error_free(_e); \
-		} \
+		metautils_gthreadpool_push("ZK", (M)->completions, (Ctx)); \
 	} \
 } while (0)
 


### PR DESCRIPTION
Despite the error returned, the pointer is queued.

Consider reading the implementation [here](https://git.gnome.org/browse/glib/tree/glib/gthreadpool.c#n518) because the documentation is error prone.
