### PR TITLE
oio-meta*-rebuilder: Accept an input file

### DIFF
--- a/bin/oio-meta1-rebuilder
+++ b/bin/oio-meta1-rebuilder
@@ -35,7 +35,8 @@ def make_arg_parser():
                             help="Log address")
 
     descr = "Rebuild meta1 databases by setting 'last_rebuild' " \
-        "property in admin table, thus triggering a replication."
+            "property in admin table, thus triggering a replication." \
+            "And print the failed container IDs."
     parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
     parser.add_argument('namespace', help="Namespace")
     parser.add_argument('--report-interval', type=int,
@@ -46,6 +47,10 @@ def make_arg_parser():
                         help="Max prefixes per second per workers (30)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
+    ifile_help = "Read container IDs from this file instead of redis. " \
+                 "Each line should be formatted like 'container_id'."
+    parser.add_argument('--input-file', nargs='?',
+                        help=ifile_help)
 
     return parser
 
@@ -77,7 +82,8 @@ if __name__ == '__main__':
     logger = get_logger(conf, None, not args.quiet)
 
     try:
-        meta1_rebuilder = Meta1Rebuilder(conf, logger)
+        meta1_rebuilder = Meta1Rebuilder(conf, logger,
+                                         input_file=args.input_file)
         meta1_rebuilder.rebuilder_pass()
     except KeyboardInterrupt:
         logger.info('Exiting')

--- a/bin/oio-meta2-rebuilder
+++ b/bin/oio-meta2-rebuilder
@@ -35,7 +35,8 @@ def make_arg_parser():
                             help="Log address")
 
     descr = "Rebuild meta2 databases by setting 'last_rebuild' " \
