### PR TITLE
sqliterepo: fix a memory leak

### DIFF
--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -608,7 +608,7 @@ struct use_request_s {
 };
 
 static void
-_use_by_udp(struct use_request_s *req, struct sqlx_peering_direct_s *self)
+_use_by_udp_no_free(struct use_request_s *req, struct sqlx_peering_direct_s *self)
 {
 	NAME2CONST(n, req->name);
 	GByteArray *msg = sqlx_pack_USE(&n);
@@ -621,6 +621,13 @@ _use_by_udp(struct use_request_s *req, struct sqlx_peering_direct_s *self)
 		GRID_DEBUG("USE(%s.%s) failed: (%d) %s",
 				n.base, n.type, errsav, strerror(errsav));
 	}
+}
+
+static void
+_use_by_udp(struct use_request_s *req, struct sqlx_peering_direct_s *self)
+{
+	_use_by_udp_no_free(req, self);
+	g_free(req);
 }
 
 struct sqlx_peering_s *
@@ -685,7 +692,7 @@ _direct_use (struct sqlx_peering_s *self,
 				metautils_gthreadpool_push("UDP", p->pool_udp_use,
 						g_memdup(&req, sizeof(req)));
 			} else {
-				_use_by_udp(&req, p);
+				_use_by_udp_no_free(&req, p);
 			}
 		}
 		return FALSE;


### PR DESCRIPTION
##### SUMMARY
Fix a memory leak introduced at commit 0404fa1016b8fdc679970c4f5a1d9e97e4cdf627, when deferring UDP requests.

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`sqlitrepo`

##### SDS VERSION
`openio 4.1.23.dev50`
