### PR TITLE
tools: fix oio-reset.sh with invalid bootstrap

### DIFF
--- a/tools/oio-reset.sh
+++ b/tools/oio-reset.sh
@@ -170,8 +170,13 @@ $cmd_openio directory bootstrap --check \
 
 echo -e "\n### Assign rdir services"
 # Force meta1 services to reload meta0 cache
+for addr in $(oio-test-config.py -t meta1); do
+    $cmd_openio cluster lock meta1 $addr
+done
 gridinit_cmd -S "$GRIDINIT_SOCK" restart "@meta1" >/dev/null
-sleep 1
+COUNT=$(oio-test-config.py -c -t meta1)
+$cmd_openio cluster wait -d 30 -u -n "$COUNT" meta1
+
 $cmd_openio volume admin bootstrap
 
 echo -e "\n### Wait for the services to have a score"


### PR DESCRIPTION
##### SUMMARY

Fix bootstrap of sds:

Restart of meta1 before rdir assignation was not checked before `openio volume boostrap` 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

tools/oio-reset.sh

##### SDS VERSION
```
4.2.x
```