### PR TITLE
Alter the meaning of TTL=0 on cached DB

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -446,13 +446,13 @@
 
 			{ "type": "monotonic", "name": "_cache_grace_delay_cool",
 				"key": "sqliterepo.cache.ttl.cool",
-				"descr": "Sets the period after the return to the IDLE/COLD state, during which the recycling is forbidden",
-				"def": "0", "min": "0", "max": "1h" },
+				"descr": "Sets the period after the return to the IDLE/COLD state, during which the recycling is forbidden. 0 means the base won't be decached.",
+				"def": "1ms", "min": "0", "max": "1d" },
 
 			{ "type": "monotonic", "name": "_cache_grace_delay_hot",
 				"key": "sqliterepo.cache.ttl.hot",
-				"descr": "Sets the period after the return to the IDLE/HOT state, during which the recycling is forbidden",
-				"def": "0", "min": "0", "max": "1h" },
+				"descr": "Sets the period after the return to the IDLE/HOT state, during which the recycling is forbidden. 0 means the base won't be decached.",
+				"def": "1ms", "min": "0", "max": "1d" },
 
 			{ "type": "uint", "name": "sqliterepo_release_size",
 				"key": "sqliterepo.release_size",

--- a/sqliterepo/cache.c
+++ b/sqliterepo/cache.c
@@ -411,12 +411,12 @@ _expire_base(sqlx_cache_t *cache, sqlx_base_t *b)
 }
 
 static gint
-_expire_specific_base(sqlx_cache_t *cache, sqlx_base_t *b, gint64 now,
-		gint64 grace_delay)
+_expire_specific_base(sqlx_cache_t *cache, sqlx_base_t *b,
+		const gint64 now, const gint64 grace_delay)
 {
-	if (now) {
-		now = (now > grace_delay) ? (now - grace_delay) : 0;
-		if (b->last_update > now)
+	/* TODO(jfs): this is way to complicated. ASAP change the logic */
+	if (now > 0) {
+	   if (grace_delay <= 0 || b->last_update > OLDEST(now, grace_delay))
 			return 0;
 	}
 


### PR DESCRIPTION
A TTL set to 0 (via `sqliterepo.cache.ttl.hot` or `sqliterepo.cache.ttl.cold`) now means the base won't expire.

We lose no functionnality:
* The default value is now non-zero but so small that the periodic bg task that expires the bases will nearly always expire any base it meets.
* It is still possible to turn the bg-task completely down via `server.periodic_decache.period = 0`