### PR TITLE
oio-reset: Simplify without `oio-wait-scored.sh`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
   - export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
+  - git fetch --tags
   - python setup.py develop
   - bash ./tools/oio-check-version.sh
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"

--- a/oio/cli/admin/cluster.py
+++ b/oio/cli/admin/cluster.py
@@ -234,6 +234,12 @@ class ClusterWait(lister.Lister):
             nargs='*',
             help='Service Type(s) to wait for (or all if unset)')
         parser.add_argument(
+            '-n', '--count',
+            metavar='<count>',
+            type=int,
+            default=0,
+            help='How many services are expected')
+        parser.add_argument(
             '-d', '--delay',
             metavar='<delay>',
             type=float,
@@ -245,6 +251,11 @@ class ClusterWait(lister.Lister):
             type=int,
             default=0,
             help='Minimum score value required for the chosen services')
+        parser.add_argument(
+            '-u', '--unlock',
+            action='store_true',
+            default=False,
+            help='Should the service be unlocked.')
         return parser
 
     def _wait(self, parsed_args):
@@ -260,6 +271,15 @@ class ClusterWait(lister.Lister):
         exc_msg = ("Timeout ({0}s) while waiting for the services to get a "
                    "score > {1}, still {2} are not")
 
+        def maybe_unlock(allsrv):
+            if not parsed_args.unlock:
+                return
+            self.app.client_manager.admin.cluster_unlock_score(allsrv)
+
+        def check_deadline():
+            if now() > deadline:
+                raise Exception(exc_msg.format(delay, min_score, ko))
+
         while True:
             descr = []
             for type_ in types:
@@ -269,15 +289,25 @@ class ClusterWait(lister.Lister):
                 descr += tmp
             ko = len([s['score'] for s in descr if s['score'] <= min_score])
             if ko == 0:
+                # If a minimum has been specified, let's check we have enough
+                # services
+                if parsed_args.count:
+                    ok = len([s for s in descr if s['score'] > min_score])
+                    if ok < parsed_args.count:
+                        self.log.debug("Only %d services up", ok)
+                        check_deadline()
+                        maybe_unlock(descr)
+                        sleep(1.0)
+                        continue
+                # No service down, and enough services, we are done.
                 for d in descr:
                     yield d['type'], d['addr'], d['score']
                 return
             else:
                 self.log.debug("Still %d services down", ko)
-                if now() > deadline:
-                    raise Exception(exc_msg.format(delay, min_score, ko))
-                else:
-                    sleep(1.0)
+                check_deadline()
+                maybe_unlock(descr)
+                sleep(1.0)
 
     def take_action(self, parsed_args):
         columns = ('Type', 'Service', 'Score')

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -e
-
-set -e
 set -x
 export COLUMNS=512 LANG= LANGUAGE=
 
@@ -43,15 +41,16 @@ function dump_syslog {
         cmd="sudo tail"
     fi
     $cmd -n 500 /var/log/syslog
-    pip list
-    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
 }
 
-function dump_coredump {
+function trap_exit {
+	set +e
+    #pip list
+    gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
+	#dump_syslog
     oio-gdb.py
 }
 
-#trap dump_syslog EXIT
 trap dump_coredump EXIT
 
 is_running_test_suite () {

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -125,7 +125,7 @@ test_proxy_forward () {
 
 func_tests () {
 	randomize_env
-    oio-reset.sh -N $OIO_NS $@
+    oio-reset.sh -v -N $OIO_NS $@
 
 	test_proxy_forward
 
@@ -169,7 +169,7 @@ func_tests () {
 
 test_meta2_filters () {
 	randomize_env
-    oio-reset.sh -N $OIO_NS $@
+    oio-reset.sh -v -N $OIO_NS $@
 
     cd $SRCDIR
     tox -e coverage
@@ -181,7 +181,7 @@ test_meta2_filters () {
 
 test_cli () {
     randomize_env
-    oio-reset.sh -N $OIO_NS $@
+    oio-reset.sh -v -N $OIO_NS $@
 
     cd $SRCDIR
     tox -e cli

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -47,7 +47,7 @@ function trap_exit {
 	set +e
     #pip list
     gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
-	#dump_syslog
+    #dump_syslog
     oio-gdb.py
 }
 

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -17,16 +17,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -e
 set -x
-export COLUMNS=512 LANG= LANGUAGE=
 
 export G_DEBUG=fatal_warnings
 export G_SLICE=always-malloc
 
 export PYTHON=python
-
 if [ "${PYTHON_COVERAGE:-}" == "1" ]; then
     PYTHON="coverage run -p --omit=/home/travis/oio/lib/python2.7/*"
 fi
+
+OIO_RESET="oio-reset.sh -v"
 
 SRCDIR=$PWD
 WRKDIR=$PWD
@@ -51,7 +51,7 @@ function trap_exit {
     oio-gdb.py
 }
 
-trap dump_coredump EXIT
+trap trap_exit EXIT
 
 is_running_test_suite () {
     [ -z "$TEST_SUITE" ] || [ "${TEST_SUITE/*$1*/$1}" == "$1" ]
@@ -124,7 +124,7 @@ test_proxy_forward () {
 
 func_tests () {
 	randomize_env
-    oio-reset.sh -v -N $OIO_NS $@
+    $OIO_RESET -N $OIO_NS $@
 
 	test_proxy_forward
 
@@ -168,7 +168,7 @@ func_tests () {
 
 test_meta2_filters () {
 	randomize_env
-    oio-reset.sh -v -N $OIO_NS $@
+    $OIO_RESET -N $OIO_NS $@
 
     cd $SRCDIR
     tox -e coverage
@@ -180,7 +180,7 @@ test_meta2_filters () {
 
 test_cli () {
     randomize_env
-    oio-reset.sh -v -N $OIO_NS $@
+    $OIO_RESET -N $OIO_NS $@
 
     cd $SRCDIR
     tox -e cli


### PR DESCRIPTION
##### SUMMARY
Simplify `oio-reset.sh` to make a better use of `openio`.

Prior to this PR, `oio-reset.sh` used an archaic version of `openio cluster wait`. The rewrite required to adapt `cluster wait` but it now helps debugging the Travis CI with less (but unified) tools that propose a decent verbosity.

Rewrite `oio-wait-scored.sh` on top of the `cluster wait` subcommand of `openio`, for the sake of the backward compliance.

##### ISSUE TYPE
Enhancement

##### COMPONENT NAME
`oio-reset`

##### SDS VERSION
`4.1.21`