### PR TITLE
Manage long contents paths

### DIFF
--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -604,4 +604,5 @@ class TestObjectStorageAPI(BaseTestCase):
         """Create an objet whose name has the maximum length allowed"""
         cname = random_str(16)
         path = random_str(1023)
-        self.api.object_create(self.account, cname, data="1"*128, obj_name=path)
+        self.api.object_create(self.account, cname,
+                               data="1"*128, obj_name=path)

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -599,3 +599,9 @@ class TestObjectStorageAPI(BaseTestCase):
         self.assertRaises(
             exc.OioException, self.api.object_truncate, self.account, name,
             name, size=129)
+
+    def test_object_create_long_name(self):
+        """Create an objet whose name has the maximum length allowed"""
+        cname = random_str(16)
+        path = random_str(1023)
+        self.api.object_create(self.account, cname, data="1"*128, obj_name=path)


### PR DESCRIPTION
* Fixes #1261 with a new norm for the xattr list of links.
* Ensure the backward compatibility with the 4.1.x branch: allow to read old-style links but only write new links.