### PR TITLE
metautils,sqliterepo: cheeseparing around wasted CPU cycles

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -1148,9 +1148,9 @@ Used by `gcc`
 
 ### sqliterepo.election.lock_alert_delay
 
-> .
+> Only effective when built in DEBUG mode. Dump the long critical sections around the elections lock, when the lock is held for longer then this threshold (in microseconds).
 
- * default: **50**
+ * default: **200**
  * type: gint64
  * cmake directive: *OIO_SQLITEREPO_ELECTION_LOCK_ALERT_DELAY*
  * range: 1 -> 60 * G_TIME_SPAN_SECOND

--- a/conf.json
+++ b/conf.json
@@ -342,8 +342,8 @@
 
 			{ "type": "monotonic", "name": "oio_election_lock_alert_delay",
 				"key": "sqliterepo.election.lock_alert_delay",
-				"descr": ".",
-				"def": "50", "min": "1", "max": "60s" },
+				"descr": "Only effective when built in DEBUG mode. Dump the long critical sections around the elections lock, when the lock is held for longer then this threshold (in microseconds).",
+				"def": "200", "min": "1", "max": "60s" },
 
 			{ "type": "monotonic", "name": "oio_election_period_cond_wait",
 				"key": "sqliterepo.election.wait.quantum",

--- a/core/http_put.c
+++ b/core/http_put.c
@@ -762,6 +762,7 @@ _curl_get_handle_proxy (void)
 	curl_easy_setopt (h, CURLOPT_FRESH_CONNECT, 0L);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTDATA, NULL);
 	curl_easy_setopt (h, CURLOPT_SOCKOPTFUNCTION, _curl_set_sockopt_proxy);
+	curl_easy_setopt (h, CURLOPT_BUFFERSIZE, 32768L);
 	if (GRID_TRACE2_ENABLED()) {
 		curl_easy_setopt (h, CURLOPT_DEBUGFUNCTION, _trace);
 		curl_easy_setopt (h, CURLOPT_VERBOSE, 1L);

--- a/metautils/lib/gridd_client.c
+++ b/metautils/lib/gridd_client.c
@@ -49,11 +49,6 @@ enum client_step_e
 	STATUS_FAILED
 };
 
-struct gridd_client_factory_s
-{
-	struct abstract_client_factory_s abstract;
-};
-
 struct gridd_client_s
 {
 	GByteArray *request;
@@ -167,16 +162,6 @@ _count_network_error (const char *url, const GError *err)
 }
 
 /* ------------------------------------------------------------------------- */
-
-static void _factory_clean(struct gridd_client_factory_s *self);
-static struct gridd_client_s * _factory_create_client (
-		struct gridd_client_factory_s *self);
-
-struct gridd_client_factory_vtable_s VTABLE_FACTORY =
-{
-	_factory_clean,
-	_factory_create_client
-};
 
 static void
 _client_reset_reply(struct gridd_client_s *client)
@@ -841,22 +826,6 @@ gridd_client_fail(struct gridd_client_s *client, GError *why)
 	_client_replace_error(client, why);
 }
 
-static void
-_factory_clean(struct gridd_client_factory_s *self)
-{
-	EXTRA_ASSERT(self != NULL);
-	EXTRA_ASSERT(self->abstract.vtable == &VTABLE_FACTORY);
-	SLICE_FREE(struct gridd_client_factory_s, self);
-}
-
-static struct gridd_client_s *
-_factory_create_client (struct gridd_client_factory_s *factory)
-{
-	EXTRA_ASSERT(factory != NULL);
-	(void) factory;
-	return gridd_client_create_empty();
-}
-
 /* ------------------------------------------------------------------------- */
 
 void
@@ -917,13 +886,5 @@ gridd_client_set_avoidance (struct gridd_client_s *c, gboolean onoff)
 {
 	if (unlikely(!c)) return;
 	c->avoidance_onoff = BOOL(onoff);
-}
-
-struct gridd_client_factory_s *
-gridd_client_factory_create(void)
-{
-	struct gridd_client_factory_s *factory = SLICE_NEW0(struct gridd_client_factory_s);
-	factory->abstract.vtable = &VTABLE_FACTORY;
-	return factory;
 }
 

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -37,23 +37,53 @@ enum client_interest_e
 /* Return TRUE to notify the reply management failed. */
 typedef gboolean (*client_on_reply)(gpointer ctx, MESSAGE reply);
 
-// wrappers to the call to the vtable.
-
+/* Destroy the gridd_client pointed by `self` and free all the linked memory */
 void gridd_client_free (struct gridd_client_s *self);
+
+/* Connect the gridd_client_s `self`to the network endpoint `u` (TCP) */
 GError * gridd_client_connect_url (struct gridd_client_s *self, const gchar *u);
+
+/* Configure the gridd_client_s `self` to send the request in
+ * `req` and call `cb` upon each reply */
 GError * gridd_client_request (struct gridd_client_s *self, GByteArray *req,
 		gpointer ctx, client_on_reply cb);
+
+/* Returns a copy of the last error that occured. */
 GError * gridd_client_error (struct gridd_client_s *self);
+
+/* Tells which among client_interest_e is to be monitored */
 int gridd_client_interest (struct gridd_client_s *self);
+
+/* Returns the last URL the gridd_client connected to */
 const gchar * gridd_client_url (struct gridd_client_s *self);
+
+/* Returns the file descriptor currently used by `self` */
 int gridd_client_fd (struct gridd_client_s *self);
+
+/* Force the file descriptor in `fd` to be used by `self` */
 GError * gridd_client_set_fd(struct gridd_client_s *self, int fd);
+
+/* Force the global timeout for the operation (all the request, including
+ * the redirections */
 void gridd_client_set_timeout (struct gridd_client_s *self, gdouble seconds);
+
+/* Force the connection timeout for each unit request */
 void gridd_client_set_timeout_cnx (struct gridd_client_s *self, gdouble sec);
+
+/* Returns if the client's last change is older than 'now' */
 gboolean gridd_client_expired(struct gridd_client_s *self, gint64 now);
+
+/* Returns FALSE if the client is still expecting events */
 gboolean gridd_client_finished (struct gridd_client_s *self);
+
+/* Initiate the request */
 gboolean gridd_client_start (struct gridd_client_s *self);
