### PR TITLE
oio-check-services: Add script to check services

### DIFF
--- a/bin/oio-check-services
+++ b/bin/oio-check-services
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import sys
+import argparse
+from os import getenv
+from oio.check_service.check_rawx import CheckRawx
+from oio.check_service.check_meta2 import CheckMeta2
+
+
+def make_arg_parser():
+    descr = "Make a cycle `PUT/GET/DELETE` on each host for RAWX and META2"
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument('namespace', help="Namespace")
+    return parser
+
+
+if __name__ == '__main__':
+    args = make_arg_parser().parse_args()
+    namespace = args.namespace
+    check_rawx = CheckRawx(namespace)
+    check_rawx.run()
+    check_meta2= CheckMeta2(namespace)
+    check_meta2.run()

--- a/oio/check_service/check_meta2.py
+++ b/oio/check_service/check_meta2.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+from eventlet import sleep
+from oio.check_service.common import CheckService, random_buffer
+from oio.account.client import AccountClient
+from oio.container.client import ContainerClient
+from oio.directory.client import DirectoryClient
+from oio.common.configuration import load_namespace_conf
+
+
+class CheckMeta2(CheckService):
+
+    account_name = "_meta2_probe"
+
+    def __init__(self, namespace, **kwargs):
+        ep_parts = ["http:/",
+                    load_namespace_conf(namespace).get('proxy'),
+                    "v3.0",
+                    namespace,
+                    "content"]
+
+        super(CheckMeta2, self).__init__(namespace, "meta2",
+                                         endpoint="/".join(ep_parts), **kwargs)
+
+        self.account = AccountClient({"namespace": self.ns})
+        self.container = ContainerClient({"namespace": self.ns})
+        self.directory = DirectoryClient({"namespace": self.ns})
+        self.reference = random_buffer('0123456789ABCDEF', 64)
+
+    def _get_params(self):
+        path = random_buffer('0123456789ABCDEF', 64)
+        return {'acct': self.account_name, 'ref': self.reference, 'path': path}
+
+    def _compare_chunks(self, chunks1, chunks2):
+        def light_chunks(chunks):
+            new_chunks = []
+            for chunk in chunks:
+                new_chunk = dict()
+                new_chunk["url"] = chunk["url"]
+                new_chunk["hash"] = chunk["hash"]
+                new_chunks.append(new_chunk)
+            return new_chunks
+        try:
+            chunks1 = light_chunks(chunks1)
+            chunks1.sort()
+            chunks2 = light_chunks(chunks2)
+            chunks2.sort()
+            return cmp(chunks1, chunks2) == 0
+        except TypeError:
+            return False
+
+    def _cycle(self, meta2_host):
+        self.directory.unlink(
+            account=self.account_name, reference=self.reference,
+            service_type=self.service_type)
+        service = {"host": meta2_host, "type": self.service_type, "args": "",
+                   "seq": 1}
+        self.directory.force(
+            account=self.account_name, reference=self.reference,
+            service_type=self.service_type, services=service)
+
+        params = self._get_params()
+        global_success = True
+
+        _, body, success = self._request(
+            "GET", "/locate", params=params, expected_status=404)
+        global_success &= success
+        headers = {'X-oio-action-mode': 'autocreate'}
+        _, body, success = self._request(
+            "POST", "/prepare", params=params, headers=headers,
+            json={"size": "1024"}, expected_status=200)
+        global_success &= success
+        chunks = body
+        _, body, success = self._request(
+            "GET", "/locate", params=params, expected_status=404)
+        global_success &= success
+        headers = {"x-oio-content-meta-length": "1024"}
+        _, _, success = self._request(
+            "POST", "/create", params=params, headers=headers, json=chunks,
+            expected_status=204)
+        global_success &= success
+        _, body, success = self._request(
+            "GET", "/locate", params=params, expected_status=200)
+        global_success &= success
+        success = self._compare_chunks(chunks, body)
+        global_success &= success
+        _, _, success = self._request(
+            "POST", "/delete", params=params, expected_status=204)
+        global_success &= success
+        _, body, success = self._request(
+            "GET", "/locate", params=params, expected_status=404)
+        global_success &= success
+
+        return global_success
+
+    def run(self):
+        try:
+            self.container.container_create(account=self.account_name,
+                                            reference=self.reference)
+            super(CheckMeta2, self).run()
+            self.container.container_delete(account=self.account_name,
+                                            reference=self.reference)
+            sleep(1)
+            self.account.account_delete(self.account_name)
+        except Exception as exc:
+            print("Exception - " + str(exc))

