### PR TITLE
meta0: Display a better error message when the service is not ready.

### DIFF
--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -477,11 +477,17 @@ meta0_backend_get_one(struct meta0_backend_s *m0, const guint8 *prefix,
 
 	if (!m0->array_by_prefix) {
 		*u = NULL;
+		return NEWERROR(CODE_UNAVAILABLE,
+				"The current META0 service is not ready yet, "
+				"it has not been initiated.");
 	} else {
 		g_rw_lock_reader_lock(&(m0->rwlock));
 		*u = meta0_utils_array_get_urlv(m0->array_by_prefix, prefix);
 		g_rw_lock_reader_unlock(&(m0->rwlock));
+		if (*u != NULL)
+			return NULL;
+		return NEWERROR(CODE_UNAVAILABLE,
+				"The current META0 service is not ready yet, "
+				"it has been partially initiated.");
 	}
-
-	return *u ? NULL : NEWERROR(EINVAL, "META0 partially missing");
 }

--- a/meta0v2/meta0_gridd_dispatcher.c
+++ b/meta0v2/meta0_gridd_dispatcher.c
@@ -141,7 +141,7 @@ meta0_dispatch_v1_GETONE(struct gridd_reply_ctx_s *reply,
 		err = meta0_backend_get_one(m0disp->m0, prefix, &urlv);
 		if (NULL != err) {
 			g_prefix_error(&err, "Backend error: ");
-			reply->send_error(CODE_INTERNAL_ERROR, err);
+			reply->send_error(0, err);
 		} else {
 			reply->add_body(_encode_meta0_tree(urlv_to_tree(prefix, urlv)));
 			reply->send_reply(CODE_FINAL_OK, "OK");

--- a/meta0v2/meta0_gridd_dispatcher.c
+++ b/meta0v2/meta0_gridd_dispatcher.c
@@ -140,7 +140,6 @@ meta0_dispatch_v1_GETONE(struct gridd_reply_ctx_s *reply,
 		gchar **urlv = NULL;
 		err = meta0_backend_get_one(m0disp->m0, prefix, &urlv);
 		if (NULL != err) {
-			g_prefix_error(&err, "Backend error: ");
 			reply->send_error(0, err);
 		} else {
 			reply->add_body(_encode_meta0_tree(urlv_to_tree(prefix, urlv)));
@@ -166,7 +165,6 @@ meta0_dispatch_v1_RELOAD(struct gridd_reply_ctx_s *reply,
 	GError *err;
 
 	if (NULL != (err = meta0_backend_reload(m0disp->m0))) {
-		g_prefix_error(&err, "Backend error: ");
 		reply->send_error(0, err);
 		return TRUE;
 	}
@@ -185,7 +183,6 @@ meta0_dispatch_v1_RESET(struct gridd_reply_ctx_s *reply,
 
 	GError *err = meta0_backend_reset(m0disp->m0, flag_local);
 	if (NULL != err) {
-		g_prefix_error(&err, "Backend error: ");
 		reply->send_error(0, err);
 		return TRUE;
 	}


### PR DESCRIPTION
##### SUMMARY
Display a better error message when a META0 (a.k.a. "meta-0") service is not ready.

Fixes #1400 

##### ISSUE TYPE
Enhancement.

##### COMPONENT NAME
Change in `oio-meta0-server` with an impact in any meta0 client (i.e. any client of oio-sds).

##### SDS VERSION
```
4.1.21
```