+
+/* If expired() is true, sets the internal error and mark the client
+ * as failed */
 gboolean gridd_client_expire (struct gridd_client_s *self, gint64 now);
+
+/* Manage the events raised */
 void gridd_client_react (struct gridd_client_s *self);
 
 /* Gives the ownership of `why` to the gridd_client_s `self` */

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -37,65 +37,6 @@ enum client_interest_e
 /* Return TRUE to notify the reply management failed. */
 typedef gboolean (*client_on_reply)(gpointer ctx, MESSAGE reply);
 
-struct gridd_client_vtable_s
-{
-	// Destructor
-	void (*clean) (struct gridd_client_s *c);
-
-	// Connectors
-	GError* (*connect_url) (struct gridd_client_s *c, const gchar *target);
-
-	// Sets the next request to be sent, and what to do with the reply.
-	GError* (*request) (struct gridd_client_s *c, GByteArray *req,
-			gpointer ctx, client_on_reply cb);
-
-	// Returns a copy of the last error that occured.
-	GError* (*error) (struct gridd_client_s *c);
-
-	// Tells which among client_interest_e is to be monitored
-	int (*interest) (struct gridd_client_s *c);
-
-	// Returns the last URL we connected to
-	const gchar* (*get_url) (struct gridd_client_s *c);
-
-	// Returns the file descriptor currently used
-	int (*get_fd) (struct gridd_client_s *c);
-
-	// Force a new descriptor
-	GError* (*set_fd) (struct gridd_client_s *c, int fd);
-
-	// Force global timeout for the operation (all the request, including
-	// the redirections)
-	void (*set_timeout) (struct gridd_client_s *c, gdouble seconds);
-
-	// Force the connection timeout for each unit request
-	void (*set_timeout_cnx) (struct gridd_client_s *c, gdouble seconds);
-
-	// Returns if the client's last change is older than 'now'
-	gboolean (*expired) (struct gridd_client_s *c, gint64 now);
-
-	// Returns FALSE if the client is still expecting events.
-	gboolean (*finished) (struct gridd_client_s *c);
-
-	// Initiate the request.
-	gboolean (*start) (struct gridd_client_s *c);
-
-	// Manage the events raised
-	void (*react) (struct gridd_client_s *c);
-
-	// If expired() is true, sets the internal error and mark the client
-	// as failed.
-	gboolean (*expire) (struct gridd_client_s *c, gint64 now);
-
-	// Gives the ownership of `why` to the gridd_client_s `self`
-	void (*fail) (struct gridd_client_s *c, GError *why);
-};
-
-struct abstract_client_s
-{
-	struct gridd_client_vtable_s *vtable;
-};
-
 // wrappers to the call to the vtable.
 
 void gridd_client_free (struct gridd_client_s *self);

--- a/metautils/lib/gridd_client.h
+++ b/metautils/lib/gridd_client.h
@@ -73,30 +73,6 @@ void gridd_client_set_keepalive(struct gridd_client_s *self, gboolean on);
 
 /* ------------------------------------------------------------------------- */
 
-struct gridd_client_factory_vtable_s
-{
-	void (*clean) (struct gridd_client_factory_s *self);
-
-	// Instatiates an empty client (no target, ni request).
-	struct gridd_client_s* (*create) (struct gridd_client_factory_s *f);
-};
-
-struct abstract_client_factory_s
-{
-	struct gridd_client_factory_vtable_s *vtable;
-};
-
-#define gridd_client_factory_clean(p) \
-	((struct abstract_client_factory_s*)(p))->vtable->clean(p)
-
-#define gridd_client_factory_create_client(p) \
-	((struct abstract_client_factory_s*)(p))->vtable->create(p)
-
-// Instanciate a clients factory with the default VTABLE. This factory will
-// provide clients with the same VTABLE than those created with
-// gridd_client_create_empty().
-struct gridd_client_factory_s * gridd_client_factory_create(void);
-
 /* If that list of peers odwn is not periodically refreshed, it ends up with
  * a set of blocked peers */
 void gridd_client_learn_peers_down(const char * const * peers);

--- a/metautils/lib/utils_syscall.c
+++ b/metautils/lib/utils_syscall.c
@@ -48,40 +48,50 @@ metautils_get_vtable_syscall(void)
 int
 metautils_syscall_open (const char *p, int flag, int mode)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.open)
 		return VTABLE.open(p, flag, mode);
+#endif
 	return open(p, flag, mode);
 }
 
 int
 metautils_syscall_unlink (const char *p)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.unlink)
 		return VTABLE.unlink(p);
+#endif
 	return unlink(p);
 }
 
 int
 metautils_syscall_socket (int domain, int type, int protocol)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.socket)
 		return VTABLE.socket(domain, type, protocol);
+#endif
 	return socket(domain, type, protocol);
 }
 
 int
 metautils_syscall_connect (int fd, const struct sockaddr *addr, socklen_t alen)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.connect)
 		return VTABLE.connect(fd, addr, alen);
+#endif
 	return connect(fd, addr, alen);
 }
 
 int
 metautils_syscall_accept (int fd, struct sockaddr *addr, socklen_t *alen)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.accept)
 		return VTABLE.accept(fd, addr, alen);
+#endif
 	return accept(fd, addr, alen);
 }
 
@@ -89,8 +99,10 @@ metautils_syscall_accept (int fd, struct sockaddr *addr, socklen_t *alen)
 int
 metautils_syscall_accept4 (int fd, struct sockaddr *addr, socklen_t *alen, int flags)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.accept4)
 		return VTABLE.accept4(fd, addr, alen, flags);
+#endif
 	return accept4(fd, addr, alen, flags);
 }
 #endif
@@ -98,64 +110,80 @@ metautils_syscall_accept4 (int fd, struct sockaddr *addr, socklen_t *alen, int f
 ssize_t
 metautils_syscall_write (int fd, const void *buf, size_t count)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.write)
 		return VTABLE.write(fd, buf, count);
+#endif
 	return write(fd, buf, count);
 }
 
 ssize_t
 metautils_syscall_send (int fd, const void *buf, size_t count, int flags)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.send)
 		return VTABLE.send(fd, buf, count, flags);
