### PR TITLE
Allow a proxy >4.1.4 to chat with a conscience <4.0.0

### DIFF
--- a/metautils/lib/comm_converter.c
+++ b/metautils/lib/comm_converter.c
@@ -20,6 +20,8 @@ License along with this library.
 #include "metautils.h"
 #include "codec.h"
 
+#include <metautils/lib/common_variables.h>
+
 /* -------------------------------------------------------------------------- */
 
 typedef gboolean(*abstract_converter_f) (const void *in, void *out);
@@ -702,6 +704,10 @@ namespace_info_cleanASN(NamespaceInfo_t * asn, gboolean only_content)
 {
 	if (!asn)
 		return;
+
+	if (asn->options)
+		asn->options->list.free = free_Parameter;
+
 	asn->storagePolicy.list.free = free_Parameter;
 	asn->dataSecurity.list.free = free_Parameter;
 	if (only_content)

--- a/metautils/lib/description.asn
+++ b/metautils/lib/description.asn
@@ -30,6 +30,10 @@ BEGIN
 
 	NamespaceInfo ::= SEQUENCE {
 		name           [0] PrintableString,
+
+		chunkSize      [2] INTEGER OPTIONAL,
+		options        [3] ParameterSequence OPTIONAL,
+
 		storagePolicy  [4] ParameterSequence,
 		dataSecurity   [5] ParameterSequence,
 		servicePools   [8] ParameterSequence

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,10 @@ add_executable(test_cache_lru test_cache_lru.c)
 target_link_libraries(test_cache_lru oiocache)
 add_test(NAME cache/lru COMMAND test_cache_lru)
 
+add_executable(test_nsinfo test_nsinfo.c)
+target_link_libraries(test_nsinfo metautils ${COMMON})
+add_test(NAME metautils/nsinfo COMMAND test_nsinfo)
+
 add_executable(test_stg_policy test_stg_policy.c)
 target_link_libraries(test_stg_policy ${COMMON})
 add_test(NAME metautils/stgpol COMMAND test_stg_policy)

--- a/tests/unit/test_nsinfo.c
+++ b/tests/unit/test_nsinfo.c
@@ -1,0 +1,62 @@
+/*
+OpenIO SDS unit tests
+Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+#include <metautils/lib/metautils.h>
+#include <metautils/lib/common_variables.h>
+
+static void
+test_decode(namespace_info_t *ns0)
+{
+	for (int i=0; i<32 ;++i) {
+		GError *err = NULL;
+		GByteArray *encoded = namespace_info_marshall(ns0, &err);
+		g_assert_no_error(err);
+		g_assert_nonnull(encoded);
+
+		namespace_info_t *ns1 = namespace_info_unmarshall(
+				encoded->data, encoded->len, &err);
+		g_assert_no_error(err);
+		g_assert_nonnull(ns1);
+
+		g_assert_cmpstr(ns0->name, ==, ns1->name);
+
+		namespace_info_free(ns1);
+
+		g_byte_array_free(encoded, TRUE);
+	}
+}
+
+static void
+test_codec(void)
+{
+	for (int i=0; i<32 ;++i) {
+		namespace_info_t *ns0 = g_malloc0(sizeof(*ns0));
+		namespace_info_init(ns0);
+		g_strlcpy(ns0->name, "XxXxXx", sizeof(ns0->name));
+		test_decode(ns0);
+		namespace_info_free(ns0);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	HC_TEST_INIT(argc,argv);
+	g_test_add_func("/metautils/nsinfo/codec", test_codec);
+	return g_test_run();
+}


### PR DESCRIPTION
Partial fix for #1218.

Upgrade path from 3.x to 4.x:
1. migrate the services and the proxy
2. goto 3.
3. migrate the conscience