### PR TITLE
The the startup of meta1 services

### DIFF
--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -447,9 +447,12 @@ meta0_backend_get_all(struct meta0_backend_s *m0, GPtrArray **result)
 		g_prefix_error(&err, "Reload error: ");
 		return err;
 	}
+	if (!m0->array_by_prefix) {
+		g_prefix_error(&err, "Prefixes not ready");
+		return err;
+	}
 
 	g_rw_lock_reader_lock(&(m0->rwlock));
-	EXTRA_ASSERT(m0->array_by_prefix != NULL);
 	*result = meta0_utils_array_dup(m0->array_by_prefix);
 	g_rw_lock_reader_unlock(&(m0->rwlock));
 

--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -476,10 +476,13 @@ meta0_backend_get_one(struct meta0_backend_s *m0, const guint8 *prefix,
 		return err;
 	}
 
-	g_rw_lock_reader_lock(&(m0->rwlock));
-	EXTRA_ASSERT(m0->array_by_prefix != NULL);
-	*u = meta0_utils_array_get_urlv(m0->array_by_prefix, prefix);
-	g_rw_lock_reader_unlock(&(m0->rwlock));
+	if (!m0->array_by_prefix) {
+		*u = NULL;
+	} else {
+		g_rw_lock_reader_lock(&(m0->rwlock));
+		*u = meta0_utils_array_get_urlv(m0->array_by_prefix, prefix);
+		g_rw_lock_reader_unlock(&(m0->rwlock));
+	}
 
 	return *u ? NULL : NEWERROR(EINVAL, "META0 partially missing");
 }

--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -448,8 +448,7 @@ meta0_backend_get_all(struct meta0_backend_s *m0, GPtrArray **result)
 		return err;
 	}
 	if (!m0->array_by_prefix) {
-		g_prefix_error(&err, "Prefixes not ready");
-		return err;
+		return NEWERROR(EINVAL, "Prefixes not ready");
 	}
 
 	g_rw_lock_reader_lock(&(m0->rwlock));

--- a/meta1v2/meta1_prefixes.c
+++ b/meta1v2/meta1_prefixes.c
@@ -314,6 +314,8 @@ meta1_prefixes_get_peers(struct meta1_prefixes_set_s *m1ps,
 		const guint8 *bytes)
 {
 	EXTRA_ASSERT(m1ps != NULL);
+	if (!m1ps->by_prefix)
+		return NULL;
 	g_mutex_lock(&m1ps->lock);
 	gchar **a = meta0_utils_array_get_urlv(m1ps->by_prefix, bytes);
 	g_mutex_unlock(&m1ps->lock);


### PR DESCRIPTION
Avoid failing miserably on the assertion mentioned in the subsequent backtrace. But it doesn't explain why the meta1 starts serving requests before having a full set of prefixes from a meta0 service. 

```
Thread 1 (Thread 0x7fec9ab9a700 (LWP 15285)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007feca48eaf5d in __GI_abort () at abort.c:90
#2  0x00007feca53a681d in g_assertion_message () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007feca53a68aa in g_assertion_message_expr () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#4  0x00007feca446ca23 in meta0_utils_array_get_urlv (byprefix=0x0, b=0x7fec9ab99636 <incomplete sequence \355>) at /home/jfs/public_git/github.com/jfsmig/oio-sds/meta0v2/meta0_utils.c:133
#5  0x00007feca5862124 in meta1_prefixes_get_peers (m1ps=0x55d1abe15420, bytes=0x7fec9ab99636 <incomplete sequence \355>) at /home/jfs/public_git/github.com/jfsmig/oio-sds/meta1v2/meta1_prefixes.c:318
#6  0x000055d1a9dd8002 in _get_peers (ss=0x7feca5854700 <SRV>, n=0x7fec9ab99860, nocache=0, result=0x7fec9ab99678) at /home/jfs/public_git/github.com/jfsmig/oio-sds/meta1v2/meta1_server.c:145
#7  0x00007feca564edf3 in _get_peers_wrapper (ss=0x7feca5854700 <SRV>, name=0x7fec9ab99860, nocache=0, result=0x7fec9ab996c8) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqlx/sqlx_service.c:550
#8  0x00007feca4684fd6 in _election_get_peers (manager=0x55d1abe44f50, n=0x7fec9ab99860, nocache=0, result=0x7fec9ab99758) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/election.c:678
#9  0x00007feca468490b in election_get_peers (m=0x55d1abe44f50, n=0x7fec9ab99860, nocache=0, peers=0x7fec9ab99758) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/election.c:612
#10 0x00007feca46847b8 in election_has_peers (m=0x55d1abe44f50, n=0x7fec9ab99860, nocache=0, result=0x7fec9ab997a4) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/election.c:589
#11 0x00007feca468ab9c in _election_make (m=0x55d1abe44f50, n=0x7fec9ab99860, op=ELOP_START) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/election.c:1724
#12 0x00007feca468ae3f in _election_start (manager=0x55d1abe44f50, n=0x7fec9ab99860) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/election.c:1777
---Type <return> to continue, or q <return> to quit---
#13 0x00007feca469f142 in sqlx_repository_use_base (repo=0x55d1abe453d0, n=0x7fec9ab99860) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/repository.c:1187
#14 0x00007feca4696feb in _handler_USE (reply=0x7fec9ab99a20, repo=0x55d1abe453d0, ignored=0x0) at /home/jfs/public_git/github.com/jfsmig/oio-sds/sqliterepo/replication_dispatcher.c:1580
#15 0x00007feca512ddef in _client_call_handler () at /home/jfs/public_git/github.com/jfsmig/oio-sds/server/transport_gridd.c:664
#16 0x00007feca512e949 in _client_manage_l4v (client=0x7fec74001310, gba=0x7fec6c002210) at /home/jfs/public_git/github.com/jfsmig/oio-sds/server/transport_gridd.c:752
#17 0x00007feca512d445 in transport_gridd_notify_input (clt=0x7fec74001310) at /home/jfs/public_git/github.com/jfsmig/oio-sds/server/transport_gridd.c:469
#18 0x00007feca51296cb in _manage_udp_task (clt=0x7fec74001310, srv=0x55d1abe351a0) at /home/jfs/public_git/github.com/jfsmig/oio-sds/server/network_server.c:701
#19 0x00007feca53a8010 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#20 0x00007feca53a7645 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#21 0x00007feca30b17fc in start_thread (arg=0x7fec9ab9a700) at pthread_create.c:465
#22 0x00007feca49c6b5f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```