+#endif
 	return send(fd, buf, count, flags);
 }
 
 ssize_t
 metautils_syscall_read (int fd, void *buf, size_t count)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.read)
 		return VTABLE.read(fd, buf, count);
+#endif
 	return read(fd, buf, count);
 }
 
 int
 metautils_syscall_poll (struct pollfd *fds, int nfds, int timeout)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.poll)
 		return VTABLE.poll(fds, nfds, timeout);
+#endif
 	return poll(fds, nfds, timeout);
 }
 
 int
 metautils_syscall_close (int fd)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.close)
 		return VTABLE.close(fd);
+#endif
 	return close(fd);
 }
 
 int
 metautils_syscall_shutdown (int fd, int how)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.shutdown)
 		return VTABLE.shutdown(fd, how);
+#endif
 	return shutdown(fd, how);
 }
 
 int
 metautils_syscall_getsockopt (int fd, int lvl, int opt, void *v, socklen_t *vl)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.getsockopt)
 		return VTABLE.getsockopt(fd, lvl, opt, v, vl);
+#endif
 	return getsockopt(fd, lvl, opt, v, vl);
 }
 
 int
 metautils_syscall_setsockopt (int fd, int lvl, int opt, const void *v, socklen_t vl)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	if (VTABLE.setsockopt)
 		return VTABLE.setsockopt(fd, lvl, opt, v, vl);
+#endif
 	return setsockopt(fd, lvl, opt, v, vl);
 }
 

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -588,7 +588,7 @@ election_manager_create(struct replication_config_s *config,
 		g_tree_new_full(metautils_strcmp3, NULL, g_free, _cond_clean);
 
 	manager->completions =
-		g_thread_pool_new((GFunc)_completion_router, manager, 2, FALSE, NULL);
+		g_thread_pool_new((GFunc)_completion_router, manager, 8, FALSE, NULL);
 
 	manager->tasks_getpeers =
 		g_thread_pool_new((GFunc)_worker_getpeers, manager, 8, FALSE, NULL);

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1468,9 +1468,14 @@ deferred_completion_ASKING(struct exec_later_ASKING_context_s *d)
 				int zrc2 = sqlx_sync_adelete(d->member->sync,
 						member_masterpath(d->member, path, sizeof(path)), -1,
 						completion_DeleteRogueNode, NULL);
-				GRID_WARN("Rogue being deleted %s", path);
-				if (zrc2 != ZOK)
-					GRID_WARN("Failed! %s", zerror(zrc2));
+				TRACE_EXECUTION(d->member->manager);
+
+				if (zrc2 != ZOK) {
+					GRID_WARN("Failed to delete Rogue %s: %s", path, zerror(zrc2));
+				} else {
+					GRID_WARN("Rogue being deleted %s", path);
+				}
+				TRACE_EXECUTION(d->member->manager);
 
 				transition(d->member, EVT_MASTER_BAD, NULL);
 			} else {

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -127,22 +127,22 @@ struct election_manager_s
 
 	GMutex lock;
 
-	struct deque_beacon_s members_by_state[STEP_MAX];
-
 	/* Trace of actions while the lock was held */
 	GArray *activity_trace;
 
 	gboolean exiting;
+
+	struct deque_beacon_s members_by_state[STEP_MAX];
 };
 
 /* @private */
 struct logged_event_s
 {
-	enum event_type_e event   :6;
-	enum election_step_e pre  :5;
-	enum election_step_e post :5;
-	gint64 time              :48;  // cheeseparing economies
-} __attribute__ ((packed));
+	gint64 time;
+	enum event_type_e event   :8;
+	enum election_step_e pre  :8;
+	enum election_step_e post :8;
+};
 
 /* @private */
 struct election_member_s

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -387,6 +387,8 @@ _cond_clean (gpointer p)
 static inline void
 _manager_record_activity(struct election_manager_s *M, const char *fn, int ln)
 {
+	if (M->exiting) return;
+
 	struct activity_trace_element_s item = {};
 	item.when = oio_ext_monotonic_time();
 	item.func = fn;
@@ -404,6 +406,8 @@ _manager_record_activity(struct election_manager_s *M, const char *fn, int ln)
 static void
 _manage_dump_activity(struct election_manager_s *M)
 {
+	if (M->exiting) return;
+
 	const GArray *ga = M->activity_trace;
 	EXTRA_ASSERT(ga->len > 0);
 	gint64 _in = g_array_index(ga, struct activity_trace_element_s, 0).when;

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2196,6 +2196,7 @@ _common_action_to_LEAVE(struct election_member_s *member,
 	int zrc = sqlx_sync_adelete(member->sync,
 			member_fullpath(member, path, sizeof(path)), -1,
 			completion_LEAVING, member);
+	TRACE_EXECUTION(member->manager);
 
 	if (unlikely(zrc != ZOK))
 		return member_fail_on_error(member, zrc);

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2007,7 +2007,6 @@ defer_USE(struct election_member_s *member)
 			MEMBER_NAME(n,member);
 			sqlx_peering__use (member->manager->peering, *p, &n);
 			TRACE_EXECUTION(member->manager);
-			member_trace("sched:USE", member);
 		}
 	}
 
@@ -2372,7 +2371,6 @@ member_action_to_SYNCING(struct election_member_s *member)
 	sqlx_peering__pipefrom (member->manager->peering, target,
 			&n, source, member->manager, 0, _result_PIPEFROM);
 	TRACE_EXECUTION(member->manager);
-	member_debug("sched:PIPEFROM", member);
 
 	return member_set_status(member, STEP_SYNCING);
 }
@@ -2443,7 +2441,6 @@ member_action_to_CHECKING_MASTER(struct election_member_s *m)
 	sqlx_peering__getvers (m->manager->peering, m->master_url,
 			&n, m->manager, 0, _result_GETVERS);
 	TRACE_EXECUTION(m->manager);
-	member_trace("sched:GETVERS", m);
 
 	return member_set_status(m, STEP_CHECKING_MASTER);
 }
@@ -2477,7 +2474,6 @@ member_action_to_CHECKING_SLAVES(struct election_member_s *m)
 		sqlx_peering__getvers (m->manager->peering, *p,
 				&n, m->manager, 0, _result_GETVERS);
 		TRACE_EXECUTION(m->manager);
