### PR TITLE
account: fix listing container with delimiter

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -343,6 +343,11 @@ class AccountBackend(RedisConn):
 
     def _raw_listing(self, account_id, limit, marker, end_marker, delimiter,
                      prefix):
+        """Fetch tuple list of containers matching options.
+           Tuple is [(container|prefix),
+                     0 *reserved for objects*,
+                     0 *reserved for size*,
+                     0 for container, 1 for prefix]"""
         conn = self.conn
         if delimiter and not prefix:
             prefix = ''
@@ -403,7 +408,8 @@ class AccountBackend(RedisConn):
                                      end_marker=end_marker, prefix=prefix,
                                      delimiter=delimiter)
         pipeline = self.conn.pipeline(True)
-        for container in raw_list:
+        # skip prefix
+        for container in [entry for entry in raw_list if not entry[3]]:
             pipeline.hmget(AccountBackend.ckey(account_id, container[0]),
                            'objects', 'bytes')
         res = pipeline.execute()


### PR DESCRIPTION
##### SUMMARY

Invalid stats was provided when listing container with delimiter

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
account

##### SDS VERSION
```
openio 4.1.21.dev5
```

##### ADDITIONAL INFORMATION
Without fix
```
(oio) murlock@asus:~/openio/oio-sds/oio/account (4.1.x)*$ openio container list --oio-account AUTH_demo --delimiter % | grep ' t'
| titi | 0 | 0 |
| toto | 0 | 0 |
| tztz | 3164 | 1 |
(oio) murlock@asus:~/openio/oio-sds/oio/account (4.1.x)*$ openio container list --oio-account AUTH_demo --delimiter % --prefix t| grep ' t'
| titi | 0 | 0 |
| toto | 3164 | 1 |
| tztz | 0 | 0 |
```
With fix
```
(oio) murlock@asus:~/openio/oio-sds/oio/account (4.1.x)*$ openio container list --oio-account AUTH_demo --delimiter % | grep ' t'
| titi | 0 | 0 |
| toto | 3164 | 1 |
| tztz | 0 | 0 |
(oio) murlock@asus:~/openio/oio-sds/oio/account (4.1.x)*$ openio container list --oio-account AUTH_demo --delimiter % --prefix t| grep ' t'
| titi | 0 | 0 |
| toto | 3164 | 1 |
| tztz | 0 | 0 |
```