### PR TITLE
Speed the exit process of the conscience-agent

### DIFF
--- a/oio/common/daemon.py
+++ b/oio/common/daemon.py
@@ -35,16 +35,33 @@ class Daemon(object):
     def run(self, *args, **kwargs):
         raise NotImplementedError('run not implemented')
 
+    def stop(self):
+        pass
+
     def start(self, **kwargs):
         drop_privileges(self.conf.get('user', 'openio'))
         redirect_stdio(self.logger)
 
-        def kill_children(*args):
-            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        def kill_children():
             os.killpg(0, signal.SIGTERM)
+            self.stop()
             sys.exit()
 
-        signal.signal(signal.SIGTERM, kill_children)
+        def _on_SIGTERM(*args):
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            kill_children()
+
+        def _on_SIGQUIT(*args):
+            signal.signal(signal.SIGQUIT, signal.SIG_IGN)
+            kill_children()
+
+        def _on_SIGINT(*args):
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            kill_children()
+
+        signal.signal(signal.SIGINT, _on_SIGINT)
+        signal.signal(signal.SIGQUIT, _on_SIGQUIT)
+        signal.signal(signal.SIGTERM, _on_SIGTERM)
 
         self.run(**kwargs)
 

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -149,9 +149,9 @@ class ConscienceClient(ProxyClient):
             raise OioException("ERROR while getting services types: %s" %
                                resp.text)
 
-    def register(self, pool, service_definition):
+    def register(self, pool, service_definition, **kwargs):
         data = json.dumps(service_definition)
-        resp, body = self._request('POST', '/register', data=data)
+        resp, body = self._request('POST', '/register', data=data, **kwargs)
 
     def info(self):
         resp, body = self._request("GET", '/info')

--- a/oio/conscience/stats/meta.py
+++ b/oio/conscience/stats/meta.py
@@ -29,7 +29,7 @@ class MetaStat(HttpStat):
     def get_stats(self):
         try:
             resp, _body = self.agent.client._request(
-                    'GET', self.uri, params=self.params)
+                    'GET', self.uri, params=self.params, retries=False)
             return self._parse_stats_lines(resp.text)
         except Exception as exc:
             self.logger.debug("get_stats error: %s", exc)


### PR DESCRIPTION
During the CI tests, especially when the load is high on large deployments, the tests sometimes fail because the conscience-agent is too slow to exit. It may even take several minutes to do so. It appears it remains sticked on loop-failing HTTP requests to the oio-proxy (that is down), retried periodically.

In this context, we:
* Allowed the proxy to react the same way to more exit signals
* Broke a main "while True" loop with the help of a flag, unset when an exit signal is received
* Forbid urllib3 to do retries when registering services