### PR TITLE
Check cluster state after bootstrap

### DIFF
--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -154,6 +154,11 @@ func_tests () {
 	CNAME=$RANDOM
 	${PYTHON} $(which openio) object create $CNAME /tmp/blob%
 
+	if is_running_test_suite "repli"; then
+		oio-check-directory ${OIO_NS} meta0 meta1 dir rdir
+		oio-check-master --oio-account $OIO_USER --oio-ns $OIO_NS $CNAME
+	fi
+
 	# At least spawn one oio-crawler-integrity on a container that exists
 	# TODO(jfs): Move in a tests/functional/cli python test
 	${PYTHON} $(which oio-crawler-integrity) $OIO_NS $OIO_ACCOUNT $CNAME


### PR DESCRIPTION
##### SUMMARY

Call check tools after bootstrap

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

Travis tests / Check tools

##### SDS VERSION
```
4.2.x
```


##### ADDITIONAL INFORMATION

Sometime the `oio-reset.sh` fails to bootstrap correctly, calling check tools will force us to fix bootstrap ! 