### PR TITLE
sqliterepo/election: Ensure a deadline in background threads

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1811,6 +1811,8 @@ watch_SELF(zhandle_t *h UNUSED, int type, int state, const char *path, void *d)
 static void
 _completion_router(gpointer p, struct election_manager_s *M)
 {
+	oio_ext_set_deadline(oio_ext_monotonic_time() + 2 * G_TIME_SPAN_SECOND);
+
 	switch (*((enum deferred_action_type_e*)p)) {
 		case DAT_CREATING:
 			return deferred_completion_CREATING(p);

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1842,6 +1842,8 @@ _worker_getpeers(struct election_member_s *m, struct election_manager_s *M)
 	m->requested_peers_decache = 0;
 	member_unlock(m);
 
+	oio_ext_set_deadline(oio_ext_monotonic_time() + 10 * G_TIME_SPAN_SECOND);
+
 	NAME2CONST(n, inline_name);
 	GError *err = election_get_peers(M, &n, decache, &peers);
 


### PR DESCRIPTION
##### SUMMARY
Ensure a deadline during some operations deferred to a pool of threads.

Sadly, the deadline is transmitted via a thread-local placeholder, the threads are not exclusive to the pool, the deadline was not explicitly set by the hook, thus a wrong deadline (in the past...) was sometimes considered. 

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.2.0.0b3.dev42`

