### PR TITLE
oio-reset: Allow a specific data directory for the services

### DIFF
--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -232,7 +232,7 @@ grid_hash_depth        1
 grid_fsync             disabled
 
 # At the end of an upload, perform a fsync() on the directory holding the chunk
-grid_fsync_dir         enabled
+grid_fsync_dir         disabled
 
 # Preallocate space for the chunk file (enabled by default)
 #grid_fallocate enabled

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -959,7 +959,6 @@ CFGDIR = SDSDIR + '/conf'
 RUNDIR = SDSDIR + '/run'
 LOGDIR = SDSDIR + '/logs'
 SPOOLDIR = SDSDIR + '/spool'
-DATADIR = SDSDIR + '/data'
 WATCHDIR = SDSDIR + '/conf/watch'
 TMPDIR = '/tmp'
 CODEDIR = '@CMAKE_INSTALL_PREFIX@'
@@ -1096,6 +1095,8 @@ def generate(options):
     backblaze_account_id = options.get('backblaze', {}).get(ACCOUNT_ID)
     backblaze_bucket_name = options.get('backblaze', {}).get(BUCKET_NAME)
     backblaze_app_key = options.get('backblaze', {}).get(APPLICATION_KEY)
+
+    DATADIR = options.get('DATADIR', SDSDIR + '/data')
 
     key_file = options.get(KEY_FILE, CFGDIR + '/' + 'application_keys.cfg')
     ENV = dict(ZK_CNXSTRING=options.get('ZK'),
@@ -1575,6 +1576,9 @@ def main():
     parser.add_argument("-p", "--port",
                         type=int, default=6000,
                         help="Specify the first port of the range")
+    parser.add_argument("-D", "--data",
+                        action="store", type=str, default=None,
+                        help="Specify a DATA directory")
     parser.add_argument("--profile", choices=['default', 'valgrind', 'callgrind'],
                         help="Launch SDS with specific tool")
     parser.add_argument("namespace",
@@ -1599,6 +1603,10 @@ def main():
     opts['beanstalkd'] = {SVC_NB: None, SVC_HOSTS: None}
 
     options = parser.parse_args()
+
+    if options.data:
+        opts['DATADIR'] = options.data
+
     if options.config:
         for path in options.config:
             with open(path, 'r') as f:

--- a/tools/oio-reset.sh
+++ b/tools/oio-reset.sh
@@ -27,13 +27,15 @@ SDS=$OIO/sds
 GRIDINIT_SOCK=${SDS}/run/gridinit.sock
 BOOTSTRAP_CONFIG=
 PROFILE=
+DATADIR=
 
 ZKSLOW=0
 verbose=0
 OPENSUSE=`grep -i opensuse /etc/*release || echo -n ''`
 
-while getopts "P:I:N:f:Z:p:Cvb" opt; do
+while getopts "D:P:I:N:f:Z:p:Cvb" opt; do
     case $opt in
+        D) DATADIR="${OPTARG}" ;;
         P) PORT="${OPTARG}" ;;
         I) IP="${OPTARG}" ;;
         N) NS="${OPTARG}" ;;
@@ -116,6 +118,7 @@ done
 mkdir -p "$OIO" && cd "$OIO" && (rm -rf sds.conf sds/{conf,data,run,logs})
 bootstrap_opt=
 if [[ -n "${PORT}" ]] ; then bootstrap_opt="${bootstrap_opt} --port ${PORT}" ; fi
+if [[ -n "${DATADIR}" ]] ; then bootstrap_opt="${bootstrap_opt} --data ${DATADIR}" ; fi
 if [[ -n "${PROFILE}" ]] ; then bootstrap_opt="${bootstrap_opt} --profile ${PROFILE}" ; fi
 ${PREFIX}-bootstrap.py $bootstrap_opt -d ${BOOTSTRAP_CONFIG} "$NS" "$IP" > /tmp/oio-bootstrap.$$
 


### PR DESCRIPTION
##### SUMMARY
Add an option `oio-reset.sh` and also to `oio-bootstrap.py` that configure a specific directory for the data of the services, instead of `~/.oio/sds/data`.

##### ISSUE TYPE
Enhancement

##### COMPONENT NAME
* `oio-reset` 
* `oio-bootstrap`

##### SDS VERSION
`4.1.21`
