### PR TITLE
Improve the configurability of the cache-related background tasks

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -578,7 +578,22 @@
 			{ "type": "uint", "name": "malloc_trim_size_periodic",
 				"key": "server.malloc_trim_size.periodic",
 				"descr": "Sets how many bytes bytes are released when the LEAN request is received by the current 'meta' service.",
-				"def": 0, "min": 0, "max": "1<<32 - 1" }
+				"def": 0, "min": 0, "max": "1<<32 - 1" },
+
+			{ "type": "uint", "name": "sqlx_periodic_decache_period",
+				"key": "server.periodic_decache.period",
+				"descr": "In ticks / jiffies, with approx. 1 tick per second. 0 means never",
+				"def": 1, "min": 0, "max": "1Mi" },
+
+			{ "type": "uint", "name": "sqlx_periodic_decache_max_bases",
+				"key": "server.periodic_decache.max_bases",
+				"descr": "How many bases may be decached eacch time the background task performs its Dance of Death",
+				"def": 100, "min": 1, "max": "4Mi" },
+
+			{ "type": "monotonic", "name": "sqlx_periodic_decache_max_delay",
+				"key": "server.periodic_decache.max_delay",
+				"descr": "How long may the decache routine take",
+				"def": "500ms", "min": "1ms", "max": "1m" }
 		]
 	},
 	"proxy": {

--- a/conf.json
+++ b/conf.json
@@ -161,6 +161,11 @@
 				"def": "5m", "min": "1s", "max": "1h",
 				"descr": "Tells how long the verbosity remains higher before being reset to the default, after a SIGUSR1 has been received." },
 
