### PR TITLE
python: Force the location to be instances of 'str'

### DIFF
--- a/oio/directory/meta0.py
+++ b/oio/directory/meta0.py
@@ -98,7 +98,7 @@ class PrefixMapping(object):
         loc = svc.get("tags", {}).get("tag.loc", default)
         if not loc or loc == "addr":
             loc = svc["addr"].rsplit(":", 1)[0]
-        return loc
+        return str(loc)
 
     @staticmethod
     def dist_between(loc1, loc2):


### PR DESCRIPTION
... instead of the type inferred from a JSON message.
Without this, a pure integer service location would raise an exception.