### PR TITLE
Fix the parsing of boolean service tags

### DIFF
--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -71,14 +71,26 @@ service_tag_get_value_boolean(struct service_tag_s *tag, gboolean *b, GError **e
 		return FALSE;
 	}
 
-	if (tag->type != STVT_BOOL) {
-		GSETERROR(error, "Tag is not of type BOOL");
-		return FALSE;
+	switch (tag->type) {
+		case STVT_I64:
+			*b = BOOL(tag->value.i);
+			return TRUE;
+		case STVT_REAL:
+			*b = (tag->value.r != 0.0);
+			return TRUE;
+		case STVT_BOOL:
+			*b = BOOL(tag->value.b);
+			return TRUE;
+		case STVT_STR:
+			*b = oio_str_parse_bool(tag->value.s, *b);
+			return TRUE;
+		case STVT_BUF:
+			*b = oio_str_parse_bool(tag->value.buf, *b);
+			return TRUE;
+		default:
+			GSETERROR(error, "Unmanaged tag type [%d]", tag->type);
+			return FALSE;
 	}
-
-	memcpy(b, &(tag->value.b), sizeof(gboolean));
-
-	return TRUE;
 }
 
 void

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1165,6 +1165,7 @@ _filter_down_hosts(GSList *l)
 		if (_srv_is_down(l->data))
 			g_ptr_array_add(tmp, _srv_url(l->data));
 	}
+	g_ptr_array_add(tmp, NULL);
 	return (gchar**) g_ptr_array_free(tmp, FALSE);
 }
 


### PR DESCRIPTION
The PR allows the `tag.up` to be well considered by the sqlx/meta* services, to decide which service is down or not.

In addition, fix a possible segfault happening when reloading the list of down peers, that was introduced at commit 5c4ecc2d58baf58e095b3e4d41b05c7e30cbef21. The error diddn't show up because the list was always empty due to a bad parsing of the `tag.up` flag in each service description.