### PR TITLE
rawx, sqliterepo: replace strncpy by g_strlcpy

### DIFF
--- a/rawx-apache2/src/mod_dav_rawx.c
+++ b/rawx-apache2/src/mod_dav_rawx.c
@@ -139,7 +139,7 @@ dav_rawx_cmd_gridconfig_docroot(cmd_parms *cmd, void *config UNUSED, const char 
 
 	dav_rawx_server_conf *conf =
 		ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-	strncpy(conf->docroot, arg1, sizeof(conf->docroot));
+	g_strlcpy(conf->docroot, arg1, sizeof(conf->docroot));
 	return NULL;
 }
 
@@ -148,7 +148,7 @@ dav_rawx_cmd_gridconfig_namespace(cmd_parms *cmd, void *config UNUSED, const cha
 {
 	dav_rawx_server_conf *conf =
 		ap_get_module_config(cmd->server->module_config, &dav_rawx_module);
-	strncpy(conf->ns_name, arg1, sizeof(conf->ns_name));
+	g_strlcpy(conf->ns_name, arg1, sizeof(conf->ns_name));
 	return NULL;
 }
 

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1063,7 +1063,7 @@ _LOCKED_init_member(struct election_manager_s *manager,
 
 		member->manager = manager;
 		member->last_status = oio_ext_monotonic_time ();
-		strncpy(member->key, key, sizeof(member->key));
+		g_strlcpy(member->key, key, sizeof(member->key));
 		g_strlcpy(member->inline_name.base, n->base, sizeof(member->inline_name.base));
 		g_strlcpy(member->inline_name.type, n->type, sizeof(member->inline_name.type));
 		g_strlcpy(member->inline_name.ns, n->ns, sizeof(member->inline_name.ns));


### PR DESCRIPTION
##### SUMMARY
Replace `strncpy` by `g_strlcpy` to avoid warnings with recent versions of GCC.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- rawx
- sqliterepo

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.1.22.dev65
```


##### ADDITIONAL INFORMATION
Errors were like
```
/home/fvennetier/src/public_git/oio-sds/sqliterepo/election.c:1066:3: error: ‘strncpy’ specified bound 65 equals destination size [-Werror=stringop-truncation]
   strncpy(member->key, key, sizeof(member->key));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```