--- a/oio/check_service/check_rawx.py
+++ b/oio/check_service/check_rawx.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import string
+from hashlib import md5
+from oio.check_service.common import CheckService, random_buffer
+from oio.common.constants import OIO_VERSION
+
+
+class CheckRawx(CheckService):
+
+    def __init__(self, namespace, **kwargs):
+        super(CheckRawx, self).__init__(namespace, "rawx", **kwargs)
+
+    def _chunk_id(self):
+        return '0'*16 + random_buffer('0123456789ABCDEF', 48)
+
+    def _chunk_headers(self, chunk_id, data):
+        return {
+            'x-oio-chunk-meta-content-id': '0123456789ABCDEF',
+            'x-oio-chunk-meta-content-version': '1456938361143740',
+            'x-oio-chunk-meta-content-path': 'test',
+            'x-oio-chunk-meta-content-chunk-method':
+                'ec/algo=liberasurecode_rs_vand,k=6,m=3',
+            'x-oio-chunk-meta-content-storage-policy': 'TESTPOLICY',
+            'x-oio-chunk-meta-container-id': '1'*64,
+            'x-oio-chunk-meta-chunk-id': chunk_id,
+            'x-oio-chunk-meta-chunk-size': len(data),
+            'x-oio-chunk-meta-chunk-hash': md5(data).hexdigest().upper(),
+            'x-oio-chunk-meta-chunk-pos': 0,
+            'x-oio-chunk-meta-full-path': ('test/test/test' +
+                                           ',test1/test1/test1'),
+            'x-oio-chunk-meta-oio-version': OIO_VERSION
+        }
+
+    def _chunk_url(self, rawx_host, chunk_id):
+        return '/'.join((rawx_host, chunk_id))
+
+    def _direct_request(self, method, url, body, headers, expected_status=None,
+                        trailers=None, **kwargs):
+        data = None
+        if method == 'PUT':
+            headers['transfer-encoding'] = 'chunked'
+
+            data = ''
+            if body:
+                data += '%x\r\n%s\r\n' % (len(body), body)
+            data += '0\r\n'
+            if trailers:
+                for k, v in trailers.iteritems():
+                    data += '%s: %s\r\n' % (k, v)
+            data += '\r\n'
+        if trailers:
+            headers['Trailer'] = list()
+            for k, v in trailers.iteritems():
+                headers['Trailer'].append(k)
+
+        response = super(CheckRawx, self)._direct_request(
+            method, url, headers=headers, data=data,
+            expected_status=expected_status, **kwargs)
+
+        if method == 'PUT':
+            del headers['transfer-encoding']
+        if trailers:
+            del headers['Trailer']
+
+        return response
+
+    def _compare_data(self, data1, data2):
+        return data1 == data2
+
+    def _cycle(self, rawx_host):
+        length = 1024
+
+        chunk_data = random_buffer(string.printable, length)
+        metachunk_size = 9 * length
+        metachunk_hash = md5().hexdigest()
+
+        trailers = {'x-oio-chunk-meta-metachunk-size': metachunk_size,
+                    'x-oio-chunk-meta-metachunk-hash': metachunk_hash}
+
+        chunk_id = self._chunk_id()
+        chunk_headers = self._chunk_headers(chunk_id, chunk_data)
+        chunk_url = self._chunk_url("http://" + rawx_host, chunk_id)
+        global_success = True
+
+        resp, _, success = self._direct_request(
+            'GET', chunk_url, None, None, expected_status=404)
+        global_success &= success
+        _, _, success = self._direct_request(
+            'DELETE', chunk_url, None, None, expected_status=404)
+        global_success &= success
+        _, _, success = self._direct_request(
+            'PUT', chunk_url, chunk_data, chunk_headers, expected_status=201,
+            trailers=trailers)
+        global_success &= success
+        _, body, success = self._direct_request(
+            'GET', chunk_url, None, None, expected_status=200)
+        global_success &= success
+        success = self._compare_data(body, chunk_data)
+        global_success &= success
+        _, _, success = self._direct_request(
+            'DELETE', chunk_url, None, None, expected_status=204)
+        global_success &= success
+        _, _, success = self._direct_request(
+            'GET', chunk_url, None, None, expected_status=404)
+        global_success &= success
+
+        return global_success

