### PR TITLE
Temporarily disable new plyvel versions which don't build

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -2,7 +2,7 @@ cliff>=2.0.0,<2.1.0
 eventlet!=0.18.3,!=0.20.1,<0.21.0,>=0.18.2
 gunicorn>=19.4.5
 lxml
-plyvel>=0.9
+plyvel>=0.9,<1.0.0
 PyECLib>=1.2.0
 pyxattr>=0.4
 PyYAML>=3.10


### PR DESCRIPTION
The (fairly new, from 2 days ago) plyvel 1.0.0 broke it, so stick with
the working one until further investigated & fixed...

Error was:
plyvel/_plyvel.cpp: In function 'int __pyx_f_6plyvel_7_plyvel_parse_options(leveldb::Options*, bool, bool, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, int, PyObject*, PyObject*)':
plyvel/_plyvel.cpp:3341:22: error: 'struct leveldb::Options' has no member named 'max_file_size'
__pyx_v_options->max_file_size = __pyx_t_4;

plyvel 1.0.0 requires leveldb 1.20, and our Travis build installs
libleveldb1 1.15.0 (and there is no superior version in this
distribution), thus we are stuck with plyvel<1.0.0.

We should use plyvel>=0.9,<1.0.0 in case someone creates updates over
the 0.9 version.