-		member_trace("sched:GETVERS", m);
 	}
 
 	return member_set_status(m, STEP_CHECKING_SLAVES);

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2072,13 +2072,13 @@ _result_GETVERS (GError *enet,
 		MEMBER_CHECK(member);
 
 		member_lock(member);
-		if (!err)
+		if (!err) {
 			transition(member, EVT_GETVERS_OK, &reqid);
-		else if (err->code == CODE_PIPEFROM)
+		} else if (err->code == CODE_PIPEFROM) {
 			transition(member, EVT_GETVERS_OLD, &reqid);
-		else if (err->code == CODE_CONCURRENT)
+		} else if (err->code == CODE_CONCURRENT) {
 			transition(member, EVT_GETVERS_RACE, &reqid);
-		else {
+		} else {
 			if (err->code == CODE_CONTAINER_NOTFOUND) {
 				// We may have asked the wrong peer
 				member->requested_peers_decache = 1;

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1322,14 +1322,14 @@ static void
 completion_DeleteRogueNode(int zrc, const void *d UNUSED)
 {
 	if (zrc == ZNONODE) {
-		GRID_TRACE2("Rogue disappeared");
+		GRID_TRACE2("Rogue ZK node disappeared");
 	} else if (zrc == ZOK) {
-		GRID_TRACE("Rogue deleted");
+		GRID_TRACE("Rogue ZK node deleted");
 	} else if (zrc == ZSESSIONEXPIRED) {
 		/* the node will expire, don't flood with logs in this case */
-		GRID_DEBUG("Rogue deletion error: %s", zerror(zrc));
+		GRID_DEBUG("Rogue ZK node deletion error: %s", zerror(zrc));
 	} else {
-		GRID_WARN("Rogue deletion error: %s", zerror(zrc));
+		GRID_WARN("Rogue ZK node deletion error: %s", zerror(zrc));
 	}
 }
 
@@ -1481,9 +1481,9 @@ deferred_completion_ASKING(struct exec_later_ASKING_context_s *d)
 				TRACE_EXECUTION(d->member->manager);
 
 				if (zrc2 != ZOK) {
-					GRID_WARN("Failed to delete Rogue %s: %s", path, zerror(zrc2));
+					GRID_WARN("Failed to delete Rogue ZK node %s: %s", path, zerror(zrc2));
 				} else {
-					GRID_WARN("Rogue being deleted %s", path);
+					GRID_WARN("Rogue ZK node being deleted %s", path);
 				}
 				TRACE_EXECUTION(d->member->manager);
 

--- a/sqliterepo/gridd_client_pool.c
+++ b/sqliterepo/gridd_client_pool.c
@@ -399,7 +399,6 @@ gridd_client_pool_defer(struct gridd_client_pool_s *pool, struct event_client_s 
 		gint64 now = oio_ext_monotonic_time();
 		ev->deadline_start = now + 4 * G_TIME_SPAN_SECOND;
 		g_async_queue_push(pool->pending_clients, ev);
-		gridd_client_pool_notify(pool);
 	}
 }
 

--- a/sqliterepo/gridd_client_pool.c
+++ b/sqliterepo/gridd_client_pool.c
@@ -36,7 +36,6 @@ License along with this library.
 
 struct gridd_client_pool_s
 {
-	struct gridd_client_pool_vtable_s *vtable;
 	struct event_client_s **active_clients;
 	GAsyncQueue *pending_clients;
 
@@ -52,22 +51,6 @@ struct gridd_client_pool_s
 
 	/* if set to any non-zero value, new requests are not started */
 	int closed;
-};
-
-static void _destroy (struct gridd_client_pool_s *p);
-
-static void _defer (struct gridd_client_pool_s *p, struct event_client_s *ev);
-
-static GError* _round (struct gridd_client_pool_s *p, time_t sec);
-
-static void _reconfigure (struct gridd_client_pool_s *p);
-
-static struct gridd_client_pool_vtable_s VTABLE =
-{
-	_destroy,
-	_defer,
-	_round,
-	_reconfigure
 };
 
 struct gridd_client_pool_s *
@@ -112,9 +95,7 @@ gridd_client_pool_create(void)
 		return NULL;
 	}
 
-	pool->vtable = &VTABLE;
-
-	_reconfigure(pool);
+	gridd_client_pool_reconfigure(pool);
 	return pool;
 }
 
@@ -182,12 +163,11 @@ event_client_free(struct event_client_s *ec)
 	g_free (ec);
 }
 
-static void
-_destroy(struct gridd_client_pool_s *pool)
+void
+gridd_client_pool_destroy(struct gridd_client_pool_s *pool)
 {
 	if (!pool)
 		return;
-	EXTRA_ASSERT(pool->vtable == &VTABLE);
 
 	pool->closed = ~0;
 
@@ -363,11 +343,10 @@ _manage_all_events(struct gridd_client_pool_s *pool,
 	}
 }
 
-static void
-_reconfigure(struct gridd_client_pool_s *pool)
+void
+gridd_client_pool_reconfigure(struct gridd_client_pool_s *pool)
 {
 	EXTRA_ASSERT(pool != NULL);
-	EXTRA_ASSERT(pool->vtable == &VTABLE);
 	if (sqliterepo_fd_max_active <= 0) {
 		pool->active_clients_max = pool->active_clients_size;
 	} else {
@@ -376,11 +355,10 @@ _reconfigure(struct gridd_client_pool_s *pool)
 	}
 }
 
-static GError *
-_round(struct gridd_client_pool_s *pool, time_t sec)
+GError *
+gridd_client_pool_round(struct gridd_client_pool_s *pool, time_t sec)
 {
 	EXTRA_ASSERT(pool != NULL);
-	EXTRA_ASSERT(pool->vtable == &VTABLE);
 	EXTRA_ASSERT(pool->fdmon >= 0);
 	g_assert(sqliterepo_fd_max_active > 0);
 
@@ -406,11 +384,10 @@ _round(struct gridd_client_pool_s *pool, time_t sec)
 	return NULL;
 }
 
