### PR TITLE
proxy: Make a better use of the route parser

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -680,6 +680,11 @@
 				"descr": "In a proxy, sets the maximum length for the URL it receives. This options protects stack allocation for that URL.",
 				"def": 2048, "min": 32, "max": 65536 },
 
+			{ "type": "float", "name": "proxy_timeout_info",
+				"key": "proxy.outgoing.timeout.info",
+				"descr": "In a proxy, sets the global timeout for 'info' requests issued",
+				"def": 5.0, "min": 0.01, "max": 60.0 },
+
 			{ "type": "float", "name": "proxy_timeout_config",
 				"key": "proxy.outgoing.timeout.config",
 				"descr": "In a proxy, sets the global timeout for 'config' requests issued",

--- a/proxy/actions.h
+++ b/proxy/actions.h
@@ -26,10 +26,18 @@ enum http_rc_e action_cache_status (struct req_args_s *args);
 enum http_rc_e action_get_config (struct req_args_s *args);
 enum http_rc_e action_set_config (struct req_args_s *args);
 
-enum http_rc_e action_forward_get_config (struct req_args_s *args);
 enum http_rc_e action_forward_set_config (struct req_args_s *args);
 enum http_rc_e action_forward_stats (struct req_args_s *args);
-enum http_rc_e action_forward (struct req_args_s *args);
+enum http_rc_e action_forward_get_config (struct req_args_s *args);
+enum http_rc_e action_forward_get_info (struct req_args_s *args);
+enum http_rc_e action_forward_get_ping (struct req_args_s *args);
+enum http_rc_e action_forward_get_handlers (struct req_args_s *args);
+enum http_rc_e action_forward_get_version (struct req_args_s *args);
+enum http_rc_e action_forward_kill (struct req_args_s *args);
+enum http_rc_e action_forward_lean_glib (struct req_args_s *args);
+enum http_rc_e action_forward_lean_sqlx (struct req_args_s *args);
+enum http_rc_e action_forward_flush (struct req_args_s *args);
+enum http_rc_e action_forward_reload (struct req_args_s *args);
 
 enum http_rc_e action_cache_flush_local (struct req_args_s *args);
 enum http_rc_e action_cache_flush_high (struct req_args_s *args);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -861,12 +861,17 @@ configure_request_handlers (void)
 	SET("/config/#POST", action_set_config);
 
 	SET("/forward/config/#POST", action_forward_set_config);
+
 	SET("/forward/config/#GET", action_forward_get_config);
-
+	SET("/forward/version/#GET", action_forward_get_version);
+	SET("/forward/info/#GET", action_forward_get_info);
 	SET("/forward/stats/#GET", action_forward_stats);
-	SET("/forward/stats/#POST", action_forward_stats);
-
-	SET("/forward/$ACTION/#POST", action_forward);
+	SET("/forward/ping/#GET", action_forward_get_ping);
+	SET("/forward/kill/#POST", action_forward_kill);
+	SET("/forward/reload/#POST", action_forward_reload);
+	SET("/forward/flush/#POST", action_forward_flush);
+	SET("/forward/lean-glib/#POST", action_forward_lean_glib);
+	SET("/forward/lean-sqlx/#POST", action_forward_lean_sqlx);
 
 	SET("/cache/status/#GET", action_cache_status);
 	SET("/cache/flush/local/#POST", action_cache_flush_local);

--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -799,25 +799,11 @@ dispatch_LISTHANDLERS(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_LEAN(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	gchar buf[128] = "Freed:";
-	(void) gdata, (void) hdata;
-
-	if (metautils_message_extract_flag (reply->request, "LIBC", FALSE)) {
-		if (malloc_trim (malloc_trim_size_ondemand))
-			g_strlcat (buf, " malloc-heap", sizeof(buf));
-	}
-
-	if (metautils_message_extract_flag (reply->request, "THREADS", FALSE)) {
-		g_thread_pool_stop_unused_threads ();
-		g_strlcat (buf, " idle-threads", sizeof(buf));
-	}
-
-	if (buf[strlen(buf)-1] != ':')
-		g_strlcat (buf, " nothing", sizeof(buf));
-
-	reply->send_reply(CODE_FINAL_OK, buf);
+	malloc_trim (malloc_trim_size_ondemand);
+	g_thread_pool_stop_unused_threads();
+	reply->send_reply(CODE_FINAL_OK, "OK");
 	return TRUE;
 }
 


### PR DESCRIPTION
Explode each of the `/forward/*` routes into separate routes with the proper verb (POST or GET when meaningful)