### PR TITLE
Python API: include netloc in urllib3 errors messages

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -135,7 +135,9 @@ class HttpApi(object):
                 except ValueError:
                     pass
         except urllib3.exceptions.HTTPError as exc:
-            oio_exception_from_httperror(exc, out_headers.get('X-oio-req-id'))
+            oio_exception_from_httperror(exc,
+                                         reqid=out_headers.get('X-oio-req-id'),
+                                         url=url)
         if resp.status >= 400:
             raise exceptions.from_response(resp, body)
         return resp, body

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -126,7 +126,8 @@ class BlobClient(object):
             resp = self.http_pool.request(
                 'HEAD', url, headers=headers)
         except urllib3.exceptions.HTTPError as ex:
-            oio_exception_from_httperror(ex, headers['X-oio-req-id'])
+            oio_exception_from_httperror(ex, reqid=headers['X-oio-req-id'],
+                                         url=url)
         if resp.status == 200:
             if not _xattr:
                 return dict()


### PR DESCRIPTION
##### SUMMARY
Include network location in messages generated after urllib3 errors.

Exemple:
```
WARNING chunk delete failed: ('reqid=9BEC2A0DFCDC2D809092FA49FE2EC374, host=127.0.0.1:6023', '<urllib3.connection.HTTPConnection object at 0x7fcb35639d50>: Failed to establish a new connection: [Errno 111] ECONNREFUSED')
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.1.25.dev6
```