### PR TITLE
sqliterepo: Keep pointer on election to avoid lookups

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -891,6 +891,7 @@ _manager_clean(struct election_manager_s *manager)
 
 	g_mutex_clear(&manager->lock);
 
+	g_free(manager->sync_tab);
 	g_free(manager);
 }
 

--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -35,6 +35,7 @@ struct election_counts_s
 /* Hidden type */
 struct sqlx_repository_s;
 struct election_manager_s;
+struct election_member_s;
 struct sqlx_sync_s;
 struct sqlx_peering_s;
 struct sqlx_name_s;
@@ -231,7 +232,5 @@ void election_manager_set_peering (struct election_manager_s *m,
 		struct sqlx_peering_s *peering);
 
 gboolean election_manager_configured(const struct election_manager_s *m);
-
-struct election_member_s;
 
 #endif /*OIO_SDS__sqliterepo__election_h*/

--- a/sqliterepo/internals.h
+++ b/sqliterepo/internals.h
@@ -37,9 +37,6 @@ License along with this library.
 
 #define MEMBER(D)   ((struct election_member_s*)(D))
 #define MMANAGER(D) MEMBER(D)->manager
-#define MKEY(D)     MEMBER(D)->key
-#define MCFG(D)     MMANAGER(D)->config
-#define MKEY_S(D)   hashstr_str(MEMBER(D)->key)
 
 #define CONFIG_CHECK(C) do {\
 	EXTRA_ASSERT((C) != NULL);\

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -31,6 +31,8 @@ License along with this library.
 
 struct sqlx_sync_s;
 
+struct election_member_s;
+
 struct sqlx_sync_vtable_s
 {
 	void (*clear) (struct sqlx_sync_s *ss);
@@ -113,12 +115,13 @@ struct gridd_client_pool_s;
 struct sqlx_peering_s;
 
 typedef void (*sqlx_peering_pipefrom_end_f) (GError *e,
-		struct election_manager_s *m, const struct sqlx_name_s *n,
+		struct election_member_s *m,
 		guint reqid);
 
 typedef void (*sqlx_peering_getvers_end_f) (GError *e,
-		struct election_manager_s *m, const struct sqlx_name_s *n,
-		guint reqid, GTree *vremote);
+		struct election_member_s *m,
+		guint reqid,
+		GTree *vremote);
 
 /* Represents what an election needs to communicate with its peers. */
 struct sqlx_peering_vtable_s
@@ -129,25 +132,28 @@ struct sqlx_peering_vtable_s
 
 	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
 	gboolean (*use) (struct sqlx_peering_s *self,
+			/* in */
 			const char *url,
 			const struct sqlx_name_inline_s *n);
 
 	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
 	gboolean (*getvers) (struct sqlx_peering_s *self,
+			/* in */
 			const char *url,
-			const struct sqlx_name_s *n,
-			/* for the return */
-			struct election_manager_s *manager,
+			const struct sqlx_name_inline_s *n,
+			/* out */
+			struct election_member_s *m,
 			guint reqid,
 			sqlx_peering_getvers_end_f result);
 
 	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
 	gboolean (*pipefrom) (struct sqlx_peering_s *self,
+			/* in */
 			const char *url,
-			const struct sqlx_name_s *n,
+			const struct sqlx_name_inline_s *n,
 			const char *src,
-			/* for the return */
-			struct election_manager_s *manager,
+			/* out */
+			struct election_member_s *m,
 			guint reqid,
 			sqlx_peering_pipefrom_end_f result);
 };
@@ -161,17 +167,29 @@ void sqlx_peering__destroy (struct sqlx_peering_s *self);
 
 void sqlx_peering__notify (struct sqlx_peering_s *self);
 
