### PR TITLE
meta*: Deny requests upon I/O errors

### DIFF
--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -65,6 +65,7 @@ class ServiceWatcher(object):
         self.client = ProxyClient(self.conf, pool_manager=self.pool_manager,
                                   no_ns_in_url=True, logger=self.logger)
         self.last_status = False
+        self.status = False
         self.failed = False
         self.service_definition = {
             'ns': self.conf['namespace'],
@@ -97,6 +98,7 @@ class ServiceWatcher(object):
         if self.deregister_on_exit:
             self.logger.info('watcher "%s" deregister service', self.name)
             try:
+                self.status = False
                 self.last_status = False
                 self.register()
             except Exception as e:
@@ -104,33 +106,41 @@ class ServiceWatcher(object):
         self.running = False
 
     def check(self):
-        status = True
+        """Perform the registered checks on the service until any of
+        them fails of the end of the list is reached."""
+        self.status = True
         for service_check in (x for x in self.service_checks if self.running):
             if not service_check.service_status():
-                status = False
-
-        if status != self.last_status:
-            if status:
-                self.logger.info('service "%s" is now up', self.name)
-            else:
-                self.logger.warn('service "%s" is now down', self.name)
-            self.last_status = status
+                self.status = False
+                return
 
     def get_stats(self):
         """Update service definition with all configured stats"""
-        if not self.last_status:
+        if not self.status:
             return
-        for stat in (x for x in self.service_stats if self.running):
-            stats = stat.get_stats()
-            self.service_definition['tags'].update(stats)
+        try:
+            for stat in (x for x in self.service_stats if self.running):
+                stats = stat.get_stats()
+                self.service_definition['tags'].update(stats)
+        except Exception as ex:
+            self.logger.debug("get_stats error: %s", ex)
+            self.status = False
 
     def register(self):
         # only accept a final zero/down-registration when exiting
-        if not self.running and self.last_status:
+        if not self.running and self.status:
             return
 
+        # Alert when the status changes
+        if self.status != self.last_status:
+            if self.status:
+                self.logger.info('service "%s" is now up', self.name)
+            else:
+                self.logger.warn('service "%s" is now down', self.name)
+            self.last_status = self.status
+
         # Use a boolean so we can easily convert it to a number in conscience
-        self.service_definition['tags']['tag.up'] = self.last_status
+        self.service_definition['tags']['tag.up'] = self.status
         try:
             self.cs.register(self.service['type'], self.service_definition,
                              retries=False)

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -71,8 +71,6 @@ class HttpStat(BaseStat):
                 result = self._parse_func(resp.read())
             else:
                 raise Exception("status code != 200: %s" % resp.status)
-        except Exception as e:
-            self.logger.debug("get_stats error: %s", e)
         finally:
             if resp:
                 try:

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -71,10 +71,10 @@ class HttpStat(BaseStat):
                 result = self._parse_func(resp.read())
             else:
                 raise Exception("status code != 200: %s" % resp.status)
+            return result
         finally:
             if resp:
                 try:
                     resp.force_close()
                 except Exception:
                     pass
-            return result

--- a/oio/conscience/stats/meta.py
+++ b/oio/conscience/stats/meta.py
@@ -27,15 +27,11 @@ class MetaStat(HttpStat):
         self.params = {'id': service_id}
 
     def get_stats(self):
-        try:
-            resp, _body = self.agent.client._request(
-                    'POST', self.uri, params=self.params, retries=False)
-            stats = self._parse_stats_lines(resp.data)
-            for key in stats.keys():
-                if key.startswith('gauge'):
-                    stat_key = 'stat.' + key.split(None, 1)[1]
-                    stats[stat_key] = stats[key]
-            return stats
-        except Exception as exc:
-            self.logger.info("get_stats error: %s", exc)
-            return {}
+        resp, _body = self.agent.client._request(
+                'POST', self.uri, params=self.params, retries=False)
+        stats = self._parse_stats_lines(resp.data)
+        for key in stats.keys():
+            if key.startswith('gauge'):
+                stat_key = 'stat.' + key.split(None, 1)[1]
+                stats[stat_key] = stats[key]
+        return stats

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -47,6 +47,8 @@ License along with this library.
 
 GQuark gq_count_all = 0;
 GQuark gq_time_all = 0;
+GQuark gq_count_ioerror = 0;
+GQuark gq_time_ioerror = 0;
 GQuark gq_count_unexpected = 0;
 GQuark gq_time_unexpected = 0;
 GQuark gq_count_overloaded = 0;
@@ -136,6 +138,8 @@ _cnx_notify_close(struct network_server_s *srv)
 static void __attribute__ ((constructor))
 _constructor (void)
 {
+	gq_count_ioerror = g_quark_from_static_string (OIO_STAT_PREFIX_REQ ".IOERROR");
+	gq_time_ioerror = g_quark_from_static_string (OIO_STAT_PREFIX_TIME ".IOERROR");
 	gq_count_overloaded = g_quark_from_static_string (OIO_STAT_PREFIX_REQ ".OVERLOADED");
 	gq_time_overloaded = g_quark_from_static_string (OIO_STAT_PREFIX_TIME ".OVERLOADED");
 

--- a/server/network_server.h
+++ b/server/network_server.h
@@ -103,6 +103,8 @@ struct network_client_s
 
 extern GQuark gq_count_all;
 extern GQuark gq_time_all;
+extern GQuark gq_count_ioerror;
+extern GQuark gq_time_ioerror;
 extern GQuark gq_count_unexpected;
 extern GQuark gq_time_unexpected;
 extern GQuark gq_count_overloaded;

--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -61,6 +61,11 @@ struct gridd_request_handler_s
 struct gridd_request_dispatcher_s
 {
 	GTree *tree_requests;
+
+	/* By default to 0, set to a monotonic time value when an I/O
+	 * error occurs, periodically checked for recent acctivity */
+	gint64 last_io_error;
+	gint64 last_io_success;
 };
 
 struct req_ctx_s
@@ -94,6 +99,8 @@ static gboolean _client_manage_l4v(struct network_client_s *clt, GByteArray *gba
  * the server but allow it to reply "config volume /path/to/docroot" in its
  * stats. */
 const char *oio_server_volume = NULL;
+
+static int _local_variable = 0;
 
 /* -------------------------------------------------------------------------- */
 
@@ -661,8 +668,14 @@ _client_call_handler(struct req_ctx_s *req_ctx)
 			_notify_request(req_ctx, gq_count_unexpected, gq_time_unexpected);
 		} else {
 			EXTRA_ASSERT(hdl->handler != NULL);
-			rc = hdl->handler(&ctx, hdl->gdata, hdl->hdata);
-			_notify_request(req_ctx, hdl->stat_name_req, hdl->stat_name_time);
+			if (hdl->hdata != &_local_variable
+					&& !grid_daemon_is_io_ok(req_ctx->disp)) {
+				rc = _client_reply_fixed(req_ctx, CODE_UNAVAILABLE, "IO errors reported");
+				_notify_request(req_ctx, gq_count_ioerror, gq_time_ioerror);
+			} else {
+				rc = hdl->handler(&ctx, hdl->gdata, hdl->hdata);
+				_notify_request(req_ctx, hdl->stat_name_req, hdl->stat_name_time);
+			}
 		}
 	}
 
@@ -783,10 +796,8 @@ _stats_runner(gpointer k, gpointer v, gpointer u)
 
 static gboolean
 dispatch_LISTHANDLERS(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
-
 	GByteArray *body = g_byte_array_sized_new(256);
 	g_tree_foreach(reply->client->transport.client_context->dispatcher->tree_requests,
 			_stats_runner, body);
@@ -798,10 +809,9 @@ dispatch_LISTHANDLERS(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_LEAN(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
 	gchar buf[128] = "Freed:";
-	(void) gdata, (void) hdata;
 
 	if (metautils_message_extract_flag (reply->request, "LIBC", FALSE)) {
 		if (malloc_trim (malloc_trim_size_ondemand))
@@ -822,9 +832,8 @@ dispatch_LEAN(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_PING(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
 	reply->no_access();
 	reply->send_reply(CODE_FINAL_OK, "OK");
 	return TRUE;
@@ -832,9 +841,8 @@ dispatch_PING(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_KILL(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
 	if (reply->client->server->abort_allowed) {
 		abort();
 		reply->send_reply(CODE_FINAL_OK, "OK");
@@ -846,10 +854,8 @@ dispatch_KILL(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_SETCFG(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
-
 	gsize length = 0;
 	void *body = metautils_message_get_BODY(reply->request, &length);
 
@@ -877,10 +883,8 @@ dispatch_SETCFG(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_GETCFG(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
-
 	GString *gstr = oio_var_list_as_json();
 	reply->add_body(g_bytes_unref_to_array(g_string_free_to_bytes(gstr)));
 	reply->send_reply(CODE_FINAL_OK, "OK");
@@ -889,9 +893,8 @@ dispatch_GETCFG(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_REDIRECT(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
 	gchar **endpoints = network_server_endpoints(reply->client->server);
 	reply->send_error(0, NEWERROR(CODE_REDIRECT, "%s", endpoints[0]));
 	g_strfreev(endpoints);
@@ -902,10 +905,8 @@ dispatch_REDIRECT(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_STATS(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
-
 	GArray *array = network_server_stat_getall(reply->client->server);
 	// Rough estimate, will be automatically resized if needed
 	GByteArray *body = g_byte_array_sized_new(array->len * 32);
@@ -934,9 +935,8 @@ dispatch_STATS(struct gridd_reply_ctx_s *reply,
 
 static gboolean
 dispatch_VERSION(struct gridd_reply_ctx_s *reply,
-		gpointer gdata, gpointer hdata)
+		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
-	(void) gdata, (void) hdata;
 	reply->no_access();
 	reply->add_body(metautils_gba_from_string(OIOSDS_PROJECT_VERSION));
 	reply->send_reply(CODE_FINAL_OK, "OK");
@@ -946,16 +946,18 @@ dispatch_VERSION(struct gridd_reply_ctx_s *reply,
 const struct gridd_request_descr_s*
 gridd_get_common_requests(void)
 {
+	/* The marker is used to detect local low-level handlers */
 	static struct gridd_request_descr_s descriptions[] = {
-		{"REQ_LEAN",      dispatch_LEAN,          NULL},
+		/* ping mustwill fail because of I/O errors */
 		{"REQ_PING",      dispatch_PING,          NULL},
 		{"REQ_STATS",     dispatch_STATS,         NULL},
-		{"REQ_VERSION",   dispatch_VERSION,       NULL},
-		{"REQ_HANDLERS",  dispatch_LISTHANDLERS,  NULL},
-		{"REQ_KILL",      dispatch_KILL,          NULL},
-		{"REQ_GETCFG",    dispatch_GETCFG,        NULL},
-		{"REQ_SETCFG",    dispatch_SETCFG,        NULL},
-		{"REQ_REDIRECT",  dispatch_REDIRECT,      NULL},
+		{"REQ_VERSION",   dispatch_VERSION,       &_local_variable},
+		{"REQ_HANDLERS",  dispatch_LISTHANDLERS,  &_local_variable},
+		{"REQ_GETCFG",    dispatch_GETCFG,        &_local_variable},
+		{"REQ_SETCFG",    dispatch_SETCFG,        &_local_variable},
+		{"REQ_REDIRECT",  dispatch_REDIRECT,      &_local_variable},
+		{"REQ_LEAN",      dispatch_LEAN,          &_local_variable},
+		{"REQ_KILL",      dispatch_KILL,          &_local_variable},
 		{NULL, NULL, NULL}
 	};
 
@@ -988,3 +990,32 @@ grid_daemon_bind_host(struct network_server_s *server, const gchar *url,
 			(network_transport_factory)transport_gridd_factory);
 }
 
+void
+grid_daemon_notify_io_status(
+		struct gridd_request_dispatcher_s *disp, gboolean ok)
+{
+	EXTRA_ASSERT(disp != NULL);
+	if (ok) {
+		disp->last_io_success = oio_ext_monotonic_time();
+	} else {
+		disp->last_io_error = oio_ext_monotonic_time();
+	}
+}
+
+gboolean
+grid_daemon_is_io_ok(struct gridd_request_dispatcher_s *disp)
+{
+	EXTRA_ASSERT(disp != NULL);
+
+	/* Never touched -> OK */
+	if (!disp->last_io_error && !disp->last_io_success)
+		return TRUE;
+
+	/* The most recent activity is an error -> KO */
+	if (disp->last_io_error > disp->last_io_success)
+		return FALSE;
+
+	/* check the probe thread was not stalled */
+	const gint64 now = oio_ext_monotonic_time();
+	return disp->last_io_success > OLDEST(now, G_TIME_SPAN_MINUTE);
+}

--- a/server/transport_gridd.h
+++ b/server/transport_gridd.h
@@ -132,4 +132,9 @@ const struct gridd_request_descr_s* gridd_get_common_requests(void);
 void grid_daemon_bind_host(struct network_server_s *server, const gchar *url,
 		struct gridd_request_dispatcher_s *dispatcher);
 
+void grid_daemon_notify_io_status(
+		struct gridd_request_dispatcher_s *disp, gboolean ok);
+
+gboolean grid_daemon_is_io_ok(struct gridd_request_dispatcher_s *disp);
+
 #endif /*OIO_SDS__server__transport_gridd_h*/

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1535,4 +1535,3 @@ sqlx_repository_get_version2(sqlx_repository_t *repo, const struct sqlx_name_s *
 	*result = version;
 	return NULL;
 }
-

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1049,6 +1049,7 @@ _task_probe_repository(gpointer p)
 	oio_str_randomize(subdir, sizeof(subdir), HEXA);
 	oio_str_randomize(filename, sizeof(filename), HEXA);
 
+	/* Try a directory creation */
 	g_strlcpy(path, ss->volume, sizeof(path));
 	g_strlcat(path, "/probe-", sizeof(path));
 	g_strlcat(path, subdir, sizeof(path));
@@ -1058,30 +1059,25 @@ _task_probe_repository(gpointer p)
 	(void) g_rmdir(path);
 	if (rc != 0) {
 		GRID_WARN("I/O error on %s: (%d) %s", path, errsav, strerror(errsav));
-		goto label_io_error;
+		grid_daemon_notify_io_status(ss->dispatcher, FALSE);
+		return;
 	}
 
+	/* Try a file creation */
 	g_strlcpy(path, ss->volume, sizeof(path));
 	g_strlcat(path, "/probe-", sizeof(path));
 	g_strlcat(path, filename, sizeof(path));
 	GRID_DEBUG("Probing file %s", path);
 	rc = g_file_set_contents(path, "", 0, &err);
-	errsav = errno;
 	(void) g_unlink(path);
 	if (!rc) {
 		GRID_WARN("I/O error on %s: (%d) %s", path, err->code, err->message);
 		g_clear_error(&err);
-		goto label_io_error;
+		grid_daemon_notify_io_status(ss->dispatcher, FALSE);
+		return;
 	}
-	if (err)
-		g_clear_error(&err);
 
 	grid_daemon_notify_io_status(ss->dispatcher, TRUE);
-	return;
-
-label_io_error:
-	grid_daemon_notify_io_status(ss->dispatcher, FALSE);
-	(void) rc;
 }
 
 static void


### PR DESCRIPTION
* oio-conscience-agent: Consider errors from /stat requests a enough to mark the service down
* server/transpport_gridd.c: Keep track of IO errors/success timestamps, if the last activity is an error or if the timestamp of the last success is not recent (stalled), consider the volume is faulty.
* server/transpport_gridd.c: Deny alll but specific local requests with a code 503 that won't fail the general call, and allow the caller to retry on peers.
* sqlx/sqlx_service.c: Implement a probe in a background thread that periodically checks for directory and file creations.

known limitation: the support of the REQ_PING is really limited in the conscience-agent, the return code is not even checked. We could save the REQ_STAT request if we immediately consider the service is down. then we could even allow the REQ_STAT to return complete information.