-static void
-_defer(struct gridd_client_pool_s *pool, struct event_client_s *ev)
+void
+gridd_client_pool_defer(struct gridd_client_pool_s *pool, struct event_client_s *ev)
 {
 	EXTRA_ASSERT(pool != NULL);
-	EXTRA_ASSERT(pool->vtable == &VTABLE);
 	EXTRA_ASSERT(ev != NULL);
 	EXTRA_ASSERT(pool->pending_clients != NULL);
 	EXTRA_ASSERT(pool->efd >= 0);
@@ -421,14 +398,19 @@ _defer(struct gridd_client_pool_s *pool, struct event_client_s *ev)
 	} else {
 		gint64 now = oio_ext_monotonic_time();
 		ev->deadline_start = now + 4 * G_TIME_SPAN_SECOND;
-		/* eventfd requires 8-byte integer */
-		guint64 c = 1u;
 		g_async_queue_push(pool->pending_clients, ev);
-		int rc = metautils_syscall_write(pool->efd, &c, 8);
-		if (unlikely(rc < 0)) {
-			GRID_WARN("Failed to signal new deferred requests: (%d) %s",
-					errno, strerror(errno));
-		}
+		gridd_client_pool_notify(pool);
 	}
 }
 
+void
+gridd_client_pool_notify(struct gridd_client_pool_s *pool)
+{
+	/* eventfd requires 8-byte integer */
+	guint64 c = 1u;
+	int rc = metautils_syscall_write(pool->efd, &c, 8);
+	if (unlikely(rc < 0)) {
+		GRID_WARN("Failed to signal new deferred requests: (%d) %s",
+				errno, strerror(errno));
+	}
+}

--- a/sqliterepo/gridd_client_pool.h
+++ b/sqliterepo/gridd_client_pool.h
@@ -47,39 +47,17 @@ struct event_client_s
 	/* hidden abstract fields */
 };
 
-struct gridd_client_pool_vtable_s
-{
-	void (*destroy) (struct gridd_client_pool_s *p);
-
-	void (*defer) (struct gridd_client_pool_s *p, struct event_client_s *ev);
-
-	/** Destined to be called continuously, it shouldn't block more than 'sec'
-	 * seconds between each run of the polling loop. */
-	GError* (*round) (struct gridd_client_pool_s *p, time_t sec);
-
-	void (*reconfigure) (struct gridd_client_pool_s *p);
-};
-
-struct abstract_client_pool_s
-{
-	struct gridd_client_pool_vtable_s *vtable;
-};
-
-#define gridd_client_pool_destroy(p) \
-	((struct abstract_client_pool_s*)p)->vtable->destroy(p)
-
-#define gridd_client_pool_defer(p,ev) \
-	((struct abstract_client_pool_s*)p)->vtable->defer(p,ev)
-
-#define gridd_client_pool_round(p,sec) \
-	((struct abstract_client_pool_s*)p)->vtable->round(p,sec)
-
-#define gridd_client_pool_reconfigure(p) \
-	((struct abstract_client_pool_s*)p)->vtable->reconfigure(p)
-
-/* Public API -------------------------------------------------------------- */
-
 struct gridd_client_pool_s * gridd_client_pool_create(void);
+
+void gridd_client_pool_destroy(struct gridd_client_pool_s *p);
+
+void gridd_client_pool_notify(struct gridd_client_pool_s *p);
+
+void gridd_client_pool_defer(struct gridd_client_pool_s *p, struct event_client_s *ev);
+
+GError * gridd_client_pool_round(struct gridd_client_pool_s *p, time_t sec);
+
+void gridd_client_pool_reconfigure(struct gridd_client_pool_s *p);
 
 /* Should not be used on an event that has already been defered. Because this
  * will be called by the gridd_client_pool. */

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -450,6 +450,111 @@ _awget_siblings (struct sqlx_sync_s *ss, const char *path,
 
 /* -------------------------------------------------------------------------- */
 
+#define SYNC_CALL(self,F) VTABLE_CALL(self,struct abstract_sqlx_sync_s*,F)
+
+void
+sqlx_sync_clear(struct sqlx_sync_s *self)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(self,clear)(self);
+#else
+	return _clear(self);
+#endif
+}
+
+GError *
+sqlx_sync_open(struct sqlx_sync_s *self)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(self,open)(self);
+#else
+	return _open(self);
+#endif
+}
+
+void
+sqlx_sync_close(struct sqlx_sync_s *self)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(self,close)(self);
+#else
+	return _close(self);
+#endif
+}
+
+int
+sqlx_sync_acreate (struct sqlx_sync_s *ss, const char *path,
+		const char *v, int vlen, int flags,
+		string_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,acreate)(ss, path, v, vlen, flags, completion, d);
+#else
+	return _acreate(ss, path, v, vlen, flags, completion, d);
+#endif
+}
+
+int
+sqlx_sync_adelete (struct sqlx_sync_s *ss, const char *path, int version,
+		void_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,adelete)(ss, path, version, completion, d);
+#else
+	return _adelete(ss, path, version, completion, d);
+#endif
+}
+
+int
+sqlx_sync_awexists(struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watch, void* watchCtx,
+		stat_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,awexists)(ss, path, watch, watchCtx, completion, d);
+#else
+	return _awexists(ss, path, watch, watchCtx, completion, d);
+#endif
+}
+
+int
+sqlx_sync_awget (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watch, void* watchCtx,
+		data_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,awget)(ss, path, watch, watchCtx, completion, d);
+#else
+	return _awget(ss, path, watch, watchCtx, completion, d);
+#endif
+}
+
+int
+sqlx_sync_awget_children (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watch, void* watchCtx,
+		strings_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,awget_children)(ss, path, watch, watchCtx, completion, d);
+#else
+	return _awget_children(ss, path, watch, watchCtx, completion, d);
+#endif
+}
+
+int
+sqlx_sync_awget_siblings (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watch, void* watchCtx,
+		strings_completion_t completion, const void *d)
+{
+#ifdef HAVE_EXTRA_DEBUG
+	SYNC_CALL(ss,awget_siblings)(ss, path, watch, watchCtx, completion, d);
+#else
+	return _awget_siblings(ss, path, watch, watchCtx, completion, d);
+#endif
+}
+
+/* -------------------------------------------------------------------------- */
+
 static void _direct_destroy (struct sqlx_peering_s *self);
 
 static void _direct_use (struct sqlx_peering_s *self,
@@ -750,14 +855,22 @@ _direct_getvers (struct sqlx_peering_s *self,
 void
 sqlx_peering__destroy (struct sqlx_peering_s *self)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	PEER_CALL(self,destroy)(self);
+#else
+	return _direct_destroy(self);
+#endif
 }
 
 void
 sqlx_peering__use (struct sqlx_peering_s *self, const char *url,
 		const struct sqlx_name_s *n)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	PEER_CALL(self,use)(self,url,n);
+#else
+	return _direct_use(self, url, n);
+#endif
 }
 
 void
