### PR TITLE
Disable the avoidance of faulty peers for the forwarded RPC from the proxy

### DIFF
--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -873,11 +873,13 @@ _client_start(struct gridd_client_s *client)
 
 	client->tv_start = client->tv_connect = oio_ext_monotonic_time ();
 
-	if (client->step != NONE)
+	if (client->step != NONE) {
+		_client_replace_error(client, SYSERR("bug: invalid client state"));
 		return FALSE;
+	}
 
 	if (!client->url[0]) {
-		_client_replace_error(client, NEWERROR(EINVAL, "No target"));
+		_client_replace_error(client, SYSERR("bug: no client target"));
 		return FALSE;
 	}
 

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -64,9 +64,6 @@ struct gridd_client_vtable_s
 	// Force a new descriptor
 	GError* (*set_fd) (struct gridd_client_s *c, int fd);
 
-	// Tells to keep the connection open between requests.
-	void (*set_keepalive) (struct gridd_client_s *c, gboolean on);
-
 	// Force global timeout for the operation (all the request, including
 	// the redirections)
 	void (*set_timeout) (struct gridd_client_s *c, gdouble seconds);
@@ -110,7 +107,6 @@ int gridd_client_interest (struct gridd_client_s *self);
 const gchar * gridd_client_url (struct gridd_client_s *self);
 int gridd_client_fd (struct gridd_client_s *self);
 GError * gridd_client_set_fd(struct gridd_client_s *self, int fd);
-void gridd_client_set_keepalive(struct gridd_client_s *self, gboolean on);
 void gridd_client_set_timeout (struct gridd_client_s *self, gdouble seconds);
 void gridd_client_set_timeout_cnx (struct gridd_client_s *self, gdouble sec);
 gboolean gridd_client_expired(struct gridd_client_s *self, gint64 now);
@@ -127,6 +123,12 @@ struct gridd_client_s * gridd_client_create_empty(void);
 
 /* Only works with clients of the default type */
 void gridd_client_no_redirect (struct gridd_client_s *c);
+
+/* Only works with clients of the default type */
+void gridd_client_set_avoidance (struct gridd_client_s *c, gboolean on);
+
+/* Only works with clients of the default type */
+void gridd_client_set_keepalive(struct gridd_client_s *self, gboolean on);
 
 /* ------------------------------------------------------------------------- */
 