--- a/oio/check_service/common.py
+++ b/oio/check_service/common.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import random
+from urllib3.response import HTTPResponse
+from oio.conscience.client import ConscienceClient
+from oio.common.exceptions import ClientException
+from oio.api.base import HttpApi
+
+
+def random_buffer(dictionary, n):
+    slot = 512
+    pattern = ''.join(random.choice(dictionary) for _ in range(slot))
+    t = []
+    while len(t) * slot < n:
+        t.append(pattern)
+    return ''.join(t)[:n]
+
+
+class CheckService(HttpApi):
+    """
+    Make a cycle `PUT/GET/DELETE` on each host for the service type
+    """
+
+    def __init__(self, namespace, service_type, **kwargs):
+        """
+        Collect the list of hosts for a service type
+        """
+        super(CheckService, self).__init__(**kwargs)
+        self.ns = namespace
+        self.service_type = service_type
+        self.all_services = ConscienceClient(
+            {"namespace": self.ns}).all_services(self.service_type)
+        self.all_services_host = []
+        for service in self.all_services:
+            self.all_services_host.append(service["addr"])
+
+    def _compare_status(self, expected_status, actual_status):
+        if expected_status is None:
+            return None
+        return expected_status == actual_status
+
+    def _direct_request(self, method, url, expected_status=None, **kwargs):
+        try:
+            resp, body = super(CheckService, self)._direct_request(
+                method, url, **kwargs)
+        except ClientException as exc:
+            body = exc.message
+            resp = HTTPResponse(status=exc.http_status)
+
+        success = self._compare_status(expected_status, resp.status)
+
+        return resp, body, success
+
+    def _cycle(self, host):
+        """
+        Must make a cycle `PUT/GET/DELETE` on the host
+        """
+        raise NotImplementedError('_cycle not implemented')
+
+    def run(self):
+        """
+        Make the cycle on each hosts
+        """
+        for service_host in self.all_services_host:
+            print(self.service_type.upper() + " " + service_host),
+            try:
+                success = self._cycle(service_host)
+                if success:
+                    print("OK")
+                else:
+                    print("FAIL")
+            except Exception:
+                print("FAIL")

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ scripts =
     bin/oio-blob-mover
     bin/oio-blob-indexer
     bin/oio-blob-rebuilder
+    bin/oio-check-services
     bin/oio-conscience-agent
     bin/oio-crawler-storage-tierer
     bin/oio-crawler-integrity


### PR DESCRIPTION
Add script to make a `GET/PUT/DELETE` on each service (`rawx` and `meta2`)

```shell
$ oio-check-services OPENIO
RAWX 127.0.0.1:6024 OK
RAWX 127.0.0.1:6023 OK
RAWX 127.0.0.1:6022 OK
META2 127.0.0.1:6015 OK
META2 127.0.0.1:6018 OK
META2 127.0.0.1:6016 OK
META2 127.0.0.1:6017 OK
```

```shell
$ gridinit_cmd -S ~/.oio/sds/run/gridinit.sock -c stop OPENIO-rawx-1
DONE OPENIO-rawx-1        Success
$ oio-check-services OPENIO
RAWX 127.0.0.1:6024 OK
RAWX 127.0.0.1:6023 OK
RAWX 127.0.0.1:6022 FAIL
META2 127.0.0.1:6015 FAIL
META2 127.0.0.1:6018 FAIL
META2 127.0.0.1:6016 FAIL
META2 127.0.0.1:6017 FAIL
```

```shell
$ gridinit_cmd -S ~/.oio/sds/run/gridinit.sock -c stop OPENIO-meta2-1
DONE OPENIO-meta2-1        Success
$ oio-check-services OPENIO
RAWX 127.0.0.1:6024 OK
RAWX 127.0.0.1:6022 OK
RAWX 127.0.0.1:6023 OK
META2 127.0.0.1:6015 FAIL
META2 127.0.0.1:6018 OK
META2 127.0.0.1:6016 OK
META2 127.0.0.1:6017 OK
```

