### PR TITLE
Use only 'urllib3' imported with 'eventlet'

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -14,7 +14,6 @@
 # License along with this library.
 
 from urllib import urlencode
-from urllib3.exceptions import HTTPError
 
 from oio.common.utils import json as jsonlib, oio_reraise, true_value
 from oio.common.http import urllib3, get_pool_manager, \
@@ -139,7 +138,7 @@ class HttpApi(object):
                     body = jsonlib.loads(body)
                 except ValueError:
                     pass
-        except HTTPError as exc:
+        except urllib3.exceptions.HTTPError as exc:
             oio_exception_from_httperror(exc, out_headers.get('X-oio-req-id'))
         if resp.status >= 400:
             raise exceptions.from_response(resp, body)

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -15,9 +15,8 @@
 
 
 from eventlet import GreenPile
-from urllib3 import Timeout
-from urllib3.exceptions import HTTPError
-from oio.common.http import get_pool_manager, oio_exception_from_httperror
+from oio.common.http import urllib3, get_pool_manager, \
+        oio_exception_from_httperror
 from oio.common import exceptions as exc, utils
 from oio.common.constants import chunk_headers, chunk_xattr_keys_optional, \
         HEADER_PREFIX
@@ -83,7 +82,7 @@ class BlobClient(object):
             headers['X-oio-chunk-meta-container-id'] = cid
         timeout = kwargs.get('timeout')
         if not timeout:
-            timeout = Timeout(CHUNK_TIMEOUT)
+            timeout = urllib3.Timeout(CHUNK_TIMEOUT)
 
         def __delete_chunk(chunk_):
             try:
@@ -91,7 +90,7 @@ class BlobClient(object):
                     "DELETE", chunk_['url'], headers=headers, timeout=timeout)
                 resp.chunk = chunk_
                 return resp
-            except HTTPError as ex:
+            except urllib3.exceptions.HTTPError as ex:
                 ex.chunk = chunk_
                 return ex
 
@@ -126,7 +125,7 @@ class BlobClient(object):
         try:
             resp = self.http_pool.request(
                 'HEAD', url, headers=headers)
-        except HTTPError as ex:
+        except urllib3.exceptions.HTTPError as ex:
             oio_exception_from_httperror(ex, headers['X-oio-req-id'])
         if resp.status == 200:
             if not _xattr:

--- a/oio/cli/admin/directory.py
+++ b/oio/cli/admin/directory.py
@@ -240,9 +240,9 @@ class DirectoryWarmup(DirectoryCmd):
 
 class WarmupWorker(object):
     def __init__(self, conf, log):
-        import urllib3
+        from oio.common.http import get_pool_manager
         self.log = log
-        self.pool = urllib3.PoolManager()
+        self.pool = get_pool_manager()
         self.url_prefix = 'http://%s/v3.0/%s/admin/status?type=meta1&cid=' % (
                 conf['proxyd_url'], conf['namespace'])
 

--- a/tests/functional/api/test_proxy_client.py
+++ b/tests/functional/api/test_proxy_client.py
@@ -15,7 +15,7 @@
 from tests.utils import BaseTestCase
 from mock import MagicMock as Mock
 from oio.common.client import ProxyClient
-from urllib3 import HTTPResponse
+from oio.common.http import urllib3
 from oio.common.exceptions import ServiceBusy, OioException
 
 
@@ -28,7 +28,8 @@ class TestProxyClient(BaseTestCase):
 
     def test_error_503(self):
         self.proxy_client.pool_manager.request = Mock(
-            return_value=HTTPResponse(status=503, reason="Service busy"))
+            return_value=urllib3.HTTPResponse(status=503,
+                                              reason="Service busy"))
         self.assertRaises(ServiceBusy,
                           self.proxy_client._direct_request, "GET", "test")
 


### PR DESCRIPTION
##### SUMMARY

Use only 'urllib3' imported with 'eventlet', otherwise the I/O of 'urllib3' is blocking.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.1.22.dev33
```