### PR TITLE
Fix faulty service avoidance, improve error messages

### DIFF
--- a/metautils/lib/gridd_client_ext.c
+++ b/metautils/lib/gridd_client_ext.c
@@ -325,12 +325,15 @@ gridd_client_run (struct gridd_client_s *self)
 {
 	if (!self)
 		return NEWERROR(CODE_INTERNAL_ERROR, "creation error");
-	if (!gridd_client_start(self))
-		return NEWERROR(CODE_INTERNAL_ERROR, "starting error");
 	GError *err;
-	if (NULL != (err = gridd_client_loop (self)))
+	if (!gridd_client_start(self)) {
+		if ((err = gridd_client_error(self)))
+			return err;
+		return NEWERROR(CODE_INTERNAL_ERROR, "starting error");
+	}
+	if ((err = gridd_client_loop(self)))
 		return err;
-	if (NULL != (err = gridd_client_error (self)))
+	if ((err = gridd_client_error(self)))
 		return err;
 	return NULL;
 }

--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -745,11 +745,11 @@ class EcMetachunkWriter(io.MetachunkWriter):
 
                 return bytes_transferred
 
-        except green.SourceReadTimeout:
-            logger.warn('Source read timeout')
+        except green.SourceReadTimeout as exc:
+            logger.warn('Source read timeout: %s', exc)
             raise
-        except SourceReadError:
-            logger.warn('Source read error')
+        except SourceReadError as exc:
+            logger.warn('Source read error: %s', exc)
             raise
         except Timeout as to:
             logger.exception('Timeout writing data')


### PR DESCRIPTION
Some `CODE_AVOIDED` errors were not properly transmitted in meta1 client, preventing it from looping over replicas.