### PR TITLE
sqliterepo: Ensure a DB exists before kicking the election FSM off

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1927,9 +1927,15 @@ _result_GETVERS (GError *enet,
 
 	if (enet) {
 		err = g_error_copy(enet);
+		GRID_DEBUG("GETVERS error [%s.%s]: (%d) %s",
+				name->base, name->type, err->code, err->message);
 	} else {
 		err = manager->config->get_version (manager->config->ctx, name, &vlocal);
 		EXTRA_ASSERT ((err != NULL) ^ (vlocal != NULL));
+		if (err) {
+			GRID_WARN("GETVERS error [%s.%s]: (%d) %s",
+					name->base, name->type, err->code, err->message);
+		}
 	}
 
 	if (!err) {
@@ -1964,7 +1970,6 @@ _result_GETVERS (GError *enet,
 		else if (err->code == CODE_CONCURRENT)
 			transition(member, EVT_GETVERS_RACE, &reqid);
 		else {
-			GRID_DEBUG("GETVERS error : (%d) %s", err->code, err->message);
 			if (err->code == CODE_CONTAINER_NOTFOUND) {
 				// We may have asked the wrong peer
 				member_decache_peers(member);

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1364,8 +1364,7 @@ _handler_GETVERS(struct gridd_reply_ctx_s *reply,
 		return TRUE;
 	}
 
-	/* TODO JFS : trigger an election, useful to reduce the number of
-	   messages during an election. */
+	/* Kickoff the election, we are already involved in it... */
 	if (NULL != (err = sqlx_repository_use_base(repo, &n0))) {
 		g_prefix_error(&err, "Use: ");
 		reply->send_error(0, err);
@@ -1381,10 +1380,11 @@ _handler_GETVERS(struct gridd_reply_ctx_s *reply,
 	}
 
 	err = sqlx_repository_get_version(sq3, &version);
+	sqlx_repository_unlock_and_close_noerror(sq3);
+
 	if (NULL != err) {
 		reply->send_error(0, err);
-	}
-	else {
+	} else {
 		GByteArray *encoded = version_encode(version);
 		if (!encoded) {
 			err = NEWERROR(CODE_INTERNAL_ERROR, "Encoding error (version)");
@@ -1396,7 +1396,6 @@ _handler_GETVERS(struct gridd_reply_ctx_s *reply,
 		}
 	}
 
-	sqlx_repository_unlock_and_close_noerror(sq3);
 	if (version)
 		g_tree_destroy(version);
 	return TRUE;


### PR DESCRIPTION
Avoids spamming DB_GETVERS requests when an election happens on a fresh DB.
Only impacts freshly deployed platforms.