### PR TITLE
proxy, Python API: fix missing object error codes

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -133,13 +133,23 @@ def handle_container_not_found(fnc):
 
 
 def handle_object_not_found(fnc):
+    """
+    Catch `oio.common.exceptions.NotFound` exceptions and raise either
+    `oio.common.exceptions.NoSuchContainer` or
+    `oio.common.exceptions.NoSuchObject` respectively if the container
+    is missing or the object is missing.
+    """
     @wraps(fnc)
     def _wrapped(self, account, container, obj, *args, **kwargs):
         try:
             return fnc(self, account, container, obj, *args, **kwargs)
-        except exc.NotFound as e:
-            e.message = "Object '%s' does not exist." % obj
-            raise exc.NoSuchObject(e)
+        except exc.NotFound as err:
+            if err.status == 406:
+                err.message = "Container '%s' does not exist." % container
+                raise exc.NoSuchContainer(err)
+            else:
+                err.message = "Object '%s' does not exist." % obj
+                raise exc.NoSuchObject(err)
 
     return _wrapped
 

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1728,8 +1728,6 @@ static enum http_rc_e action_m2_content_touch (struct req_args_s *args,
 
 	PACKER_VOID(_pack) { return m2v2_remote_pack_TOUCHC (args->url); }
 	GError *err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
-	if (err && CODE_IS_NOTFOUND(err->code))
-		return _reply_forbidden_error (args, err);
 	return _reply_m2_error (args, err);
 }
 
@@ -1757,8 +1755,6 @@ static enum http_rc_e action_m2_content_link (struct req_args_s *args,
 
 	PACKER_VOID(_pack) { return m2v2_remote_pack_LINK (args->url); }
 	err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
-	if (err && CODE_IS_NOTFOUND(err->code))
-		return _reply_forbidden_error (args, err);
 	return _reply_m2_error (args, err);
 }
 
@@ -1792,8 +1788,6 @@ static enum http_rc_e action_m2_content_propset (struct req_args_s *args,
 	PACKER_VOID(_pack) { return m2v2_remote_pack_PROP_SET (args->url, flags, beans); }
 	GError *err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
 	_bean_cleanl2 (beans);
-	if (err && CODE_IS_NOTFOUND(err->code))
-		return _reply_forbidden_error (args, err);
 	return _reply_m2_error (args, err);
 }
 
@@ -1811,8 +1805,6 @@ static enum http_rc_e action_m2_content_propdel (struct req_args_s *args,
 	PACKER_VOID(_pack) { return m2v2_remote_pack_PROP_DEL (args->url, namev); }
 	err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
 	g_strfreev(namev);
-	if (err && CODE_IS_NOTFOUND(err->code))
-		return _reply_forbidden_error (args, err);
 	return _reply_m2_error (args, err);
 }
 
@@ -2068,7 +2060,5 @@ enum http_rc_e action_content_copy (struct req_args_s *args) {
 	}
 	GError *err = _resolve_meta2 (args, _prefer_master(), _pack, NULL);
 	oio_url_pclean(&target_url);
-	if (err && CODE_IS_NOTFOUND(err->code))
-		return _reply_forbidden_error (args, err);
 	return _reply_m2_error (args, err);
 }

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -560,7 +560,7 @@ class TestMeta2Contents(BaseTestCase):
         # No user, no container, no content
         resp = self.request('POST', self.url_content('copy'),
                             headers=headers, params=params)
-        self.assertError(resp, 403, 406)
+        self.assertError(resp, 404, 406)
 
         # No content
         data = json.dumps({'properties': {}})
@@ -569,7 +569,7 @@ class TestMeta2Contents(BaseTestCase):
         self.assertEqual(resp.status, 201)
         resp = self.request('POST', self.url_content('copy'),
                             headers=headers, params=params)
-        self.assertError(resp, 403, 420)
+        self.assertError(resp, 404, 420)
 
     def test_cycle_properties(self):
         path = random_content()
@@ -636,7 +636,7 @@ class TestMeta2Contents(BaseTestCase):
         self.assertError(resp, 404, 406)
 
         resp = self.request('POST', self.url_content('touch'), params=params)
-        self.assertError(resp, 403, 406)
+        self.assertError(resp, 404, 406)
 
         resp = self.request('POST', self.url_content('prepare'),
                             data=json.dumps({'size': '1024'}),


### PR DESCRIPTION
##### SUMMARY
Before that commit, the proxy used to return a 403 error code indifferently when a container or an object was missing. It is now returning a 404 error code, and the body of the response is telling if the container is missing (extended code 406) or the object is missing (extended code 420).

This applies to the following oio-proxy routes:
- `content/touch`
- `content/link`
- `content/set_properties`
- `content/del_properties`
- `content/copy`

The other routes were already responding as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- oio-proxy
- Python API

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.1.23.dev14
```