### PR TITLE
events: Make configurable the buffering delay

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -313,7 +313,7 @@ Used by `gcc`
 
 > Sets the buffering delay of the events emitted by the application
 
- * default: **5 * G_TIME_SPAN_SECOND**
+ * default: **1 * G_TIME_SPAN_SECOND**
  * type: gint64
  * cmake directive: *OIO_EVENTS_COMMON_PENDING_DELAY*
  * range: 1 * G_TIME_SPAN_MILLISECOND -> 1 * G_TIME_SPAN_HOUR

--- a/conf.json
+++ b/conf.json
@@ -55,7 +55,7 @@
 		"variables": [
 			{ "type": "monotonic", "name": "oio_events_common_buffer_delay",
 				"key": "events.common.pending.delay",
-				"def": "5s", "min": "1ms", "max": "1h",
+				"def": "1s", "min": "1ms", "max": "1h",
 				"descr": "Sets the buffering delay of the events emitted by the application" },
 
 			{ "type": "uint32", "name": "oio_events_common_max_pending",

--- a/events/oio_events_queue.c
+++ b/events/oio_events_queue.c
@@ -75,6 +75,13 @@ oio_events_queue__get_health(struct oio_events_queue_s *self)
 	return 100;
 }
 
+void
+oio_events_queue__set_buffering (struct oio_events_queue_s *self,
+		gint64 delay)
+{
+	EVTQ_CALL(self,set_buffering)(self,delay);
+}
+
 GError *
 oio_events_queue__run (struct oio_events_queue_s *self,
 		gboolean (*running) (gboolean pending))

--- a/events/oio_events_queue.h
+++ b/events/oio_events_queue.h
@@ -38,6 +38,9 @@ gboolean oio_events_queue__is_stalled (struct oio_events_queue_s *self);
 /* Get a health metric for the events queue, from 0 (bad) to 100 (good). */
 gint64 oio_events_queue__get_health(struct oio_events_queue_s *self);
 
+void oio_events_queue__set_buffering (struct oio_events_queue_s *self,
+		gint64 delay);
+
 GError * oio_events_queue__run (struct oio_events_queue_s *self,
 		gboolean (*running) (gboolean pending));
 

--- a/events/oio_events_queue_beanstalkd.c
+++ b/events/oio_events_queue_beanstalkd.c
@@ -102,7 +102,7 @@ oio_events_queue_factory__create_beanstalkd (const char *endpoint,
 	self->tube = g_strdup(OIO_EVT_BEANSTALKD_DEFAULT_TUBE);
 	self->endpoint = g_strdup (endpoint);
 
-	oio_events_queue_buffer_init(&(self->buffer), 1 * G_TIME_SPAN_SECOND);
+	oio_events_queue_buffer_init(&(self->buffer));
 
 	*out = (struct oio_events_queue_s*) self;
 	return NULL;

--- a/events/oio_events_queue_buffer.c
+++ b/events/oio_events_queue_buffer.c
@@ -22,13 +22,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 void
-oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf,
-		gint64 delay)
+oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf)
 {
 	g_mutex_init(&(buf->msg_by_key_lock));
 	buf->msg_by_key = lru_tree_create((GCompareFunc)g_strcmp0, g_free, g_free,
 			LTO_NOATIME|LTO_NOUTIME);
-	buf->delay = delay;
+	buf->delay = oio_events_common_buffer_delay;
 }
 
 void

--- a/events/oio_events_queue_buffer.h
+++ b/events/oio_events_queue_buffer.h
@@ -29,8 +29,7 @@ struct oio_events_queue_buffer_s
 	gint64 delay;
 };
 
-void oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf,
-		gint64 delay);
+void oio_events_queue_buffer_init(struct oio_events_queue_buffer_s *buf);
 void oio_events_queue_buffer_clean(struct oio_events_queue_buffer_s *buf);
 void oio_events_queue_buffer_set_delay(struct oio_events_queue_buffer_s *buf,
 		gint64 new_delay);

--- a/events/oio_events_queue_fanout.c
+++ b/events/oio_events_queue_fanout.c
@@ -96,7 +96,13 @@ oio_events_queue_factory__create_fanout (
 	self->queue = g_async_queue_new ();
 	self->output_tab = subv;
 	self->output_nb = sublen;
-	oio_events_queue_buffer_init(&(self->buffer), 1 * G_TIME_SPAN_SECOND);
+	oio_events_queue_buffer_init(&(self->buffer));
+
+	/* Turn the buffering off, it is already done in the fanout layer */
+	for (guint i = 0; i < sublen; i++) {
+		struct oio_events_queue_s *sub = subv[i];
+		oio_events_queue__set_buffering(sub, 0);
+	}
 
 	*out = (struct oio_events_queue_s*) self;
 	return NULL;

--- a/events/oio_events_queue_zmq.c
+++ b/events/oio_events_queue_zmq.c
@@ -133,7 +133,7 @@ oio_events_queue_factory__create_zmq (const char *zurl,
 	self->url = g_strdup (zurl);
 	self->max_recv_per_round = 32;
 	self->procid = getpid();
-	oio_events_queue_buffer_init(&(self->buffer), 1 * G_TIME_SPAN_SECOND);
+	oio_events_queue_buffer_init(&(self->buffer));
 	*out = (struct oio_events_queue_s *) self;
 	return NULL;
 }


### PR DESCRIPTION
##### SUMMARY

Take into account the `events.common.pending.delay` configuration directive that allows to tune the buffering delay for the events. The configuration value is only considered at the startup of the services.
Prior to this patch, the configuration directive existed but was ignored. Its default value has been changed to match the default behaviour, for a seamless upgrade.

##### ISSUE TYPE
Enhancement

##### COMPONENT NAME
`oio_events_queue` that is indirectly used by `oio-meta1-server`, `oio-meta2-server`, `rawx`

##### SDS VERSION
```
4.1.21
```