### PR TITLE
Python API: expose backoff_factor option

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -23,7 +23,7 @@ from oio.common.http import CONNECTION_TIMEOUT, READ_TIMEOUT
 from oio.common.constants import ADMIN_HEADER
 
 _POOL_MANAGER_OPTIONS_KEYS = ["pool_connections", "pool_maxsize",
-                              "max_retries"]
+                              "max_retries", "backoff_factor"]
 
 URLLIB3_REQUESTS_KWARGS = ('fields', 'headers', 'body', 'retries', 'redirect',
                            'assert_same_host', 'timeout', 'pool_timeout',

--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -31,6 +31,7 @@ READ_TIMEOUT = 30.0
 
 DEFAULT_POOLSIZE = 32
 DEFAULT_RETRIES = 0
+DEFAULT_BACKOFF = 0
 
 
 class CustomHTTPResponse(HTTPResponse):
@@ -258,7 +259,8 @@ class HeadersDict(dict):
 
 def get_pool_manager(pool_connections=DEFAULT_POOLSIZE,
                      pool_maxsize=DEFAULT_POOLSIZE,
-                     max_retries=DEFAULT_RETRIES):
+                     max_retries=DEFAULT_RETRIES,
+                     backoff_factor=DEFAULT_BACKOFF):
     """
     Get `urllib3.PoolManager` to manage pools of connections
 
@@ -268,11 +270,15 @@ def get_pool_manager(pool_connections=DEFAULT_POOLSIZE,
     :type pool_maxsize: `int`
     :param max_retries: number of retries per request
     :type max_retries: `int`
+    :param backoff_factor: backoff factor to apply between attemps after
+        second try
+    :type backoff_factor: `float`
     """
     if max_retries == DEFAULT_RETRIES:
         max_retries = urllib3.Retry(0, read=False)
     else:
-        max_retries = urllib3.Retry.from_int(max_retries)
+        max_retries = urllib3.Retry(total=max_retries,
+                                    backoff_factor=backoff_factor)
     return urllib3.PoolManager(num_pools=pool_connections,
                                maxsize=pool_maxsize, retries=max_retries,
                                block=False)

--- a/tests/functional/rdir/test_server.py
+++ b/tests/functional/rdir/test_server.py
@@ -84,7 +84,7 @@ def _check_process_absent(proc):
 class RdirTestCase(CommonTestCase):
     def setUp(self):
         super(RdirTestCase, self).setUp()
-        self.http_pool = get_pool_manager(max_retries=10)
+        self.http_pool = get_pool_manager(max_retries=10, backoff_factor=0.05)
         self.garbage_files = list()
         self.garbage_procs = list()
 


### PR DESCRIPTION
By default, urllib3 doesn't use backoff when retries are
enabled. This commit introduce parameter to update it.

Following urllib3 documentation, backoff is used after second
try and will sleep by using formula:
{backoff factor} * (2 ^ ({number of total retries} - 1))