### PR TITLE
Python API: fix chunk full_path conversion

### DIFF
--- a/oio/common/http.py
+++ b/oio/common/http.py
@@ -231,7 +231,11 @@ def headers_from_object_metadata(metadata):
             out[chunk_headers[key]] = metadata[key]
 
     header = {k: quote_plus(str(v)) for (k, v) in out.iteritems()}
-    header[chunk_headers["full_path"]] = ','.join(metadata['full_path'])
+    full_path = metadata['full_path']
+    if isinstance(full_path, basestring):
+        header[chunk_headers['full_path']] = full_path
+    else:
+        header[chunk_headers['full_path']] = ','.join(full_path)
     return header
 
 


### PR DESCRIPTION
##### SUMMARY
When `full_path` was a string (instead of a list or tuple), it was split
and re-assembled with commas between letters, triggering the creation of
many extended attributes on each chunk.

Thanks to @AymericDu 🦁

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
```
openio 4.1.23.dev13
```
