### PR TITLE
[WIP] Use UUID instead of IP:PORT

### DIFF
--- a/cluster/module/server.c
+++ b/cluster/module/server.c
@@ -82,6 +82,10 @@ static GSList *config_paths = NULL;
 #  define LIMIT_LENGTH_SRVDESCR (LIMIT_LENGTH_SRVTYPE + 1 + STRLEN_ADDRINFO)
 # endif
 
+# ifndef LIMIT_LENGTH_UUID
+#  define LIMIT_LENGTH_UUID (36 + 1)
+# endif
+
 struct conscience_srv_s {
 	addr_info_t addr;
 
@@ -98,6 +102,7 @@ struct conscience_srv_s {
 	struct conscience_srv_s *prev;
 
 	gchar description[LIMIT_LENGTH_SRVDESCR];
+    gchar uuid[LIMIT_LENGTH_UUID];
 };
 
 struct conscience_srvtype_s
@@ -504,14 +509,32 @@ conscience_srvtype_refresh(struct conscience_srvtype_s *srvtype, struct service_
 	gboolean really_first = FALSE;
 
 	/* register the service if necessary, excepted if unlocking */
+    /* TODO: it should use uuid instead of addr */
 	struct conscience_srv_s *p_srv = g_hash_table_lookup(srvtype->services_ht, &si->addr);
 	if (!p_srv) {
 		if (si->score.value == SCORE_UNLOCK) {
 			return NULL;
 		} else {
+            /* TODO: it should use uuid instead of addr */
 			p_srv = conscience_srvtype_register_srv(srvtype, &si->addr);
 			g_assert_nonnull (p_srv);
 			really_first = tag_first && tag_first->type == STVT_BOOL && tag_first->value.b;
+
+            /* XXX temporary stuff to retrieve UUID if present */
+	        if (si->tags) {
+                const guint max = si->tags->len;
+                for (guint i = 0; i < max; i++) {
+                    struct service_tag_s *tag = g_ptr_array_index(si->tags, i);
+                    if (tag == tag_first) continue;
+
+                    if (g_strcmp0(tag->name, "tag.uuid")) {
+                        continue;
+                    }
+
+                    service_tag_to_string(tag, p_srv->uuid, LIMIT_LENGTH_UUID);
+                    GRID_ERROR("associate %s to %s", p_srv->description, p_srv->uuid);
+                }
+	        }
 		}
 	}
 

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -81,6 +81,7 @@ class Account(WerkzeugApp):
     # }}ACCT
     def on_status(self, req):
         status = self.backend.status()
+        status['uuid'] = self.conf.get('uuid')
         return Response(json.dumps(status), mimetype='text/json')
 
     def on_account_create(self, req):

--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -76,27 +76,29 @@ class ClusterList(lister.Lister):
                 location = tags.get('tag.loc', 'n/a')
                 slots = tags.get('tag.slots', 'n/a')
                 volume = tags.get('tag.vol', 'n/a')
+                # FIXME: should be mandatory ?
+                uuid = tags.get('tag.uuid', 'n/a')
                 addr = srv['addr']
                 up = tags.get('tag.up', 'n/a')
                 score = srv['score']
                 if parsed_args.stats:
                     stats = ["%s=%s" % (k, v) for k, v in tags.items()
                              if k.startswith('stat.')]
-                    values = (srv_type, addr, volume, location,
+                    values = (srv_type, addr, uuid, volume, location,
                               slots, up, score, " ".join(stats))
                 else:
-                    values = (srv_type, addr, volume, location,
+                    values = (srv_type, addr, uuid, volume, location,
                               slots, up, score)
                 yield values
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
         if parsed_args.stats:
-            columns = ('Type', 'Id', 'Volume', 'Location', 'Slots', 'Up',
-                       'Score', 'Stats')
+            columns = ('Type', 'Id', 'Uuid', 'Volume', 'Location', 'Slots',
+                       'Up', 'Score', 'Stats')
         else:
-            columns = ('Type', 'Id', 'Volume', 'Location', 'Slots', 'Up',
-                       'Score')
+            columns = ('Type', 'Id', 'Uuid', 'Volume', 'Location', 'Slots',
+                       'Up', 'Score')
         return columns, self._list_services(parsed_args)
 
 

--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -79,6 +79,9 @@ class ServiceWatcher(object):
         if self.service.get('slots', None):
             self.service_definition['tags']['tag.slots'] = \
                     ','.join(self.service['slots'])
+        if self.service.get('uuid', None):
+            self.service_definition['tags']['tag.uuid'] = \
+                self.service['uuid']
         self.service_checks = list()
         self.service_stats = list()
         self.init_checkers(service)

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -58,7 +58,11 @@ class HttpStat(BaseStat):
     def _parse_stats_json(body):
         """Prefix each entry with 'stat.'"""
         body = json.loads(body)
-        return {'stat.' + k: body[k] for k in body.keys()}
+        uuid = body.pop('uuid', None)
+        res = {'stat.' + k: body[k] for k in body.keys()}
+        if uuid:
+            res['tag.uuid'] = uuid
+        return res
 
     def get_stats(self):
         result = {}

--- a/oio/conscience/stats/rawx.py
+++ b/oio/conscience/stats/rawx.py
@@ -24,6 +24,7 @@ class RawxStat(HttpStat):
     rawx_stat_keys = [
             ("counter", "req.hits", "stat.total_reqpersec"),
             ("counter", "req.time", "stat.total_avreqtime"),
+            ("config",  "uuid",     "tag.uuid"),
     ]
 
     def configure(self):

--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -101,6 +101,16 @@ dav_rawx_merge_server_config(apr_pool_t *p, void *base UNUSED, void *overrides)
 }
 
 static const char *
+dav_rawx_cmd_gridconfig_uuid(cmd_parms *cmd, void *config UNUSED, const char *arg1)
+{
+	dav_rawx_server_conf *conf =
+		ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
+
+	g_strlcpy(conf->uuid, arg1, sizeof(conf->uuid));
+	return NULL;
+}
+
+static const char *
 dav_rawx_cmd_gridconfig_hash_width(cmd_parms *cmd, void *config UNUSED, const char *arg1)
 {
 	dav_rawx_server_conf *conf =
@@ -434,6 +444,7 @@ label_error:
 
 static const command_rec dav_rawx_cmds[] =
 {
+    AP_INIT_TAKE1("grid_uuid",        dav_rawx_cmd_gridconfig_uuid,        NULL, RSRC_CONF, "UUID of service"),
     AP_INIT_TAKE1("grid_hash_width",  dav_rawx_cmd_gridconfig_hash_width,  NULL, RSRC_CONF, "hash width on a chunk's name"),
     AP_INIT_TAKE1("grid_hash_depth",  dav_rawx_cmd_gridconfig_hash_depth,  NULL, RSRC_CONF, "hash depth on a chunk's name"),
     AP_INIT_TAKE1("grid_docroot",     dav_rawx_cmd_gridconfig_docroot,     NULL, RSRC_CONF, "chunks docroot"),

--- a/rawx-apache2/src/rawx_config.h
+++ b/rawx-apache2/src/rawx_config.h
@@ -108,6 +108,7 @@ typedef struct dav_rawx_server_conf_s dav_rawx_server_conf;
 
 struct dav_rawx_server_conf_s {
 	char rawx_id[64]; /* enough for @ipv6:port */
+	char uuid[37]; /* 36 + 1 */
 	apr_pool_t *pool;
 	char docroot[1024];
 	char ns_name[LIMIT_LENGTH_NSNAME];

--- a/rawx-apache2/src/rawx_req_info.c
+++ b/rawx-apache2/src/rawx_req_info.c
@@ -106,7 +106,7 @@ static const char *
 __gen_info(const dav_resource *resource, apr_pool_t *pool)
 {
 	dav_rawx_server_conf *conf = resource->info->conf;
-	return apr_pstrcat(pool, "namespace ", conf->ns_name, "\npath ", conf->docroot, "\n", NULL);
+	return apr_pstrcat(pool, "namespace ", conf->ns_name, "\npath ", conf->docroot, "\nuuid ", conf->uuid, "\n", NULL);
 }
 
 /*
@@ -191,7 +191,8 @@ __gen_stats(const dav_resource *resource, apr_pool_t *pool)
 			STR_KV(rep_bread,     "counter rep.bread"),
 			STR_KV(rep_bwritten,  "counter rep.bwritten"),
 
-			apr_psprintf(pool, "config volume %s", c->docroot),
+			apr_psprintf(pool, "config volume %s\n", c->docroot),
+			apr_psprintf(pool, "config uuid %s", c->uuid),
 			NULL);
 }
 

--- a/rdir/rdir.c
+++ b/rdir/rdir.c
@@ -36,6 +36,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 static gchar *ns_name = NULL;
 static gchar *basedir = NULL;
+static gchar *uuid = NULL;
 static gboolean config_system = TRUE;
 static GSList *config_paths = NULL;
 static GSList *config_urlv = NULL;
@@ -1255,6 +1256,8 @@ _route_srv_status(struct req_args_s *args)
 	GString *gstr = g_string_sized_new(128);
 	g_string_append_c(gstr, '{');
 	oio_str_gstring_append_json_pair_int(gstr, "opened_db_count", count);
+	g_string_append_c(gstr, ',');
+	oio_str_gstring_append_json_pair(gstr, "uuid", uuid);
 	g_string_append_c(gstr, '}');
 
 	return _reply_ok(args->rp, gstr);
@@ -1533,6 +1536,7 @@ grid_main_specific_fini(void)
 	g_cond_clear(&cond_bases);
 	g_mutex_clear(&lock_bases);
 	oio_str_clean(&basedir);
+    oio_str_clean(&uuid);
 }
 
 static void
@@ -1595,6 +1599,12 @@ grid_main_configure(int argc, char **argv)
 	if (!basedir) {
 		g_key_file_free(gkf);
 		return _config_error("DB path", err);
+	}
+
+    uuid = CFG("uuid");
+	if (!uuid) {
+		g_key_file_free(gkf);
+		return _config_error("UUID", err);
 	}
 
 	gchar *cfg_ip = CFG("bind_addr");

--- a/tests/functional/rdir/test_server.py
+++ b/tests/functional/rdir/test_server.py
@@ -19,6 +19,7 @@ import shutil
 import simplejson as json
 import subprocess
 import errno
+import uuid
 from os import remove
 from oio.common.http_urllib3 import get_pool_manager
 
@@ -30,7 +31,8 @@ def _key(rec):
 
 
 map_cfg = {'host': 'bind_addr', 'port': 'bind_port',
-           'ns': 'namespace', 'db': 'db_path'}
+           'ns': 'namespace', 'db': 'db_path',
+           'uuid': 'uuid'}
 
 
 def _write_config(path, config):
@@ -373,10 +375,12 @@ class TestRdirServer2(RdirTestCase):
         self.num, self.host, self.port = 17, '127.0.0.1', 5999
         self.cfg_path = tempfile.mktemp()
         self.db_path = tempfile.mkdtemp()
+        self.uuid = str(uuid.uuid4())
         self.garbage_files.extend((self.cfg_path, self.db_path))
 
         config = {'host': self.host, 'port': self.port,
-                  'ns': self.ns, 'db': self.db_path}
+                  'ns': self.ns, 'db': self.db_path,
+                  'uuid': self.uuid}
         _write_config(self.cfg_path, config)
 
         child = subprocess.Popen(['oio-rdir-server', self.cfg_path],
@@ -396,7 +400,8 @@ class TestRdirServer2(RdirTestCase):
         # check the service has no opened DB
         resp = self._get('/status')
         self.assertEqual(resp.status, 200)
-        self.assertEqual(self.json_loads(resp.data), {'opened_db_count': 0})
+        self.assertEqual(self.json_loads(resp.data),
+                         {'opened_db_count': 0, 'uuid': self.uuid})
 
         # DB creation
         resp = self._post("/v1/rdir/create", params={'vol': vol})
@@ -405,7 +410,8 @@ class TestRdirServer2(RdirTestCase):
         # The base remains open after it has been created
         resp = self._get('/status')
         self.assertEqual(resp.status, 200)
-        self.assertEqual(self.json_loads(resp.data), {'opened_db_count': 1})
+        self.assertEqual(self.json_loads(resp.data),
+                         {'opened_db_count': 1, 'uuid': self.uuid})
 
     def test_bad_routes(self):
         routes = ('/status', '/config',

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -329,6 +329,7 @@ host: ${IP}
 port: ${PORT}
 type: ${SRVTYPE}
 location: ${LOC}
+uuid: ${UUID}
 slots:
     - ${SRVTYPE}
 checks:
@@ -389,6 +390,7 @@ host: ${IP}
 port: ${PORT}
 type: redis
 location: localhost.db${SRVNUM}
+uuid: ${UUID}
 checks:
     - {type: tcp}
 slots:
@@ -1245,7 +1247,9 @@ def generate(options):
         # watcher
         tpl = Template(template_meta_watch)
         with open(watch(env), 'w+') as f:
+            env['UUID'] = uuid.uuid4()
             f.write(tpl.safe_substitute(env))
+            del env['UUID']
 
     # meta0
     nb_meta0 = max(getint(options['meta0'].get(SVC_NB), defaults['NB_M0']),
@@ -1335,7 +1339,9 @@ def generate(options):
             f.write(tpl.safe_substitute(env))
         with open(watch(env), 'w+') as f:
             tpl = Template(template_redis_watch)
+            env['UUID'] = uuid.uuid4()
             f.write(tpl.safe_substitute(env))
+            del env['UUID']
 
     # proxy
     env = subenv({'SRVTYPE': 'proxy', 'SRVNUM': 1, 'PORT': port_proxy,

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -25,7 +25,7 @@ import pwd
 from string import Template
 import re
 import argparse
-
+import uuid
 
 template_redis = """
 daemonize no
@@ -855,6 +855,7 @@ log_facility = LOG_LOCAL0
 log_level = INFO
 log_address = /dev/log
 syslog_prefix = OIO,${NS},rdir,${SRVNUM}
+uuid = ${UUID}
 """
 
 template_admin = """
@@ -1411,7 +1412,9 @@ def generate(options):
             f.write(tpl.safe_substitute(env))
         with open(config(env), 'w+') as f:
             tpl = Template(template_rdir)
+            env['UUID'] = uuid.uuid4()
             f.write(tpl.safe_substitute(env))
+        del env['UUID']
         with open(watch(env), 'w+') as f:
             tpl = Template(template_rdir_watch)
             f.write(tpl.safe_substitute(env))

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -833,6 +833,7 @@ log_facility = LOG_LOCAL0
 log_level = INFO
 log_address = /dev/log
 syslog_prefix = OIO,${NS},${SRVTYPE},${SRVNUM}
+uuid = ${UUID}
 
 # Let this option empty to connect directly to redis_host
 #sentinel_hosts = 127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381
@@ -1395,7 +1396,9 @@ def generate(options):
         f.write(tpl.safe_substitute(env))
     with open(config(env), 'w+') as f:
         tpl = Template(template_account)
+        env['UUID'] = uuid.uuid4()
         f.write(tpl.safe_substitute(env))
+        del env['UUID']
     with open(watch(env), 'w+') as f:
         tpl = Template(template_account_watch)
         f.write(tpl.safe_substitute(env))

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -212,6 +212,7 @@ DavDepthInfinity Off
 grid_docroot           ${DATADIR}/${NS}-${SRVTYPE}-${SRVNUM}
 grid_namespace         ${NS}
 grid_dir_run           ${RUNDIR}
+grid_uuid              ${UUID}
 
 # How many hexdigits must be used to name the indirection directories
 grid_hash_width        3
@@ -1296,7 +1297,9 @@ def generate(options):
                 f.write(tpl.safe_substitute(env))
             # service
             tpl = Template(template_rawx_service)
+            env['UUID'] = uuid.uuid4()
             to_write = tpl.safe_substitute(env)
+            del env['UUID']
             if options.get(OPENSUSE, None):
                 to_write = re.sub(r"LoadModule.*mpm_worker.*", "", to_write)
             with open(httpd_config(env), 'w+') as f:


### PR DESCRIPTION
- [x] Include UUID to each service (need more specification for real deployment)
- [x] expose to openio cli
- [ ] add fallback for old service (generate it from UUID)
- [ ] add migration step ? (to be discussed)
- [ ] store UUID instead of IP:PORT in directories
- [ ] add documention