### PR TITLE
Python API: fix account client encoding

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -17,7 +17,7 @@ import json
 import sys
 import time
 from oio.api.base import HttpApi
-from oio.common.utils import get_logger, quote
+from oio.common.utils import get_logger
 from oio.common.exceptions import ClientException, OioNetworkException
 from oio.conscience.client import ConscienceClient
 
@@ -87,7 +87,8 @@ class AccountClient(HttpApi):
         if not params:
             params = dict()
         if account:
-            params['id'] = quote(account)
+            # Do not quote account, _request() will urlencode query string
+            params['id'] = account
         try:
             resp, body = self._request(method, action, params=params, **kwargs)
         except OioNetworkException as exc:


### PR DESCRIPTION
##### SUMMARY
Do not early quote account name, the low-level HTTP client will encode the
whole query string.

Jira: OS-68

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API
- CLI

##### SDS VERSION
```
openio 4.1.25.dev8
```


##### ADDITIONAL INFORMATION
Before:
```
> openio account create ?
+------+---------+
| Name | Created |
+------+---------+
| ?    | True    |
+------+---------+
> openio account show ?
+------------+------------+
| Field      | Value      |
+------------+------------+
| account    | %3F        |
| bytes      | 0B         |
| containers | 0          |
| ctime      | 1528709312 |
| metadata   | {}         |
| objects    | 0          |
+------------+------------+
```

After:
```
> openio account create ?
+------+---------+
| Name | Created |
+------+---------+
| ?    | True    |
+------+---------+
> openio account show ?
+------------+------------+
| Field      | Value      |
+------------+------------+
| account    | ?          |
| bytes      | 0B         |
| containers | 0          |
| ctime      | 1528712190 |
| metadata   | {}         |
| objects    | 0          |
+------------+------------+
```