### PR TITLE
Python API: allow disabling client-side chunk checksums

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -75,11 +75,15 @@ class WriteHandler(object):
     def __init__(self, source, sysmeta, chunk_preparer,
                  storage_method, headers=None,
                  connection_timeout=None, write_timeout=None,
-                 read_timeout=None, **_kwargs):
+                 read_timeout=None, chunk_checksum_algo='md5',
+                 **_kwargs):
         """
         :param connection_timeout: timeout to establish the connection
         :param write_timeout: timeout to send a buffer of data
         :param read_timeout: timeout to read a buffer of data from source
+        :param chunk_checksum_algo: algorithm to use to compute chunk
+            checksums locally. Can be `None` to disable local checksum
+            computation and let the rawx compute it (will be md5).
         """
         if isinstance(source, IOBase):
             self.source = BufferedReader(source)
@@ -98,6 +102,7 @@ class WriteHandler(object):
         self.connection_timeout = connection_timeout or CONNECTION_TIMEOUT
         self.write_timeout = write_timeout or CHUNK_TIMEOUT
         self.read_timeout = read_timeout or CLIENT_TIMEOUT
+        self.chunk_checksum_algo = chunk_checksum_algo
 
     def stream(self):
         """
@@ -505,11 +510,13 @@ class ChunkReader(object):
 class MetachunkWriter(object):
     """Base class for metachunk writers"""
 
-    def __init__(self, storage_method=None, quorum=None, **_kwargs):
+    def __init__(self, storage_method=None, quorum=None,
+                 chunk_checksum_algo='md5', **_kwargs):
         self.storage_method = storage_method
         self._quorum = quorum
         if storage_method is None and quorum is None:
             raise ValueError('Missing storage_method or quorum')
+        self.chunk_checksum_algo = chunk_checksum_algo
 
     @property
     def quorum(self):

--- a/oio/api/replication.py
+++ b/oio/api/replication.py
@@ -45,9 +45,9 @@ class FakeChecksum(object):
 class ReplicatedMetachunkWriter(io.MetachunkWriter):
     def __init__(self, sysmeta, meta_chunk, checksum, storage_method,
                  quorum=None, connection_timeout=None, write_timeout=None,
-                 read_timeout=None, headers=None):
+                 read_timeout=None, headers=None, **kwargs):
         super(ReplicatedMetachunkWriter, self).__init__(
-            storage_method=storage_method, quorum=quorum)
+            storage_method=storage_method, quorum=quorum, **kwargs)
         self.sysmeta = sysmeta
         self.meta_chunk = meta_chunk
         self.checksum = checksum
@@ -59,7 +59,10 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
     def stream(self, source, size=None):
         bytes_transferred = 0
         meta_chunk = self.meta_chunk
-        meta_checksum = hashlib.md5()
+        if self.chunk_checksum_algo:
+            meta_checksum = hashlib.new(self.chunk_checksum_algo)
+        else:
+            meta_checksum = None
         pile = GreenPile(len(meta_chunk))
         failed_chunks = []
         current_conns = []
@@ -103,7 +106,8 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
                                     conn.queue.put('0\r\n\r\n')
                             break
                     self.checksum.update(data)
-                    meta_checksum.update(data)
+                    if meta_checksum:
+                        meta_checksum.update(data)
                     bytes_transferred += len(data)
                     # copy current_conns to be able to remove a failed conn
                     for conn in current_conns[:]:
@@ -141,18 +145,18 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
                 continue
             pile.spawn(self._get_response, conn)
 
-        meta_checksum_hex = meta_checksum.hexdigest()
         for (conn, resp) in pile:
             if resp:
-                self._handle_resp(conn, resp, meta_checksum_hex,
-                                  success_chunks, failed_chunks)
+                self._handle_resp(
+                    conn, resp,
+                    meta_checksum.hexdigest() if meta_checksum else None,
+                    success_chunks, failed_chunks)
         self.quorum_or_fail(success_chunks, failed_chunks)
 
         for chunk in success_chunks:
             chunk["size"] = bytes_transferred
-            chunk["hash"] = meta_checksum_hex
 
-        return bytes_transferred, meta_checksum_hex, success_chunks
+        return bytes_transferred, success_chunks[0]['hash'], success_chunks
 
     def _connect_put(self, chunk):
         """
@@ -231,7 +235,8 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
                              conn.chunk, resp.status)
             else:
                 rawx_checksum = resp.getheader(chunk_headers['chunk_hash'])
-                if rawx_checksum and rawx_checksum.lower() != checksum:
+                if rawx_checksum and checksum and \
+                        rawx_checksum.lower() != checksum:
                     conn.failed = True
                     conn.chunk['error'] = \
                         "checksum mismatch: %s (local), %s (rawx)" % \
@@ -240,6 +245,7 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
                     logger.error("%s: %s",
                                  conn.chunk['url'], conn.chunk['error'])
                 else:
+                    conn.chunk['hash'] = checksum or rawx_checksum
                     successes.append(conn.chunk)
         conn.close()
 
@@ -262,9 +268,9 @@ class ReplicatedWriteHandler(io.WriteHandler):
                 connection_timeout=self.connection_timeout,
                 write_timeout=self.write_timeout,
                 read_timeout=self.read_timeout,
-                headers=self.headers)
-            bytes_transferred, _checksum, chunks = handler.stream(self.source,
-                                                                  size)
+                headers=self.headers,
+                chunk_checksum_algo=self.chunk_checksum_algo)
+            bytes_transferred, _h, chunks = handler.stream(self.source, size)
             content_chunks += chunks
 
             total_bytes_transferred += bytes_transferred

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -44,7 +44,7 @@ object_headers = {
     "chunk_method": "%schunk-method" % OBJECT_METADATA_PREFIX
 }
 
-chunk_headers = {
+CHUNK_HEADERS = {
     "container_id": "%scontainer-id" % CHUNK_METADATA_PREFIX,
     "chunk_id": "%schunk-id" % CHUNK_METADATA_PREFIX,
     "chunk_hash": "%schunk-hash" % CHUNK_METADATA_PREFIX,
@@ -60,6 +60,8 @@ chunk_headers = {
     "full_path": "%sfull-path" % CHUNK_METADATA_PREFIX,
     "oio_version": "%soio-version" % CHUNK_METADATA_PREFIX,
 }
+# TODO(FVE): remove from versions >= 4.2.0
+chunk_headers = CHUNK_HEADERS
 
 chunk_xattr_keys = {
     'chunk_hash': 'grid.chunk.hash',

--- a/tests/unit/api/__init__.py
+++ b/tests/unit/api/__init__.py
@@ -20,7 +20,9 @@ from oio.api.object_storage import ObjectStorageApi
 from oio.directory.client import DirectoryClient
 
 CHUNK_SIZE = 1048576
-EMPTY_CHECKSUM = 'd41d8cd98f00b204e9800998ecf8427e'
+EMPTY_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
+EMPTY_SHA256 = \
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
 
 class FakeAPI(object):


### PR DESCRIPTION
##### SUMMARY
Allow disabling client-side chunk checksums, to reduce CPU usage during upload.



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.1.22.dev39
```


##### ADDITIONAL INFORMATION
This modifications prepares a future evolution where the checksum algorithm will be selectable. Only `'md5'` (default) and `None` (disable client-side checksums) are supported at the moment.
