### PR TITLE
Python API: disable autocreate feature on demand

### DIFF
--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -79,6 +79,14 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
 
         parser = super(CreateObject, self).get_parser(prog_name)
         self.patch_parser(parser)
+        # TODO(mb): manage --opt and --no-opt
+        parser.add_argument(
+            '--no-autocreate',
+            help=("Forbid autocreation of container if nonexistent"),
+            action="store_false",
+            dest="autocreate",
+            default=True
+        )
         parser.add_argument(
             'objects',
             metavar='<filename>',
@@ -126,6 +134,7 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
         objs = parsed_args.objects
         names = parsed_args.name
         key_file = parsed_args.key_file
+        autocreate = parsed_args.autocreate
         if key_file and key_file[0] != '/':
             key_file = os.getcwd() + '/' + key_file
 
@@ -148,7 +157,8 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
                         policy=policy,
                         metadata=properties,
                         key_file=key_file,
-                        mime_type=parsed_args.mime_type)
+                        mime_type=parsed_args.mime_type,
+                        autocreate=autocreate)
 
                     results.append((name, data[1], data[2].upper(), 'Ok'))
             except KeyboardInterrupt:

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -371,8 +371,7 @@ class ContainerClient(ProxyClient):
         if chunk_method is not None:
             hdrs['x-oio-content-meta-chunk-method'] = chunk_method
         resp, body = self._direct_request(
-            'POST', uri, data=data, params=params, autocreate=True,
-            headers=hdrs, **kwargs)
+            'POST', uri, data=data, params=params, headers=hdrs, **kwargs)
         return resp, body
 
     def content_drain(self, account=None, reference=None, path=None, cid=None,

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -614,6 +614,19 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.assertEqual(len(data), 128)
         self.assertEqual(data, "1" * 128)
 
+    def test_object_simple_fast_copy_different_container_no_autocreate(self):
+        target_container = random_str(16)
+        link_container = random_str(16)
+        target_obj = random_str(16)
+        link_obj = random_str(16)
+        self.api.object_create(self.account, target_container, data="1"*128,
+                               obj_name=target_obj)
+        self.assertRaises(
+            exc.NotFound,
+            self.api.object_fastcopy, self.account, target_container,
+            target_obj, self.account, link_container, link_obj,
+            autocreate=False)
+
     def test_object_simple_fast_copy_same_container(self):
         container = random_str(16)
         target_obj = random_str(16)
@@ -802,3 +815,15 @@ class TestObjectList(ObjectStorageApiTestBase):
         self.assertIn('truncated', res)
         self.assertFalse(res['objects'])
         self.assertListEqual(['2/'], res['prefixes'])
+
+    def test_object_create_without_autocreate_and_missing_container(self):
+        name = random_str(32)
+        self.assertRaises(
+            exc.NoSuchContainer, self.api.object_create, self.account, name,
+            data="data", obj_name=name, autocreate=False)
+
+    def test_object_create_without_autocreate_and_existing_container(self):
+        name = random_str(32)
+        self._create(name)
+        self.api.object_create(self.account, name, data="data", obj_name=name,
+                               autocreate=False)

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -643,7 +643,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         link_obj = random_str(16)
         self.api.object_create(self.account, target_container, data="1"*128,
                                obj_name=target_obj)
-        self.api.object_create(self.account, target_container, data="1"*128,
+        self.api.object_create(self.account, target_container, data="0"*128,
                                obj_name=link_obj)
         self.api.object_fastcopy(self.account, target_container, target_obj,
                                  self.account, link_container, link_obj)

--- a/tests/functional/cli/storage/test_obj.py
+++ b/tests/functional/cli/storage/test_obj.py
@@ -45,6 +45,18 @@ class ObjTest(CliTestCase):
             self._test_obj(f.name, test_content, self.CONTAINER_NAME)
         self._test_many_obj()
 
+    def test_obj_without_autocreate(self):
+        with tempfile.NamedTemporaryFile() as f:
+            test_content = 'test content'
+            f.write(test_content)
+            f.flush()
+
+            self.assertRaises(
+                CommandFailed,
+                self.openio,
+                'object create --no-autocreate ' +
+                uuid.uuid4().hex + ' ' + f.name)
+
     def _test_many_obj(self):
         cname = self.CONTAINER_NAME
         opts = self.get_opts([], 'json')


### PR DESCRIPTION
##### SUMMARY

The autocreate feature on API Python was hardcoded

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
```
openio 4.1.23.dev20
```


##### ADDITIONAL INFORMATION
Default value of autocreate option is still True to avoid breaking backward compat
