### PR TITLE
Ensure trailing '\0' when copying strings

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -517,8 +517,9 @@ static int _get_major_minor (const gchar *path, guint *pmaj, guint *pmin) {
 			out = p;
 	}
 	if (!out) {
-		out = g_malloc0 (sizeof(struct path_maj_min_s) + strlen(path) + 1);
-		strcpy (out->path, path);
+		const size_t len = strlen(path);
+		out = g_malloc0 (sizeof(struct path_maj_min_s) + len + 1);
+		memcpy(out->path, path, len + 1);
 		majmin_cache = g_slist_prepend (majmin_cache, out);
 	}
 

--- a/core/lb.c
+++ b/core/lb.c
@@ -253,11 +253,11 @@ static struct oio_lb_pool_vtable_s vtable_LOCAL =
 static struct _lb_item_s *
 _item_make (oio_location_t location, const char *id, const char *addr)
 {
-	int len = strlen (id);
+	const size_t len = strlen (id);
 	struct _lb_item_s *out = g_malloc0 (sizeof(struct _lb_item_s) + len + 1);
 	out->location = location;
-	strcpy (out->id, id);
-	strcpy (out->addr, addr);
+	g_strlcpy (out->addr, addr, sizeof(out->addr));
+	memcpy(out->id, id, len + 1);
 	return out;
 }
 
@@ -886,7 +886,7 @@ oio_lb_world__add_pool_target (struct oio_lb_pool_s *self, const char *to)
 	EXTRA_ASSERT (lb->targets != NULL);
 
 	/* prepare the string to be easy to parse. */
-	gsize tolen = strlen (to);
+	const size_t tolen = strlen (to);
 	gchar *copy = g_malloc (tolen + 2);
 	memcpy (copy, to, tolen + 1);
 	copy [tolen+1] = '\0';
@@ -1130,11 +1130,12 @@ oio_lb_world__get_item(struct oio_lb_world_s *self, const char *id)
 	g_rw_lock_reader_lock(&self->lock);
 	struct _lb_item_s *item0 = g_tree_lookup(self->items, id);
 	if (item0) {
-		item = g_malloc0(sizeof(struct oio_lb_item_s) + strlen(id) + 1);
+		const size_t len = strlen(id);
+		item = g_malloc0(sizeof(struct oio_lb_item_s) + len + 1);
 		item->location = item0->location;
 		item->weight = item0->weight;
-		strcpy(item->id, id);
-		strcpy(item->addr, item0->addr);
+		memcpy(item->addr, item0->addr, sizeof(item->addr));
+		memcpy(item->id, id, len + 1);
 	}
 	g_rw_lock_reader_unlock(&self->lock);
 	return item;

--- a/core/sds.c
+++ b/core/sds.c
@@ -122,7 +122,7 @@ struct chunk_s
 	guint32 score;
 	gchar hexhash[STRLEN_CHUNKHASH];
 	guint8 flag_success : 1;  /* only used during an upload */
-	gchar url[1];
+	gchar url[];
 };
 
 struct metachunk_s
@@ -170,8 +170,9 @@ _load_one_chunk (struct json_object *jurl, struct json_object *jsize,
 		struct json_object *jpos, struct json_object *jscore)
 {
 	const char *s = json_object_get_string(jurl);
-	struct chunk_s *result = g_malloc0 (sizeof(struct chunk_s) + strlen(s));
-	strcpy (result->url, s);
+	const size_t len = strlen(s);
+	struct chunk_s *result = g_malloc0 (sizeof(struct chunk_s) + len + 1);
+	memcpy(result->url, s, len + 1);
 	result->size = json_object_get_int64(jsize);
 	if (jscore != NULL)
 		result->score = (guint32)json_object_get_int64(jscore);

--- a/core/var.c
+++ b/core/var.c
@@ -162,7 +162,7 @@ oio_var_register_string(gchar *p,
 	rec.ptr.str = p;
 	rec.min.u = limit;
 	rec.max.u = limit;
-	strncpy(rec.ptr.str, def, rec.max.u);
+	g_strlcpy(rec.ptr.str, def, rec.max.u);
 	rec.def.str = (char *) def;
 	_register_record(&rec);
 }
@@ -208,7 +208,7 @@ _record_set(struct oio_var_record_s *rec, union oio_var_default_u v)
 			*(rec->ptr.t) = CLAMP(v.t, rec->min.t, rec->max.t);
 			return;
 		case OIO_VARTYPE_string:
-			strncpy(rec->ptr.str, v.str, rec->max.u);
+			g_strlcpy(rec->ptr.str, v.str, rec->max.u);
 			return;
 	}
 	g_assert_not_reached();

--- a/events/oio_events_queue_beanstalkd.c
+++ b/events/oio_events_queue_beanstalkd.c
@@ -255,7 +255,7 @@ _check_server(struct _queue_BEANSTALKD_s *q, int fd)
 	gchar buf[2048];
 
 	/* send the request */
