### PR TITLE
meta*, sqlx: Restore the cache of the resolver

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -568,7 +568,7 @@ Used by `gcc`
 
 ### proxy.cache.enabled
 
-> In a proxy, sets if any form of caching is allowed
+> In a proxy, sets if any form of caching is allowed. Supersedes the value of resolver.cache.enabled.
 
  * default: **TRUE**
  * type: gboolean
@@ -822,7 +822,7 @@ Used by `gcc`
 
 > Allows the resolver instances to cache entries
 
- * default: **TRUE**
+ * default: **FALSE**
  * type: gboolean
  * cmake directive: *OIO_RESOLVER_CACHE_ENABLED*
 

--- a/conf.json
+++ b/conf.json
@@ -131,7 +131,7 @@
 			{ "type": "bool", "name": "oio_resolver_cache_enabled",
 				"key": "resolver.cache.enabled",
 				"descr": "Allows the resolver instances to cache entries",
-				"def": true },
+				"def": false },
 
 			{ "type": "monotonic", "name": "oio_resolver_m0cs_default_ttl",
 				"key": "resolver.cache.csm0.ttl.default",
@@ -795,7 +795,7 @@
 
 			{ "type": "bool", "name": "flag_cache_enabled",
 				"key": "proxy.cache.enabled",
-				"descr": "In a proxy, sets if any form of caching is allowed",
+				"descr": "In a proxy, sets if any form of caching is allowed. Supersedes the value of resolver.cache.enabled.",
 				"def": true,
 				"aliases": ["Cache"]},
 

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -362,7 +362,11 @@ _init_configless_structures(struct sqlx_service_s *ss)
 		GRID_WARN("SERVICE init error: memory allocation failure");
 		return FALSE;
 	}
-	oio_var_fix_one("resolver.cache.enabled", "false");
+
+	/* JFS: It was a good idea initially, to turn caching of and avoid
+	 * many decache orders to have predictive movers and rebuilders...
+	 * But it turns so slow without that cache :/ */
+	//oio_var_fix_one("resolver.cache.enabled", "false");
 
 	return TRUE;
 }


### PR DESCRIPTION
##### SUMMARY
In terms of performance, bring the 4.2.x in the row of the 4.1.x

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`sqliterepo`, `resolver`

##### SDS VERSION
`openio 4.1.25.dev45`