### PR TITLE
Conscience: Remove abusive assertions

### DIFF
--- a/cluster/module/server.c
+++ b/cluster/module/server.c
@@ -1015,7 +1015,6 @@ _cs_dispatch_PUSH(struct gridd_reply_ctx_s *reply,
 	GSList *list_srvinfo = NULL;
 	GError *err = metautils_message_extract_body_encoded(
 			reply->request, TRUE, &list_srvinfo, service_info_unmarshall);
-	EXTRA_ASSERT((err != NULL) ^ (list_srvinfo != NULL));
 	if (err) {
 		reply->send_error(0, err);
 		return TRUE;
@@ -1065,7 +1064,6 @@ _cs_dispatch_RM(struct gridd_reply_ctx_s *reply,
 	GSList *list_srvinfo = NULL;
 	GError *err = metautils_message_extract_body_encoded(
 			reply->request, TRUE, &list_srvinfo, service_info_unmarshall);
-	EXTRA_ASSERT((err != NULL) ^ (list_srvinfo != NULL));
 	if (err) {
 		reply->send_error(0, err);
 		return TRUE;

--- a/proxy/cs_actions.c
+++ b/proxy/cs_actions.c
@@ -107,6 +107,9 @@ conscience_remote_get_types(gchar **allcs, gchar ***out, gint64 deadline)
 GError *
 conscience_remote_push_services(gchar **allcs, GSList *ls, gint64 deadline)
 {
+	if (!ls)  /* Avoid sending an empty request */
+		return NULL;
+
 	GError * action(const char *cs) {
 		MESSAGE req = metautils_message_create_named("CS_PSH",
 				oio_clamp_deadline(proxy_timeout_conscience, deadline));


### PR DESCRIPTION
##### SUMMARY
Remove abusive assertions in the conscience (they validated input from the network :cry: )
Avoid sending the empty requests (despite being valid) from the proxy.

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`conscience`, `oio-proxy`

##### SDS VERSION
`4.2.0`