-	strcpy(buf, "stats\r\n");
+	g_strlcpy(buf, "stats\r\n", sizeof(buf));
 	struct iovec iov[1] = {};
 	iov[0].iov_base = buf;
 	iov[0].iov_len = strlen(buf);

--- a/meta1v2/meta1_backend_services.c
+++ b/meta1v2/meta1_backend_services.c
@@ -47,16 +47,15 @@ static GError *__get_container_all_services(struct sqlx_sqlite3_s *sq3,
 static struct meta1_service_url_s *
 meta1_url_dup(struct meta1_service_url_s *u)
 {
-	struct meta1_service_url_s *result;
-
 	if (!u)
 		return NULL;
 
-	result = g_malloc0(sizeof(struct meta1_service_url_s) + 1 + strlen(u->args));
+	const size_t argslen = strlen(u->args);
+	struct meta1_service_url_s *result = g_malloc0(sizeof(*result) + argslen + 1);
 	result->seq = u->seq;
-	strcpy(result->srvtype, u->srvtype);
-	strcpy(result->host, u->host);
-	strcpy(result->args, u->args);
+	g_strlcpy(result->srvtype, u->srvtype, sizeof(result->srvtype));
+	g_strlcpy(result->host, u->host, sizeof(result->host));
+	g_strlcpy(result->args, u->args, argslen + 1);
 
 	return result;
 }
@@ -838,7 +837,7 @@ __relink_container_services(struct m1v2_relink_input_s *in, gchar ***out)
 	if (!err && !in->dryrun) {
 		packed = _ids_to_url((char**)ids->pdata);
 		packed->seq = ref->seq;
-		strcpy (packed->srvtype, ref->srvtype);
+		g_strlcpy (packed->srvtype, ref->srvtype, sizeof(packed->srvtype));
 		err = __save_service (in->sq3, in->url, packed, TRUE);
 	}
 

--- a/metautils/lib/lb.c
+++ b/metautils/lib/lb.c
@@ -128,7 +128,7 @@ oio_lb_world__reload_pools(struct oio_lb_world_s *lbw,
 			return;
 		}
 		char *str_def = g_alloca(def->len + 1);
-		strncpy(str_def, (const char*)def->data, def->len);
+		memcpy(str_def, (const char*)def->data, def->len);
 		str_def[def->len] = '\0';
 		struct oio_lb_pool_s *pool = NULL;
 		pool = oio_lb_world__create_pool(lbw, name);

--- a/metautils/lib/utils_m1url.c
+++ b/metautils/lib/utils_m1url.c
@@ -28,9 +28,9 @@ meta1_unpack_url(const gchar *url)
 
 	EXTRA_ASSERT(url != NULL);
 
-	int len = strlen(url);
-	gchar *tmp = g_alloca(len+1);
-	g_strlcpy(tmp, url, len+1);
+	const size_t urllen = strlen(url);
+	gchar *tmp = g_alloca(urllen + 1);
+	memcpy(tmp, url, urllen + 1);
 
 	if (!(type = strchr(tmp, '|')))
 		return NULL;
@@ -43,15 +43,17 @@ meta1_unpack_url(const gchar *url)
 	if (!(args = strchr(host, '|')))
 		return NULL;
 	*(args++) = '\0';
-	if (strlen(args) >= LIMIT_LENGTH_SRVARGS)
+
+	const size_t argslen = strlen(args);
+	if (argslen >= LIMIT_LENGTH_SRVARGS)
 		return NULL;
 
 	struct meta1_service_url_s *result;
-	result = g_malloc0(sizeof(*result) + strlen(args) + 1);
+	result = g_malloc0(sizeof(*result) + argslen + 1);
 	result->seq = g_ascii_strtoll(url, NULL, 10);
 	g_strlcpy(result->srvtype, type, sizeof(result->srvtype));
 	g_strlcpy(result->host, host, sizeof(result->host));
-	strcpy(result->args, args);
+	g_strlcpy(result->args, args, argslen + 1);
 
 	return result;
 }

--- a/sqliterepo/hash.c
+++ b/sqliterepo/hash.c
@@ -36,7 +36,7 @@ sqliterepo_hash_name (const struct sqlx_name_s *n, gchar *d, gsize dlen)
 	g_checksum_update(h, (guint8*)n->type, strlen(n->type));
 	const char *hex = g_checksum_get_string(h);
 	/* TODO maybe is it possible to make this in one pass */
-	strncpy(d, hex, dlen);
+	g_strlcpy(d, hex, dlen);
 	oio_str_upper(d);
 	g_checksum_free(h);
 


### PR DESCRIPTION
##### SUMMARY
Avoid the `strcpy` and `strncpy` that do not ensure a trailing NUL character, and rather use `g_strlcpy` or even `memcpy` when the size is known.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
All of them

##### SDS VERSION
`4.2.0`
