### PR TITLE
Fix chunk size and blob rebuilder tests

### DIFF
--- a/core/tool_roundtrip.c
+++ b/core/tool_roundtrip.c
@@ -641,6 +641,7 @@ check_chunksize (const char * const * properties)
 
 	/**************************************************
 	 * Configure the chunk size only for this upload. */
+	oio_var_value_one("core.sds.adapt_metachunk_size", "false");
 	ul_dst.chunk_size = chunk_size;
 	err = oio_sds_upload_from_buffer(client, &ul_dst, buffer, size);
 	NOERROR(err);

--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -372,6 +372,29 @@ class ClusterFlush(command.Command):
                                 (srv_type, str(e)))
 
 
+class ClusterResolve(show.ShowOne):
+    """Resolve a service ID to an IP address and port"""
+
+    log = getLogger(__name__ + '.ClusterFlush')
+
+    def get_parser(self, prog_name):
+        parser = super(ClusterResolve, self).get_parser(prog_name)
+        parser.add_argument(
+            'srv_type',
+            help='Service type')
+        parser.add_argument(
+            'srv_id',
+            help='ID of the service'
+        )
+
+        return parser
+
+    def take_action(self, parsed_args):
+        resolved = self.app.client_manager.cluster.resolve(
+            parsed_args.srv_type, parsed_args.srv_id)
+        return zip(*resolved.items())
+
+
 class LocalNSConf(show.ShowOne):
     """show namespace configuration values locally configured"""
 

--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -93,10 +93,10 @@ class ClusterList(lister.Lister):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
         if parsed_args.stats:
-            columns = ('Type', 'Addr', 'ServiceId', 'Volume', 'Location',
+            columns = ('Type', 'Addr', 'Service Id', 'Volume', 'Location',
                        'Slots', 'Up', 'Score', 'Stats')
         else:
-            columns = ('Type', 'Addr', 'ServiceId', 'Volume', 'Location',
+            columns = ('Type', 'Addr', 'Service Id', 'Volume', 'Location',
                        'Slots', 'Up', 'Score')
         return columns, self._list_services(parsed_args)
 
@@ -133,7 +133,7 @@ class ClusterLocalList(lister.Lister):
             if not srv_types or srv_type in srv_types:
                 results.append((srv_type, addr, service_id, volume, location,
                                 slots, up, score))
-        columns = ('Type', 'Addr', 'ServiceId', 'Volume', 'Location',
+        columns = ('Type', 'Addr', 'Service Id', 'Volume', 'Location',
                    'Slots', 'Up', 'Score')
         result_gen = (r for r in results)
         return columns, result_gen

--- a/oio/cli/volume/volume.py
+++ b/oio/cli/volume/volume.py
@@ -19,7 +19,10 @@ from cliff import lister, show
 
 class ShowAdminVolume(show.ShowOne):
     """
-    Show information about a volume, especially the last incident date.
+    Show information about a volume, like the last incident date,
+    or the presence of a lock on the volume.
+
+    An empty output means there is no lock and incident on the volume.
     """
 
     log = getLogger(__name__ + '.ShowAdminVolume')
@@ -29,7 +32,7 @@ class ShowAdminVolume(show.ShowOne):
         parser.add_argument(
             'volume',
             metavar='<volume>',
-            help='IP:PORT of the rawx service')
+            help='ID of the rawx service')
         return parser
 
     def take_action(self, parsed_args):
@@ -45,7 +48,7 @@ class ShowAdminVolume(show.ShowOne):
 
 
 class ClearAdminVolume(lister.Lister):
-    """Clear admin volume"""
+    """Clear volume incident date."""
 
     log = getLogger(__name__ + '.ClearAdminVolume')
 
@@ -55,7 +58,7 @@ class ClearAdminVolume(lister.Lister):
             'volumes',
             metavar='<volumes>',
             nargs='+',
-            help='IP:PORT of the rawx services',
+            help='IDs of the rawx services',
         )
         return parser
 
@@ -74,7 +77,10 @@ class ClearAdminVolume(lister.Lister):
 
 
 class ShowVolume(show.ShowOne):
-    """Show volume"""
+    """
+    Show various volume information, like number of indexed chunks,
+    and names of containers having chunks on this volume.
+    """
 
     log = getLogger(__name__ + '.ShowVolume')
 
@@ -83,7 +89,7 @@ class ShowVolume(show.ShowOne):
         parser.add_argument(
             'volume',
             metavar='<volume>',
-            help='IP:PORT of the rawx service',
+            help='ID of the rawx service',
         )
         return parser
 
@@ -97,7 +103,7 @@ class ShowVolume(show.ShowOne):
 
 
 class IncidentAdminVolume(lister.Lister):
-    """Set incident on Volume"""
+    """Declare an incident on the specified volume."""
 
     log = getLogger(__name__ + '.IncidentAdminVolume')
 
@@ -107,7 +113,7 @@ class IncidentAdminVolume(lister.Lister):
             'volumes',
             metavar='<volumes>',
             nargs='+',
-            help='IP:PORT of the rawx services',
+            help='IDs of the rawx services',
         )
         parser.add_argument(
             '--date',
@@ -115,7 +121,7 @@ class IncidentAdminVolume(lister.Lister):
             default=[],
             type=int,
             action='append',
-            help='Incident date to set (seconds)')
+            help='Incident date to set (seconds since Epoch)')
         return parser
 
     def take_action(self, parsed_args):
