### PR TITLE
Python API: fix kwargs hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
   - export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install
+  - git fetch --tags
   - python setup.py develop
   - bash ./tools/oio-check-version.sh
   - export G_DEBUG_LEVEL=D PATH="$PATH:/tmp/oio/bin" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/tmp/oio/lib"

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -314,7 +314,7 @@ class ObjectStorageApi(object):
         - `write_timeout`: `float`
     """
     TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
-    EXTRA_KEYWORDS = ('chunk_checksum_algo')
+    EXTRA_KEYWORDS = ('chunk_checksum_algo', )
 
     def __init__(self, namespace, logger=None, **kwargs):
         """


### PR DESCRIPTION
##### SUMMARY
Fix kwargs hack in ObjectStorageApi preventing usage of
chunk_checksum_algo keyword.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
```
openio 4.1.23.dev2
```