### PR TITLE
rebuilder: Fix the import of 'get_logger'

### DIFF
--- a/bin/oio-meta1-rebuilder
+++ b/bin/oio-meta1-rebuilder
@@ -19,7 +19,7 @@
 import argparse
 
 from oio.rebuilder.meta1_rebuilder import Meta1Rebuilder
-from oio.common.utils import get_logger
+from oio.common.logger import get_logger
 
 
 def make_arg_parser():

--- a/bin/oio-meta2-rebuilder
+++ b/bin/oio-meta2-rebuilder
@@ -19,7 +19,7 @@
 import argparse
 
 from oio.rebuilder.meta2_rebuilder import Meta2Rebuilder
-from oio.common.utils import get_logger
+from oio.common.logger import get_logger
 
 
 def make_arg_parser():


### PR DESCRIPTION
##### SUMMARY

Fix the import of 'get_logger'.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `oio-meta1-rebuilder`
- `oio-meta2-rebuilder`

##### SDS VERSION

```
openio 4.1.22.dev32
```