### PR TITLE
Python API: create NoMatchFound exception for RegexContainerBuilder

### DIFF
--- a/oio/common/autocontainer.py
+++ b/oio/common/autocontainer.py
@@ -121,6 +121,14 @@ class AutocontainerBuilder(ContainerBuilder):
             return False
 
 
+class NoMatchFound(ValueError):
+    """
+    Exception raised when none of the configured patterns match
+    the input object name.
+    """
+    pass
+
+
 class RegexContainerBuilder(object):
     """
     Build a container name from a regular expression applied on a user
@@ -151,7 +159,8 @@ class RegexContainerBuilder(object):
             match = pattern.search(path)
             if match:
                 return self.builder(''.join(match.groups()))
-        raise ValueError("'%s' does not match any configured patterns" % path)
+        raise NoMatchFound(
+            "'%s' does not match any configured patterns" % path)
 
     def verify(self, name):
         return self.builder.verify(name)

--- a/tests/unit/common/test_autocontainer.py
+++ b/tests/unit/common/test_autocontainer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 OpenIO SAS
+# Copyright (C) 2017-2018 OpenIO SAS
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,7 +15,7 @@
 import unittest
 
 from oio.common.autocontainer import (ContainerBuilder, RegexContainerBuilder,
-                                      HashedContainerBuilder)
+                                      HashedContainerBuilder, NoMatchFound)
 
 
 class ContainerBuilderTest(unittest.TestCase):
@@ -104,7 +104,7 @@ class RegexContainerBuilderTest(unittest.TestCase):
         builder = RegexContainerBuilder(r'(\d+)')
         self.assertEqual(builder("abc/123/def"), "123")
         self.assertEqual(builder("abc123def"), "123")
-        self.assertRaises(ValueError, builder, "abcdef")
+        self.assertRaises(NoMatchFound, builder, "abcdef")
 
     def test_concatenated_digits(self):
         builder = RegexContainerBuilder(r'(\d+)/(\d+)/(\d+)')
@@ -115,7 +115,7 @@ class RegexContainerBuilderTest(unittest.TestCase):
             "previews/images/59/38/69/normal/idirlgfdh.jpg?1502312379"),
             "593869")
         self.assertRaises(
-            ValueError, builder,
+            NoMatchFound, builder,
             "previews/images/normal/idirlgfdh.jpg?1502312379")
 
     def test_several_regex(self):
@@ -128,7 +128,7 @@ class RegexContainerBuilderTest(unittest.TestCase):
             "previews/images/591/384/697/normal/idirlgfdh.jpg?1502312379"),
             "591384697")
         self.assertRaises(
-            ValueError, builder,
+            NoMatchFound, builder,
             "previews/images/591/384/697/medium/idirlgfdh.jpg?1502312379")
 
     def test_prefix_container(self):


### PR DESCRIPTION
In oio-swift's regexcontainer middleware, we will need to catch an exception coming from the `RegexContainerBuilder` class. Before this patch, the exception was of the generic type `ValueError`.