### PR TITLE
Set properties when linking objects

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -935,7 +935,7 @@ class ObjectStorageApi(object):
     @patch_kwargs
     def object_fastcopy(self, target_account, target_container, target_obj,
                         link_account, link_container, link_obj,
-                        version=None,  **kwargs):
+                        version=None, properties_directive='COPY', **kwargs):
         meta, chunks = self.object_locate(
             target_account, target_container, target_obj, version=version,
             **kwargs)
@@ -951,6 +951,14 @@ class ObjectStorageApi(object):
                                            link_obj, version)
         data = {'chunks': chunks_copies,
                 'properties': meta["properties"] or {}}
+        if properties_directive == 'REPLACE':
+            if 'metadata' in kwargs:
+                # TODO it should emit a DeprecationWarning
+                data['properties'] = kwargs['metadata']
+            elif 'properties' in kwargs:
+                data['properties'] = kwargs['properties']
+            else:
+                data['properties'] = {}
         try:
             self._send_copy(chunks_url, chunks_copies_url, fullpath[0])
             self.container.content_create(link_account, link_container,

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -665,6 +665,31 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.assertEqual(len(data), 128)
         self.assertEqual(data, "1" * 128)
 
+    def test_object_simple_fast_copy_with_metadata(self):
+        target_container = random_str(16)
+        link_container = random_str(16)
+        target_obj = random_str(16)
+        link_obj = random_str(16)
+        self.api.object_create(self.account, target_container, data="1"*128,
+                               obj_name=target_obj,
+                               metadata={'AAA': '1', 'BBB': '1'})
+        self.api.object_fastcopy(self.account, target_container, target_obj,
+                                 self.account, link_container, link_obj,
+                                 metadata={'BBB': '2'})
+        metadata, _ = self.api.object_fetch(self.account, link_container,
+                                            link_obj)
+        self.assertDictEqual(metadata.get('properties', {}),
+                             {'AAA': '1', 'BBB': '1'})
+
+        self.api.object_fastcopy(self.account, target_container, target_obj,
+                                 self.account, link_container, link_obj,
+                                 metadata={'BBB': '2'},
+                                 properties_directive='REPLACE')
+        metadata, _ = self.api.object_fetch(self.account, link_container,
+                                            link_obj)
+        self.assertDictEqual(metadata.get('properties', {}),
+                             {'BBB': '2'})
+
     def test_object_create_then_truncate(self):
         """Create an object then truncate data"""
         name = random_str(16)


### PR DESCRIPTION

##### SUMMARY

Metadata was copied from original source without possibilities to change them

It is first part that fix modifying ACL of existing object on Swift / S3.

Like S3/Swift, we allow to copy or replace metadata through a dedicated parameter.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

OIO

##### SDS VERSION
```
4.1.x
```

##### ADDITIONAL INFORMATION

Behavior to adopt is not clear as API must allow to specify metadata or not (https://developer.openstack.org/api-ref/object-store/index.html#copy-object with `X-Fresh-Metadata` or https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html with `x-amz-metadata-directive`)

And it should not break container snapshot of `4.2`