### PR TITLE
Fix 32 bits build, for example armhf

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -972,7 +972,7 @@ member_log_event(struct election_member_s *member, enum election_step_e pre,
 	plog->event = evt;
 	plog->pre = pre;
 	plog->post = member->step;
-	plog->time = (oio_ext_real_time() / G_TIME_SPAN_MILLISECOND) % (1L << 48);
+	plog->time = (oio_ext_real_time() / G_TIME_SPAN_MILLISECOND) % (1LL << 48);
 }
 
 #ifdef HAVE_EXTRA_DEBUG


### PR DESCRIPTION
[ 50%] Building C object sqliterepo/CMakeFiles/sqliterepo.dir/election.c.o
cd /build/openio-sds-4.1.13/obj-arm-linux-gnueabihf/sqliterepo && /usr/bin/arm-linux-gnueabihf-gcc  -DG_LOG_DOMAIN=\"oio.sqlite\" -DHAVE_ACCEPT4 -DHAVE_SOCKET3 -DHAVE_SOCKLEN_T -DOIOSDS_PROJECT_VERSION=\"master/4.1\" -DTHREADED -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_LARGE_FILES -D_REENTRANT -Dsqliterepo_EXPORTS -I/build/openio-sds-4.1.13/obj-arm-linux-gnueabihf/sqliterepo -I/build/openio-sds-4.1.13/obj-arm-linux-gnueabihf/metautils/lib -I/build/openio-sds-4.1.13/obj-arm-linux-gnueabihf/metautils/asn1c -I/build/openio-sds-4.1.13/obj-arm-linux-gnueabihf -I/build/openio-sds-4.1.13 -I/build/openio-sds-4.1.13/sqliterepo -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -I/usr/include/zookeeper  -g -fPIC -pipe -Wall -Wextra -std=gnu99 -Wno-missing-field-initializers -Wunused -Wno-variadic-macros -Wsequence-point -Wredundant-decls -Wshadow -Wcomment -Wmain -Wparentheses -Wfloat-equal -Wunsafe-loop-optimizations -Wunused-but-set-parameter -Wunused-but-set-variable -Wmissing-prototypes -Werror -O2 -fPIC   -o CMakeFiles/sqliterepo.dir/election.c.o   -c /build/openio-sds-4.1.13/sqliterepo/election.c
/build/openio-sds-4.1.13/sqliterepo/election.c: In function 'member_log_event':
/build/openio-sds-4.1.13/sqliterepo/election.c:975:69: error: left shift count >= width of type [-Werror=shift-count-overflow]
  plog->time = (oio_ext_real_time() / G_TIME_SPAN_MILLISECOND) % (1L << 48);
                                                                     ^
/build/openio-sds-4.1.13/sqliterepo/election.c:975:63: error: division by zero [-Werror=div-by-zero]
  plog->time = (oio_ext_real_time() / G_TIME_SPAN_MILLISECOND) % (1L << 48);

Fixes: b17504724c68bc49a1379ddce1ae085cacb4d2fb