@@ -765,7 +878,11 @@ sqlx_peering__getvers (struct sqlx_peering_s *self, const char *url,
 		const struct sqlx_name_s *n, struct election_manager_s *manager,
 		guint reqid, sqlx_peering_getvers_end_f result)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	PEER_CALL(self,getvers)(self,url,n, manager,reqid,result);
+#else
+	return _direct_getvers(self, url, n, manager, reqid, result);
+#endif
 }
 
 void
@@ -774,5 +891,9 @@ sqlx_peering__pipefrom (struct sqlx_peering_s *self, const char *url,
 			struct election_manager_s *manager, guint reqid,
 			sqlx_peering_pipefrom_end_f result)
 {
+#ifdef HAVE_EXTRA_DEBUG
 	PEER_CALL(self,pipefrom)(self,url,n,src, manager,reqid,result);
+#else
+	return _direct_pipefrom(self, url, n, src, manager, reqid, result);
+#endif
 }

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -585,10 +585,6 @@ struct sqlx_peering_direct_s
 {
 	struct sqlx_peering_vtable_s *vtable;
 
-	/* Instanciates client. Designed for testing purposes, to avoid requiring
-	   any network during the tests. */
-	struct gridd_client_factory_s *factory;
-
 	/* pool'ifies the client sockets to avoid reserving to many file
 	 * descriptors. */
 	struct gridd_client_pool_s *pool;
@@ -599,13 +595,11 @@ struct sqlx_peering_direct_s
 };
 
 struct sqlx_peering_s *
-sqlx_peering_factory__create_direct (struct gridd_client_pool_s *pool,
-		struct gridd_client_factory_s *factory)
+sqlx_peering_factory__create_direct (struct gridd_client_pool_s *pool)
 {
 	struct sqlx_peering_direct_s *self = g_malloc0 (sizeof(*self));
 	self->vtable = &vtable_peering_DIRECT;
 	self->pool = pool;
-	self->factory = factory;
 	self->fd_udp = -1;
 	return (struct sqlx_peering_s*) self;
 }
