### PR TITLE
server: Ease the integration with prometheus exporters

### DIFF
--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -843,6 +843,7 @@ dispatch_PING(struct gridd_reply_ctx_s *reply,
 		gpointer gdata UNUSED, gpointer hdata UNUSED)
 {
 	reply->no_access();
+	reply->add_body(metautils_gba_from_string("OK\r\n"));
 	reply->send_reply(CODE_FINAL_OK, "OK");
 	return TRUE;
 }


### PR DESCRIPTION
##### SUMMARY
Adds a payload to replies on PING calls. With a marker in it, so that a simple TCP handler can look for that marker: "OK\r\n"

##### ISSUE TYPE
`enhancement` ... though I am not sure what it enhances, the entropy or the features.

##### COMPONENT NAME
`server`

##### SDS VERSION
`openio 4.1.24`