### PR TITLE
tests: run coverage on more files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
   - export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
-  - python setup.py install
+  - python setup.py develop
   - bash ./tools/oio-check-version.sh
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"
   - make coverage_init


### PR DESCRIPTION
Travis was using coverage on installed files and was ignored by codecov,
our python module will be used with `python setup.py develop` to fix that.

##### SUMMARY

Coverage was not done

##### ISSUE TYPE

 - Test Pull Request

##### COMPONENT NAME

Python API

##### SDS VERSION

```
openio 4.1.22.dev38
```