@@ -656,7 +650,7 @@ _direct_use (struct sqlx_peering_s *self,
 		}
 	} else {
 		struct event_client_s *mc = g_malloc0 (sizeof(struct event_client_s));
-		mc->client = gridd_client_factory_create_client (p->factory);
+		mc->client = gridd_client_create_empty ();
 
 		gridd_client_set_timeout(mc->client, oio_election_use_timeout_req);
 		gridd_client_set_timeout_cnx(mc->client, oio_election_use_timeout_cnx);
@@ -720,7 +714,7 @@ _direct_pipefrom (struct sqlx_peering_s *self,
 
 	struct evtclient_PIPEFROM_s *mc =
 		g_malloc0 (sizeof(struct evtclient_PIPEFROM_s));
-	mc->ec.client = gridd_client_factory_create_client (p->factory);
+	mc->ec.client = gridd_client_create_empty ();
 	mc->ec.on_end = (gridd_client_end_f) on_end_PIPEFROM;
 	mc->hook = result;
 	mc->manager = manager;
@@ -820,7 +814,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 
 	struct evtclient_GETVERS_s *mc =
 		g_malloc0 (sizeof(struct evtclient_GETVERS_s));
-	mc->ec.client = gridd_client_factory_create_client (p->factory);
+	mc->ec.client = gridd_client_create_empty();
 	mc->ec.on_end = (gridd_client_end_f) on_end_GETVERS;
 	mc->hook = result;
 	mc->manager = manager;

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -106,6 +106,7 @@ void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
 /* -------------------------------------------------------------------------- */
 
 struct sqlx_name_s;
+struct sqlx_name_inline_s;
 struct election_manager_s;
 struct gridd_client_pool_s;
 
@@ -124,11 +125,15 @@ struct sqlx_peering_vtable_s
 {
 	void (*destroy) (struct sqlx_peering_s *self);
 
-	void (*use) (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n);
+	void (*notify) (struct sqlx_peering_s *self);
 
-	void (*getvers) (struct sqlx_peering_s *self,
+	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
+	gboolean (*use) (struct sqlx_peering_s *self,
+			const char *url,
+			const struct sqlx_name_inline_s *n);
+
+	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
+	gboolean (*getvers) (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
 			/* for the return */
@@ -136,7 +141,8 @@ struct sqlx_peering_vtable_s
 			guint reqid,
 			sqlx_peering_getvers_end_f result);
 
-	void (*pipefrom) (struct sqlx_peering_s *self,
+	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
+	gboolean (*pipefrom) (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
 			const char *src,
@@ -153,14 +159,16 @@ struct sqlx_peering_abstract_s
 
 void sqlx_peering__destroy (struct sqlx_peering_s *self);
 
-void sqlx_peering__use (struct sqlx_peering_s *self, const char *url,
-		const struct sqlx_name_s *n);
+void sqlx_peering__notify (struct sqlx_peering_s *self);
 
-void sqlx_peering__getvers (struct sqlx_peering_s *self, const char *url,
+gboolean sqlx_peering__use (struct sqlx_peering_s *self, const char *url,
+		const struct sqlx_name_inline_s *n);
+
+gboolean sqlx_peering__getvers (struct sqlx_peering_s *self, const char *url,
 		const struct sqlx_name_s *n, struct election_manager_s *manager,
 		guint reqid, sqlx_peering_getvers_end_f result);
 
-void sqlx_peering__pipefrom (struct sqlx_peering_s *self, const char *url,
+gboolean sqlx_peering__pipefrom (struct sqlx_peering_s *self, const char *url,
 			const struct sqlx_name_s *n, const char *src,
 			struct election_manager_s *manager, guint reqid,
 			sqlx_peering_pipefrom_end_f result);

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -67,32 +67,33 @@ struct abstract_sqlx_sync_s
 	struct sqlx_sync_vtable_s *vtable;
 };
 
-#define sqlx_sync_clear(ss) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->clear(ss)
+void sqlx_sync_clear(struct sqlx_sync_s *ss);
 
-#define sqlx_sync_open(ss) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->open(ss)
+GError * sqlx_sync_open(struct sqlx_sync_s *ss);
 
-#define sqlx_sync_close(ss) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->close(ss)
+void sqlx_sync_close(struct sqlx_sync_s *ss);
 
-#define sqlx_sync_acreate(ss, path, v, vlen, flags, completion, data) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->acreate(ss, path, v, vlen, flags, completion, data)
+int sqlx_sync_acreate (struct sqlx_sync_s *ss, const char *path, const char *v,
+		int vlen, int flags, string_completion_t completion, const void *data);
 
-#define sqlx_sync_adelete(ss, path, ver, completion, data) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->adelete(ss, path, ver, completion, data)
+int sqlx_sync_adelete (struct sqlx_sync_s *ss, const char *path, int version,
+		void_completion_t completion, const void *data);
 
-#define sqlx_sync_awexists(ss, path, watch, watchctx, completion, data) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->awexists(ss, path, watch, watchctx, completion, data)
+int sqlx_sync_awexists(struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watcher, void* watcherCtx,
+		stat_completion_t completion, const void *data);
 
-#define sqlx_sync_awget(ss, path, watch, watchctx, completion, data) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->awget(ss, path, watch, watchctx, completion, data)
+int sqlx_sync_awget (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watcher, void* watcherCtx,
+		data_completion_t completion, const void *data);
 
-#define sqlx_sync_awget_children(ss, path, watch, watchctx, completion, d) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->awget_children(ss, path, watch, watchctx, completion, d)
+int sqlx_sync_awget_children (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watcher, void* watcherCtx,
+		strings_completion_t completion, const void *data);
 
-#define sqlx_sync_awget_siblings(ss, path, watch, watchctx, completion, d) \
-	((struct abstract_sqlx_sync_s*)(ss))->vtable->awget_siblings(ss, path, watch, watchctx, completion, d)
+int sqlx_sync_awget_siblings (struct sqlx_sync_s *ss, const char *path,
+		watcher_fn watcher, void* watcherCtx,
+		strings_completion_t completion, const void *data);
 
 /** Initiates a sqlx synchronizer based on ZooKeeper.
  * @param url the Zookeeper connection string */

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -107,7 +107,6 @@ void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
 
 struct sqlx_name_s;
 struct election_manager_s;
-struct gridd_client_factory_s;
 struct gridd_client_pool_s;
 
 struct sqlx_peering_s;
@@ -167,8 +166,7 @@ void sqlx_peering__pipefrom (struct sqlx_peering_s *self, const char *url,
 			sqlx_peering_pipefrom_end_f result);
 
 struct sqlx_peering_s * sqlx_peering_factory__create_direct (
-		struct gridd_client_pool_s *clipool,
-		struct gridd_client_factory_s *clifac);
+		struct gridd_client_pool_s *clipool);
 
 void sqlx_peering_direct__set_udp (struct sqlx_peering_s *self, int fd);
 

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -347,7 +347,6 @@ _init_configless_structures(struct sqlx_service_s *ss)
 			|| !(ss->server = network_server_init())
 			|| !(ss->dispatcher = transport_gridd_build_empty_dispatcher())
 			|| !(ss->clients_pool = gridd_client_pool_create())
-			|| !(ss->clients_factory = gridd_client_factory_create())
 			|| !(ss->resolver = hc_resolver_create())
 			|| !(ss->gtq_admin = grid_task_queue_create("admin"))
 			|| !(ss->gtq_reload = grid_task_queue_create("reload"))) {
@@ -361,8 +360,7 @@ _init_configless_structures(struct sqlx_service_s *ss)
 static gboolean
 _configure_peering (struct sqlx_service_s *ss)
 {
-	ss->peering = sqlx_peering_factory__create_direct
-		(ss->clients_pool, ss->clients_factory);
+	ss->peering = sqlx_peering_factory__create_direct(ss->clients_pool);
 	return TRUE;
 }
 
@@ -910,11 +908,6 @@ sqlx_service_specific_fini(void)
 	if (SRV.clients_pool) {
 		gridd_client_pool_destroy (SRV.clients_pool);
 		SRV.clients_pool = NULL;
-	}
-
-	if (SRV.clients_factory) {
-		gridd_client_factory_clean(SRV.clients_factory);
-		SRV.clients_factory = NULL;
 	}
 
 	// Must be freed after SRV.clients_pool

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -23,7 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PSRV(P) ((struct sqlx_service_s*)(P))
 
 struct election_manager_s;
-struct gridd_client_factory_s;
 struct gridd_client_pool_s;
 struct gridd_request_dispatcher_s;
 struct grid_single_rrd_s;
@@ -117,7 +116,6 @@ struct sqlx_service_s
 	struct grid_task_queue_s *gtq_admin;
 	GThread *thread_admin;
 
-	struct gridd_client_factory_s *clients_factory;
 	struct gridd_client_pool_s *clients_pool;
 	GThread *thread_client;
 

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -98,11 +98,13 @@ _get_vers (gpointer ctx UNUSED, const struct sqlx_name_s *n UNUSED,
 
 static void _peering_destroy (struct sqlx_peering_s *self);
 
-static void _peering_use (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n);
+static void _peering_notify (struct sqlx_peering_s *self UNUSED) {}
 
-static void _peering_getvers (struct sqlx_peering_s *self,
+static gboolean _peering_use (struct sqlx_peering_s *self,
+			const char *url,
+			const struct sqlx_name_inline_s *n);
+
+static gboolean _peering_getvers (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
 			/* for the return */
@@ -110,7 +112,7 @@ static void _peering_getvers (struct sqlx_peering_s *self,
 			guint reqid,
 			sqlx_peering_getvers_end_f result);
 
-static void _peering_pipefrom (struct sqlx_peering_s *self,
+static gboolean _peering_pipefrom (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
 			const char *src,
@@ -121,21 +123,23 @@ static void _peering_pipefrom (struct sqlx_peering_s *self,
 
 struct sqlx_peering_vtable_s vtable_peering_NOOP =
 {
-	_peering_destroy, _peering_use, _peering_getvers, _peering_pipefrom
+	_peering_destroy, _peering_notify,
+	_peering_use, _peering_getvers, _peering_pipefrom
 };
 
 static void _peering_destroy (struct sqlx_peering_s *self) { g_free (self); }
 
-static void
+static gboolean
 _peering_use (struct sqlx_peering_s *self,
 			const char *url,
-			const struct sqlx_name_s *n)
+			const struct sqlx_name_inline_s *n)
 {
 	(void) self, (void) url, (void) n;
 	GRID_DEBUG (">>> %s (%s)", __FUNCTION__, url);
+	return FALSE;
 }
 
-static void
+static gboolean
 _peering_getvers (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
@@ -146,9 +150,10 @@ _peering_getvers (struct sqlx_peering_s *self,
 {
 	(void) self, (void) url, (void) n;
 	(void) manager, (void) reqid, (void) result;
+	return FALSE;
 }
 
-static void
+static gboolean
 _peering_pipefrom (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_s *n,
@@ -160,6 +165,7 @@ _peering_pipefrom (struct sqlx_peering_s *self,
 {
 	(void) self, (void) url, (void) n, (void) src;
 	(void) manager, (void) reqid, (void) result;
+	return FALSE;
 }
 
 static struct sqlx_peering_s *

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -246,51 +246,48 @@ _sync_clear (struct sqlx_sync_s *ss)
 }
 
 static GError *
-_sync_open (struct sqlx_sync_s *ss)
+_sync_open (struct sqlx_sync_s *ss UNUSED)
 {
-	(void) ss;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	GRID_DEBUG ("%s", __FUNCTION__);
 	return NULL;
 }
 
 static void
-_sync_close (struct sqlx_sync_s *ss)
+_sync_close (struct sqlx_sync_s *ss UNUSED)
 {
-	(void) ss;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	GRID_DEBUG ("%s", __FUNCTION__);
 }
 
 static int
-_sync_acreate (struct sqlx_sync_s *ss, const char *path, const char *v,
-		int vlen, int flags, string_completion_t completion, const void *data)
+_sync_acreate (struct sqlx_sync_s *ss, const char *path UNUSED,
+		const char *v UNUSED, int vlen UNUSED, int flags UNUSED,
+		string_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss;
-	(void) path, (void) v, (void) vlen, (void) flags;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	enum hook_type_e val = CMD_CREATE;
 	g_array_append_vals (ss->pending, &val, 1);
 	return ZOK;
 }
 
 static int
-_sync_adelete (struct sqlx_sync_s *ss, const char *path, int version,
-		void_completion_t completion, const void *data)
+_sync_adelete (struct sqlx_sync_s *ss,
+		const char *path UNUSED, int version UNUSED,
+		void_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss, (void) path, (void) version;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	enum hook_type_e val = CMD_DELETE;
 	g_array_append_vals (ss->pending, &val, 1);
 	return ZOK;
 }
 
 static int
-_sync_awexists (struct sqlx_sync_s *ss, const char *path,
-		watcher_fn watcher, void* watcherCtx,
-		stat_completion_t completion, const void *data)
+_sync_awexists (struct sqlx_sync_s *ss, const char *path UNUSED,
+		watcher_fn watcher UNUSED, void* watcherCtx UNUSED,
+		stat_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss, (void) path;
-	(void) watcher, (void) watcherCtx;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	if (completion) {
 		enum hook_type_e val = CMD_EXIST;
 		g_array_append_vals (ss->pending, &val, 1);
@@ -298,13 +295,11 @@ _sync_awexists (struct sqlx_sync_s *ss, const char *path,
 	return ZOK;
 }
 
-static int _sync_awget (struct sqlx_sync_s *ss, const char *path,
-		watcher_fn watcher, void* watcherCtx,
-		data_completion_t completion, const void *data)
+static int _sync_awget (struct sqlx_sync_s *ss, const char *path UNUSED,
+		watcher_fn watcher UNUSED, void* watcherCtx UNUSED,
+		data_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss, (void) path;
-	(void) watcher, (void) watcherCtx;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	if (completion) {
 		enum hook_type_e val = CMD_GET;
 		g_array_append_vals (ss->pending, &val, 1);
@@ -313,13 +308,11 @@ static int _sync_awget (struct sqlx_sync_s *ss, const char *path,
 }
 
 static int
-_sync_awget_children (struct sqlx_sync_s *ss, const char *path,
-		watcher_fn watcher, void* watcherCtx,
-		strings_completion_t completion, const void *data)
+_sync_awget_children (struct sqlx_sync_s *ss, const char *path UNUSED,
+		watcher_fn watcher UNUSED, void* watcherCtx UNUSED,
+		strings_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss, (void) path;
-	(void) watcher, (void) watcherCtx;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	if (completion) {
 		enum hook_type_e val = CMD_LIST;
 		g_array_append_vals (ss->pending, &val, 1);
@@ -328,13 +321,11 @@ _sync_awget_children (struct sqlx_sync_s *ss, const char *path,
 }
 
 static int
-_sync_awget_siblings (struct sqlx_sync_s *ss, const char *path,
-		watcher_fn watcher, void* watcherCtx,
-		strings_completion_t completion, const void *data)
+_sync_awget_siblings (struct sqlx_sync_s *ss, const char *path UNUSED,
+		watcher_fn watcher UNUSED, void* watcherCtx UNUSED,
+		strings_completion_t completion UNUSED, const void *data UNUSED)
 {
-	(void) ss, (void) path;
-	(void) watcher, (void) watcherCtx;
-	(void) completion, (void) data;
+	EXTRA_ASSERT (ss->vtable == &vtable_sync_NOOP);
 	if (completion) {
 		enum hook_type_e val = CMD_LIST;
 		g_array_append_vals (ss->pending, &val, 1);


### PR DESCRIPTION
##### SUMMARY

Scratch even more CPU cycle involved in non-necessary code during critical sections:
* use shorter buffers for sockets
* useless pseudo-objects that made the code more complex
* useless debug code based on VTable, now only called in Debug builds
* defer syscalls involved in USE/GETVERS out of the critical sections  

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`metautils`, `sqliterepo`

##### SDS VERSION
```4.1.22```

##### ADDITIONAL INFORMATION
With such a pach