--- a/metautils/lib/gridd_client_ext.c
+++ b/metautils/lib/gridd_client_ext.c
@@ -324,12 +324,13 @@ GError *
 gridd_client_run (struct gridd_client_s *self)
 {
 	if (!self)
-		return NEWERROR(CODE_INTERNAL_ERROR, "creation error");
+		return SYSERR("creation error");
 	GError *err;
 	if (!gridd_client_start(self)) {
 		if ((err = gridd_client_error(self)))
 			return err;
-		return NEWERROR(CODE_INTERNAL_ERROR, "starting error");
+		/* TODO good place for a g_assert_not_reached(); */
+		return SYSERR("client startup: unknown error");
 	}
 	if ((err = gridd_client_loop(self)))
 		return err;

--- a/metautils/lib/gridd_client_ext.c
+++ b/metautils/lib/gridd_client_ext.c
@@ -442,24 +442,6 @@ gridd_client_exec_and_concat (const gchar *to, gdouble seconds, GByteArray *req,
 }
 
 GError *
-gridd_client_exec_and_concat_string (const gchar *to, gdouble seconds, GByteArray *req,
-		gchar **out)
-{
-	GByteArray *tmp = NULL;
-	GError *err = gridd_client_exec_and_concat (to, seconds, req, out ? &tmp : NULL);
-
-	if (err) {
-		if (tmp) g_byte_array_unref (tmp);
-		return err;
-	}
-	if (out) {
-		g_byte_array_append (tmp, (guint8*)"", 1);
-		*out = (gchar*) g_byte_array_free (tmp, FALSE);
-	}
-	return NULL;
-}
-
-GError *
 gridd_client_exec_and_decode (const gchar *to, gdouble seconds,
 		GByteArray *req, GSList **out, body_decoder_f decode)
 {

--- a/metautils/lib/gridd_client_ext.h
+++ b/metautils/lib/gridd_client_ext.h
@@ -58,10 +58,6 @@ GError * gridd_client_exec_and_decode (const char *to, gdouble timeout,
 GError * gridd_client_exec_and_concat (const char *to, gdouble timeout,
 		GByteArray *req, GByteArray **out);
 
-/* wraps gridd_client_exec_and_concat() */
-GError * gridd_client_exec_and_concat_string (const char *to, gdouble timeout, GByteArray *req,
-		gchar **out);
-
 /* Implementation specifics / array of structures -------------------------- */
 
 // @return NULL if one of the subsequent client creation fails

--- a/proxy/cache_actions.c
+++ b/proxy/cache_actions.c
@@ -66,7 +66,7 @@ action_forward (struct req_args_s *args)
 	if (!g_ascii_strcasecmp (action, "flush")) {
 		GByteArray *encoded = message_marshall_gba_and_clean (
 				metautils_message_create_named (NAME_MSGNAME_SQLX_FLUSH));
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -74,7 +74,7 @@ action_forward (struct req_args_s *args)
 	if (!g_ascii_strcasecmp (action, "reload")) {
 		GByteArray *encoded = message_marshall_gba_and_clean (
 				metautils_message_create_named (NAME_MSGNAME_SQLX_RELOAD));
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -82,7 +82,7 @@ action_forward (struct req_args_s *args)
 	if (!g_ascii_strcasecmp (action, "kill")) {
 		GByteArray *encoded = message_marshall_gba_and_clean (
 				metautils_message_create_named("REQ_KILL"));
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -91,7 +91,7 @@ action_forward (struct req_args_s *args)
 		args->rp->no_access();
 		GByteArray *encoded = message_marshall_gba_and_clean (
 				metautils_message_create_named("REQ_PING"));
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -101,7 +101,7 @@ action_forward (struct req_args_s *args)
 		metautils_message_add_field_str(req, "LIBC", "1");
 		metautils_message_add_field_str(req, "THREADS", "1");
 		GByteArray *encoded = message_marshall_gba_and_clean (req);
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -110,7 +110,7 @@ action_forward (struct req_args_s *args)
 	if (!g_ascii_strcasecmp (action, "lean-sqlx")) {
 		GByteArray *encoded = message_marshall_gba_and_clean (
 				metautils_message_create_named(NAME_MSGNAME_SQLX_LEANIFY));
-		err = gridd_client_exec (id, proxy_timeout_common, encoded);
+		err = CLIENT_EXEC (id, proxy_timeout_common, encoded);
 		if (err)
 			return _reply_common_error (args, err);
 		return _reply_success_json (args, NULL);
@@ -305,7 +305,7 @@ action_forward_set_config (struct req_args_s *args)
 	MESSAGE req = metautils_message_create_named("REQ_SETCFG");
 	metautils_message_set_BODY(req, args->rq->body->data, args->rq->body->len);
 	GByteArray *encoded = message_marshall_gba_and_clean (req);
-	GError *err = gridd_client_exec(id, proxy_timeout_config, encoded);
+	GError *err = CLIENT_EXEC(id, proxy_timeout_config, encoded);
 	if (err) {
 		if (CODE_IS_NETWORK_ERROR(err->code)) {
 			if (err->code == ERRCODE_CONN_TIMEOUT || err->code == ERRCODE_READ_TIMEOUT)

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -559,3 +559,22 @@ GError * KV_read_usersys_properties (struct json_object *j, gchar ***out) {
 	*out = kv;
 	return NULL;
 }
+
+GError *
+gridd_client_exec_and_concat_string (const gchar *to, gdouble seconds,
+		GByteArray *req, gchar **out)
+{
+	GByteArray *tmp = NULL;
+	GError *err = gridd_client_exec_and_concat (to, seconds, req, out ? &tmp : NULL);
+
+	if (err) {
+		if (tmp) g_byte_array_unref (tmp);
+		return err;
+	}
+	if (out) {
+		g_byte_array_append (tmp, (guint8*)"", 1);
+		*out = (gchar*) g_byte_array_free (tmp, FALSE);
+	}
+	return NULL;
+}
+

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -575,7 +575,7 @@ gridd_client_exec_and_concat_string (const gchar *to, gdouble seconds,
 		GByteArray *req, gchar **out)
 {
 	EXTRA_ASSERT(to != NULL);
-	EXTRA_ASSERT(out != NULL);
+	EXTRA_ASSERT(out == NULL || *out == NULL);
 
 	GError *err = NULL;
 	GByteArray *tmp = g_byte_array_sized_new(512);
@@ -590,16 +590,16 @@ gridd_client_exec_and_concat_string (const gchar *to, gdouble seconds,
 	} else {
 		if (seconds > 0.0)
 			gridd_client_set_timeout (client, seconds);
+		gridd_client_set_avoidance(client, FALSE);
 		err = gridd_client_run (client);
 		gridd_client_free (client);
 	}
 
-	if (!err) {
+	if (!err && out) {
 		g_byte_array_append (tmp, (guint8*)"", 1);
 		*out = (gchar*) g_byte_array_free (tmp, FALSE);
 		tmp = NULL;
 	}
-
 	if (tmp)
 		g_byte_array_free (tmp, TRUE);
 

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -322,4 +322,10 @@ extern gint32 oio_proxy_request_failure_threshold_last;
 extern gint32 oio_proxy_request_failure_threshold_middle;
 #endif
 
+/* ------------------------------------------------------------------------- */
+
+/* wraps gridd_client_exec_and_concat() */
+GError * gridd_client_exec_and_concat_string (const char *to, gdouble timeout,
+		GByteArray *req, gchar **out);
+
 #endif /*OIO_SDS__proxy__common_h*/

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -324,7 +324,12 @@ extern gint32 oio_proxy_request_failure_threshold_middle;
 
 /* ------------------------------------------------------------------------- */
 
-/* wraps gridd_client_exec_and_concat() */
+/* Execute the request without avoidance, and discard the output */
+#define CLIENT_EXEC(Url,Timeout,Req) \
+	gridd_client_exec_and_concat_string(Url,Timeout,Req,NULL)
+
+/* wraps gridd_client_exec_and_concat() but disable the avoidance of peers
+ * seen faulty or down. */
 GError * gridd_client_exec_and_concat_string (const char *to, gdouble timeout,
 		GByteArray *req, gchar **out);
 


### PR DESCRIPTION
Also:
* Slight simplification of gridd_client
* Slight code reorg between metautils and proxy (gridd_client_exec_and_concat_string() was only used in the proxy)