-gboolean sqlx_peering__use (struct sqlx_peering_s *self, const char *url,
+gboolean sqlx_peering__use (struct sqlx_peering_s *self,
+		/* in */
+		const char *url,
 		const struct sqlx_name_inline_s *n);
 
-gboolean sqlx_peering__getvers (struct sqlx_peering_s *self, const char *url,
-		const struct sqlx_name_s *n, struct election_manager_s *manager,
-		guint reqid, sqlx_peering_getvers_end_f result);
+gboolean sqlx_peering__getvers (struct sqlx_peering_s *self,
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_getvers_end_f result);
 
-gboolean sqlx_peering__pipefrom (struct sqlx_peering_s *self, const char *url,
-			const struct sqlx_name_s *n, const char *src,
-			struct election_manager_s *manager, guint reqid,
-			sqlx_peering_pipefrom_end_f result);
+gboolean sqlx_peering__pipefrom (struct sqlx_peering_s *self,
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		const char *src,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_pipefrom_end_f result);
 
 struct sqlx_peering_s * sqlx_peering_factory__create_direct (
 		struct gridd_client_pool_s *clipool);

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -40,6 +40,15 @@ static volatile gint64 CLOCK = 0;
 static gint64 _get_monotonic (void) { return CLOCK; }
 static gint64 _get_real (void) { return CLOCK; }
 
+static struct election_member_s *
+manager_get_member (struct election_manager_s *m, const char *k)
+{
+	_manager_lock(m);
+	struct election_member_s *member = _LOCKED_get_member (m, k);
+	_manager_unlock(m);
+	return member;
+}
+
 static void
 member_reset_requests(struct election_member_s *m)
 {
@@ -105,21 +114,23 @@ static gboolean _peering_use (struct sqlx_peering_s *self,
 			const struct sqlx_name_inline_s *n);
 
 static gboolean _peering_getvers (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n,
-			/* for the return */
-			struct election_manager_s *manager,
-			guint reqid,
-			sqlx_peering_getvers_end_f result);
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_getvers_end_f result);
 
 static gboolean _peering_pipefrom (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n,
-			const char *src,
-			/* for the return */
-			struct election_manager_s *manager,
-			guint reqid,
-			sqlx_peering_pipefrom_end_f result);
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		const char *src,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_pipefrom_end_f result);
 
 struct sqlx_peering_vtable_s vtable_peering_NOOP =
 {
@@ -131,8 +142,8 @@ static void _peering_destroy (struct sqlx_peering_s *self) { g_free (self); }
 
 static gboolean
 _peering_use (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_inline_s *n)
+		const char *url,
+		const struct sqlx_name_inline_s *n)
 {
 	(void) self, (void) url, (void) n;
 	GRID_DEBUG (">>> %s (%s)", __FUNCTION__, url);
@@ -141,30 +152,32 @@ _peering_use (struct sqlx_peering_s *self,
 
 static gboolean
 _peering_getvers (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n,
-			/* for the return */
-			struct election_manager_s *manager,
-			guint reqid,
-			sqlx_peering_getvers_end_f result)
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_getvers_end_f result)
 {
 	(void) self, (void) url, (void) n;
-	(void) manager, (void) reqid, (void) result;
+	(void) m, (void) reqid, (void) result;
 	return FALSE;
 }
 
 static gboolean
 _peering_pipefrom (struct sqlx_peering_s *self,
-			const char *url,
-			const struct sqlx_name_s *n,
-			const char *src,
-			/* for the return */
-			struct election_manager_s *manager,
-			guint reqid,
-			sqlx_peering_pipefrom_end_f result)
+		/* in */
+		const char *url,
+		const struct sqlx_name_inline_s *n,
+		const char *src,
+		/* out */
+		struct election_member_s *m,
+		guint reqid,
+		sqlx_peering_pipefrom_end_f result)
 {
 	(void) self, (void) url, (void) n, (void) src;
-	(void) manager, (void) reqid, (void) result;
+	(void) m, (void) reqid, (void) result;
 	return FALSE;
 }
 


### PR DESCRIPTION
##### SUMMARY
During async operations deferred out of the critical section around FSM locks, instead of keeping the key to the election (and then requiring a lookup during the completion hook), we keep the direct pointer to the election member. 

This leads to smaller structures (the pointer is smaller than the name components), less CPU consumed, and requires refcounts to be handled well.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.1.25.dev45`