@@ -137,7 +143,10 @@ class IncidentAdminVolume(lister.Lister):
 
 
 class LockAdminVolume(lister.Lister):
-    """Lock Volume"""
+    """
+    Lock the specified volumes.
+    Useful to prevent several rebuilders to work on the same volume.
+    """
 
     log = getLogger(__name__ + '.LockAdminVolume')
 
@@ -147,12 +156,12 @@ class LockAdminVolume(lister.Lister):
             'volumes',
             metavar='<volumes>',
             nargs='+',
-            help='IP:PORT of the rawx services')
+            help='IDs of the rawx services')
         parser.add_argument(
             '--key',
             metavar='<key>',
             required=True,
-            help='Lock key')
+            help='Identifier of what is locking the volume')
         return parser
 
     def take_action(self, parsed_args):
@@ -171,7 +180,7 @@ class LockAdminVolume(lister.Lister):
 
 
 class UnlockAdminVolume(lister.Lister):
-    """Unlock Volume"""
+    """Unlock the specified volumes."""
 
     log = getLogger(__name__ + '.UnlockAdminVolume')
 
@@ -181,7 +190,7 @@ class UnlockAdminVolume(lister.Lister):
             'volumes',
             metavar='<volumes>',
             nargs='+',
-            help='IP:PORT of the rawx services')
+            help='IDs of the rawx services')
         return parser
 
     def take_action(self, parsed_args):

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ openio.cluster =
     cluster_unlock = oio.cli.cluster.cluster:ClusterUnlock
     cluster_lock = oio.cli.cluster.cluster:ClusterLock
     cluster_flush = oio.cli.cluster.cluster:ClusterFlush
+    cluster_resolve = oio.cli.cluster.cluster:ClusterResolve
     cluster_wait = oio.cli.cluster.cluster:ClusterWait
     cluster_local_conf = oio.cli.cluster.cluster:LocalNSConf
 openio.election =

--- a/tests/functional/cli/cluster/test_cluster.py
+++ b/tests/functional/cli/cluster/test_cluster.py
@@ -18,7 +18,7 @@ import json
 from tests.functional.cli import CliTestCase
 
 CLUSTER_FIELDS = ['namespace', 'storage_policy', 'chunksize']
-CLUSTER_LIST_HEADERS = ['Type', 'Addr', 'ServiceId', 'Volume', 'Location',
+CLUSTER_LIST_HEADERS = ['Type', 'Addr', 'Service Id', 'Volume', 'Location',
                         'Slots', 'Up', 'Score']
 
 


### PR DESCRIPTION
##### SUMMARY
Recent modifications in the C API made some chunk size related tests fail. This pull requests tries to fix them. Besides, the blob rebuilder tests were not using service IDs (mandatory for rdir related operations).

Also implement `openio cluster resolve`  command, necessary for blob rebuilder tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- C API
- CLI
- tests

##### SDS VERSION
```
openio 4.1.25.dev43
```