### PR TITLE
C API: allow configuration of rawx timeouts

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -203,6 +203,24 @@ Used by `gcc`
  * type: gboolean
  * cmake directive: *OIO_CORE_SDS_NOSHUFFLE*
 
+### core.sds.timeout.cnx.rawx
+
+> Sets the connection timeout for requests issued to rawx services.
+
+ * default: **5.0**
+ * type: gdouble
+ * cmake directive: *OIO_CORE_SDS_TIMEOUT_CNX_RAWX*
+ * range: 0.001 -> 300.0
+
+### core.sds.timeout.req.rawx
+
+> Sets the global timeout when uploading a chunk to a rawx service.
+
+ * default: **60.0**
+ * type: gdouble
+ * cmake directive: *OIO_CORE_SDS_TIMEOUT_REQ_RAWX*
+ * range: 0.001 -> 600.0
+
 ### core.sds.version
 
 > The version of the sds. It's used to know the expected metadata of a chunk

--- a/conf.json
+++ b/conf.json
@@ -817,6 +817,15 @@
 				"descr": "Sets the timeout for the requests issued to the SQLX services.",
 				"def": 30.0, "min": 0.01, "max": 60.0 },
 
+			{ "type": "float", "name": "oio_client_rawx_timeout_cnx",
+				"key": "core.sds.timeout.cnx.rawx",
+				"descr": "Sets the connection timeout for requests issued to rawx services.",
+				"def": 5.0, "min": 0.001, "max": 300.0 },
+			{ "type": "float", "name": "oio_client_rawx_timeout_req",
+				"key": "core.sds.timeout.req.rawx",
+				"descr": "Sets the global timeout when uploading a chunk to a rawx service.",
+				"def": 60.0, "min": 0.001, "max": 600.0 },
+
 			{ "type": "monotonic", "name": "_refresh_cpu_idle",
 				"key": "core.period.refresh.cpu_idle",
 				"descr": "Sets the miniimal amount of time between two refreshed of the known CPU-idle counters for the current host. Keep this value small.",

--- a/core/http_put.c
+++ b/core/http_put.c
@@ -87,8 +87,8 @@ struct http_put_s
 
 	CURLM *mhandle;
 
-	long timeout_cnx;
-	long timeout_op;
+	long timeout_cnx;  // milliseconds
+	long timeout_op;  // milliseconds
 
 	/* how many bytes are announced to the server
 	 *   <0 : streaming with transfer-encoding=chunked
@@ -159,8 +159,8 @@ http_put_create(gint64 content_length, gint64 soft_length)
 	p->dests = NULL;
 	p->mhandle = curl_multi_init();
 	p->buffer_tail = g_queue_new();
-	p->timeout_cnx = 60;
-	p->timeout_op = 60;
+	p->timeout_cnx = oio_client_rawx_timeout_cnx * 1000L;  // seconds to ms
+	p->timeout_op = oio_client_rawx_timeout_req * 1000L;  // seconds to ms
 	p->content_length = content_length;
 	p->remaining_length = p->soft_length = soft_length;
 	p->state = HTTP_WHOLE_BEGIN;
@@ -454,8 +454,8 @@ _start_upload(struct http_put_s *p)
 		dest->handle = _curl_get_handle_blob();
 		EXTRA_ASSERT(dest->handle != NULL);
 
-		curl_easy_setopt(dest->handle, CURLOPT_CONNECTTIMEOUT, p->timeout_cnx);
-		curl_easy_setopt(dest->handle, CURLOPT_TIMEOUT, p->timeout_op);
+		curl_easy_setopt(dest->handle, CURLOPT_CONNECTTIMEOUT_MS, p->timeout_cnx);
+		curl_easy_setopt(dest->handle, CURLOPT_TIMEOUT_MS, p->timeout_op);
 
 		curl_easy_setopt(dest->handle, CURLOPT_PRIVATE, dest);
 		curl_easy_setopt(dest->handle, CURLOPT_URL, dest->url);
@@ -716,7 +716,7 @@ _curl_set_sockopt_blob (void *u, curl_socket_t fd, curlsocktype event)
 }
 
 /* Overrides the default setsockopt() for proxy connections.
-   SO_LINGER is now set. */
+ * SO_LINGER is now set. */
 static int
 _curl_set_sockopt_proxy (void *u, curl_socket_t fd, curlsocktype event)
 {

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -29,7 +29,7 @@ License along with this library.
 
 /** Version started to be defined in June, 2016. Version prior to 20160600
  * have no ABI incompatibilities. */
-#define OIO_SDS_VERSION 20170301
+#define OIO_SDS_VERSION 20180206
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Allow configuration of connection and overall request timeouts to rawx
services, from sds.conf configuration file.