### PR TITLE
Use the same blob client for the content factory

### DIFF
--- a/oio/content/content.py
+++ b/oio/content/content.py
@@ -25,14 +25,15 @@ from oio.common.constants import OIO_VERSION
 class Content(object):
 
     def __init__(self, conf, container_id, metadata, chunks, storage_method,
-                 account, container_name, container_client=None, logger=None):
+                 account, container_name, blob_client=None,
+                 container_client=None, logger=None):
         self.conf = conf
         self.container_id = container_id
         self.metadata = metadata
         self.chunks = ChunksHelper(chunks)
         self.storage_method = storage_method
         self.logger = logger or get_logger(self.conf)
-        self.blob_client = BlobClient()
+        self.blob_client = (blob_client or BlobClient())
         self.container_client = (container_client
                                  or ContainerClient(self.conf,
                                                     logger=self.logger))

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -17,6 +17,7 @@ from oio.common.exceptions import ContentNotFound
 from oio.common.exceptions import NotFound
 from oio.common.utils import get_logger, GeneratorIO
 from oio.container.client import ContainerClient
+from oio.blob.client import BlobClient
 from oio.content.plain import PlainContent
 from oio.content.ec import ECContent
 from oio.common.storage_method import STORAGE_METHODS
@@ -30,6 +31,7 @@ class ContentFactory(object):
         self.logger = logger or get_logger(conf)
         self.container_client = ContainerClient(conf, logger=self.logger,
                                                 **kwargs)
+        self.blob_client = BlobClient(**kwargs)
 
     def get(self, container_id, content_id, account=None,
             container_name=None):
@@ -51,9 +53,10 @@ class ContentFactory(object):
                 container_name = container_info['sys.user.name']
         cls = ECContent if storage_method.ec else PlainContent
         return cls(self.conf, container_id, meta, chunks, storage_method,
-                   account,
-                   container_name,
-                   container_client=self.container_client, logger=self.logger)
+                   account, container_name,
+                   container_client=self.container_client,
+                   blob_client=self.blob_client,
+                   logger=self.logger)
 
     def new(self, container_id, path, size, policy, account=None,
             container_name=None, **kwargs):


### PR DESCRIPTION
##### SUMMARY

Use the same blob client, so the same connection pool, for the content factory.

##### ISSUE TYPE

 - Improvement Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.1.22.dev34
```