### PR TITLE
CLI: fix object create error handling

### DIFF
--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -132,6 +132,7 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
         properties = parsed_args.property
         results = []
         for obj in objs:
+            name = obj
             try:
                 with io.open(obj, 'rb') as f:
                     name = names.pop(0) if names else os.path.basename(f.name)


### PR DESCRIPTION
(cherry picked from commit 60ada2a07a5300f20c00e97f45471cd577acd3b0)