+			{ "type": "float", "name": "oio_m1_client_timeout_common",
+				"key": "meta1.outgoing.timeout.common.req",
+				"descr": "Sets the timeout to the set of (quick) RPC that query a meta1 service",
+				"def": 10.0, "min": 0.01, "max": 60.0 },
+
 			{ "type": "float", "name": "oio_m0_client_timeout_common",
 				"key": "meta0.outgoing.timeout.common.req",
 				"descr": "Sets the timeout to the set of (quick) RPC that query a meta0 service",

--- a/core/internals.h
+++ b/core/internals.h
@@ -83,6 +83,12 @@ extern "C" {
 	VTABLE_CHECK(self,T,F); \
 	return VTABLE_CALL_NOCHECK(self,T,F)
 
+#define VARIABLE_PERIOD_DECLARE() \
+	static volatile guint tick = 0;
+
+#define VARIABLE_PERIOD_SKIP(period) \
+	((period <= 0) || (0 != ((tick++) % MAX(1,period))))
+
 #define ADAPTIVE_PERIOD_DECLARE() \
 	static volatile gboolean already_succeeded = FALSE; \
 	static volatile guint tick_reload = 0; \

--- a/meta1v2/meta1_remote.c
+++ b/meta1v2/meta1_remote.c
@@ -18,6 +18,7 @@ License along with this library.
 */
 
 #include <metautils/lib/metautils.h>
+#include <metautils/lib/common_variables.h>
 
 #include "./internals.h"
 #include "./meta1_remote.h"
@@ -28,7 +29,7 @@ static GError *array_request(const char *to, GByteArray *req,
 	EXTRA_ASSERT(req != NULL);
 
 	GByteArray *gba = NULL;
-	GError *err = gridd_client_exec_and_concat(to, 30.0, req, out ? &gba : NULL);
+	GError *err = gridd_client_exec_and_concat(to, oio_m1_client_timeout_common, req, out ? &gba : NULL);
 
 	if (NULL != err) {
 		if (gba)

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1056,9 +1056,12 @@ _task_expire_resolver(gpointer p)
 	if (!grid_main_is_running ())
 		return;
 
-	guint count = hc_resolver_expire(PSRV(p)->resolver);
-	if (count)
-		GRID_DEBUG("Expired %u entries from the resolver cache", count);
+	guint count_expire = hc_resolver_expire(PSRV(p)->resolver);
+	guint count_purge = hc_resolver_purge (PSRV(p)->resolver);
+	if (count_expire || count_purge) {
+		GRID_DEBUG ("Resolver: expired %u, purged %u",
+				count_expire, count_purge);
+	}
 }
 
 static void

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1038,7 +1038,13 @@ _task_expire_bases(gpointer p)
 
 	struct sqlx_cache_s *cache = sqlx_repository_get_cache(PSRV(p)->repository);
 	if (cache != NULL) {
-		guint count = sqlx_cache_expire(cache, 100, 500 * G_TIME_SPAN_MILLISECOND);
+
+		VARIABLE_PERIOD_DECLARE();
+		if (VARIABLE_PERIOD_SKIP(sqlx_periodic_decache_period))
+			return;
+
+		guint count = sqlx_cache_expire(cache,
+				sqlx_periodic_decache_max_bases, sqlx_periodic_decache_max_delay);
 		if (count)
 			GRID_DEBUG("Expired %u bases", count);
 	}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(test_oio_url test_url.c)
 target_link_libraries(test_oio_url ${COMMON})
 add_test(NAME core/url COMMAND test_oio_url)
 
+add_executable(test_variable_period test_variable_period.c)
+target_link_libraries(test_variable_period ${COMMON})
+add_test(NAME core/variable_period COMMAND test_variable_period)
+
 add_executable(test_core_sysstat test_core_sysstat.c)
 target_link_libraries(test_core_sysstat ${COMMON})
 add_test(NAME core/sysstat COMMAND test_core_sysstat)

--- a/tests/unit/test_variable_period.c
+++ b/tests/unit/test_variable_period.c
@@ -1,0 +1,66 @@
+/*
+OpenIO SDS unit tests
+Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <core/oio_core.h>
+#include <core/internals.h>
+
+/* zero means always skip, aka never do */
+static void test_zero(void) {
+	volatile gint period = 0;
+	VARIABLE_PERIOD_DECLARE();
+	for (guint i=0; i<8 ;++i) {
+		g_assert_true(VARIABLE_PERIOD_SKIP(period));
+	}
+	g_assert_cmpuint(tick, ==, 8);
+}
+
+/* negative means zero */
+static void test_negative(void) {
+	volatile gint period = -1;
+	VARIABLE_PERIOD_DECLARE();
+	for (guint i=0; i<8 ;++i) {
+		g_assert_true(VARIABLE_PERIOD_SKIP(period));
+	}
+	g_assert_cmpuint(tick, ==, 8);
+}
+
+static void test_positive(void) {
+	volatile gint period = 3;
+	VARIABLE_PERIOD_DECLARE();
+	for (guint i=0; i<8 ;++i) {
+		g_assert_false(VARIABLE_PERIOD_SKIP(period));
+		g_assert_true(VARIABLE_PERIOD_SKIP(period));
+		g_assert_true(VARIABLE_PERIOD_SKIP(period));
+	}
+	g_assert_cmpuint(tick, ==, 24);
+}
+
+int
+main(int argc, char **argv)
+{
+	HC_TEST_INIT(argc,argv);
+	g_test_add_func("/core/variable_period/zero", test_zero);
+	g_test_add_func("/core/variable_period/positive", test_positive);
+	g_test_add_func("/core/variable_period/negative", test_negative);
+	return g_test_run();
+}
+

--- a/tests/unit/test_variable_period.c
+++ b/tests/unit/test_variable_period.c
@@ -30,7 +30,7 @@ static void test_zero(void) {
 	for (guint i=0; i<8 ;++i) {
 		g_assert_true(VARIABLE_PERIOD_SKIP(period));
 	}
-	g_assert_cmpuint(tick, ==, 8);
+	g_assert_cmpuint(tick, ==, 0);
 }
 
 /* negative means zero */
@@ -40,7 +40,7 @@ static void test_negative(void) {
 	for (guint i=0; i<8 ;++i) {
 		g_assert_true(VARIABLE_PERIOD_SKIP(period));
 	}
-	g_assert_cmpuint(tick, ==, 8);
+	g_assert_cmpuint(tick, ==, 0);
 }
 
 static void test_positive(void) {


### PR DESCRIPTION
Make the meta* services react to the same set of (recently fixed) rules to expires the items in the cache of the resolver. The items 

Also configure the expiration of the bases in the caches of unused bases in sqliterepo.