-        "property in admin table, thus triggering a replication."
+            "property in admin table, thus triggering a replication. " \
+            "And print the failed container IDs."
     parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
     parser.add_argument('namespace', help="Namespace")
     parser.add_argument('--report-interval', type=int,
@@ -46,6 +47,10 @@ def make_arg_parser():
                         help="Max references per second per workers (30)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
+    ifile_help = "Read container IDs from this file instead of redis. " \
+                 "Each line should be formatted like 'container_id'."
+    parser.add_argument('--input-file', nargs='?',
+                        help=ifile_help)
 
     return parser
 
@@ -77,7 +82,8 @@ if __name__ == '__main__':
     logger = get_logger(conf, None, not args.quiet)
 
     try:
-        meta2_rebuilder = Meta2Rebuilder(conf, logger)
+        meta2_rebuilder = Meta2Rebuilder(conf, logger,
+                                         input_file=args.input_file)
         meta2_rebuilder.rebuilder_pass()
     except KeyboardInterrupt:
         logger.info('Exiting')

--- a/core/ext.c
+++ b/core/ext.c
@@ -106,25 +106,31 @@ gsize oio_ext_array_partition (gpointer *array, gsize len,
 	/* qualify each item, so that we call the predicate only once */
 	guchar *good = g_malloc0 (len);
 
-	for (gsize i=0; i<len ;i++)
+	guchar any = 0;
+	for (gsize i=0; i<len; i++) {
 		good[i] = 0 != ((*predicate) (array[i]));
+		any |= good[i];
+	}
 
 	/* partition the items, the predicate==TRUE first */
-	for (gsize i=0; i<len ;i++) {
-		if (good[i])
-			continue;
-		/* swap the items */
-		gchar *tmp = array[len-1];
-		array[len-1] = array[i];
-		array[i] = tmp;
-		/* swap the qualities */
-		gboolean b = good[len-1];
-		good[len-1] = good[i];
-		good[i] = b;
+	if (any) {
+		for (gsize i=0; i<len; i++) {
+			if (good[i])
+				continue;
+			/* swap the items */
+			gchar *tmp = array[len-1];
+			array[len-1] = array[i];
+			array[i] = tmp;
+			/* swap the qualities */
+			gboolean b = good[len-1];
+			good[len-1] = good[i];
+			good[i] = b;
 
-		-- len;
-		-- i;
-	}
+			-- len;
+			-- i;
+		}
+	} else
+		len = 0;
 
 	g_free (good);
 	return len;

--- a/oio/rebuilder/blob_rebuilder.py
+++ b/oio/rebuilder/blob_rebuilder.py
@@ -29,13 +29,11 @@ from oio.rebuilder.rebuilder import Rebuilder, RebuilderWorker
 
 class BlobRebuilder(Rebuilder):
 
-    def __init__(self, conf, logger, volume,
-                 input_file=None, try_chunk_delete=False,
+    def __init__(self, conf, logger, volume, try_chunk_delete=False,
                  beanstalkd_addr=None, **kwargs):
         super(BlobRebuilder, self).__init__(conf, logger, **kwargs)
         self.volume = volume
         self.rdir_client = RdirClient(conf, logger=self.logger)
-        self.input_file = input_file
         self.try_chunk_delete = try_chunk_delete
         self.beanstalkd_addr = beanstalkd_addr
         self.beanstalkd_tube = conf.get('beanstalkd_tube', 'rebuild')

--- a/oio/rebuilder/meta1_rebuilder.py
+++ b/oio/rebuilder/meta1_rebuilder.py
@@ -33,6 +33,9 @@ class Meta1Rebuilder(MetaRebuilder):
         return Meta1RebuilderWorker(self.conf, self.logger, **kwargs)
 
     def _fill_queue(self, queue, **kwargs):
+        if self._fill_queue_from_file(queue, **kwargs):
+            return
+
         prefixes = set()
 
         rawx_services = self.conscience.all_services('rawx')

--- a/oio/rebuilder/meta2_rebuilder.py
+++ b/oio/rebuilder/meta2_rebuilder.py
@@ -29,6 +29,9 @@ class Meta2Rebuilder(MetaRebuilder):
         return Meta2RebuilderWorker(self.conf, self.logger, **kwargs)
 
     def _fill_queue(self, queue, **kwargs):
+        if self._fill_queue_from_file(queue, **kwargs):
+            return
+
         accounts = self.api.account_list()
         for account in accounts:
             containers = self._full_container_list(account)

--- a/oio/rebuilder/rebuilder.py
+++ b/oio/rebuilder/rebuilder.py
@@ -31,9 +31,10 @@ class Rebuilder(object):
       `_get_report()`.
     """
 
-    def __init__(self, conf, logger, **kwargs):
+    def __init__(self, conf, logger, input_file=None, **kwargs):
         self.conf = conf
         self.logger = logger or get_logger(conf)
+        self.input_file = input_file
         self.nworkers = int_value(conf.get('workers'), 1)
 
     def rebuilder_pass(self, **kwargs):

--- a/oio/rebuilder/rebuilder.py
+++ b/oio/rebuilder/rebuilder.py
@@ -136,6 +136,7 @@ class RebuilderWorker(object):
                                      **kwargs))
                 report_time = now
                 self.last_reported = now
+                self.passes = 0
 
             self.rebuilder_time += (now - loop_time)
             queue.task_done()

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -158,7 +158,8 @@ static void _sort_services (struct client_ctx_s *ctx,
 		const char *k, gchar **m1uv) {
 	_debug_services ("PRE sort: ", m1uv);
 
-	gsize pivot = g_strv_length (m1uv);
+	gsize len = g_strv_length (m1uv);
+	gsize pivot = len;
 
 	/* prefer services recently available */
 	if (pivot > 1)
@@ -181,9 +182,22 @@ static void _sort_services (struct client_ctx_s *ctx,
 		}
 	}
 
-	/* If multiple available & preferred services, shuffle them */
-	if (pivot > 1 && oio_proxy_srv_shuffle)
-		oio_ext_array_shuffle ((void**)m1uv, pivot);
+	if (oio_proxy_srv_shuffle) {
+		switch (pivot) {
+			case 1:
+				break;
+			case 0:
+				/* If no available & preferred service, shuffle them */
+				if (len > 1)
+					pivot = len;
+				else
+					break;
+				// FALLTHROUGH
+			default:
+				/* If multiple available & preferred services, shuffle them */
+				oio_ext_array_shuffle((void**)m1uv, pivot);
+		}
+	}
 
 	_debug_services ("POST sort: ", m1uv);
 }


### PR DESCRIPTION
##### SUMMARY

- In the `proxy`, shuffle services if no preferred service
- Accept an input file for `oio-meta1-rebuilder` and `oio-meta2-rebuilder`
- For all rebuilder, reset the number of passes between each report

##### ISSUE TYPE

 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME

- `oio-meta1-rebuilder`
- `oio-meta2-rebuilder`
- `oio-blob-rebuilder`
- `proxy`

##### SDS VERSION

```
openio 4.1.22.dev19
```