### PR TITLE
CLI: tolerate partial object entries

### DIFF
--- a/oio/cli/storage/obj.py
+++ b/oio/cli/storage/obj.py
@@ -315,14 +315,12 @@ class ShowObject(ObjectCommandMixin, show.ShowOne):
             version=parsed_args.object_version)
         info = {'account': account,
                 'container': container,
-                'object': obj,
-                'id': data['id'],
-                'version': data['version'],
-                'mime-type': data['mime_type'],
-                'size': data['length'],
-                'hash': data['hash'],
-                'ctime': data['ctime'],
-                'policy': data['policy']}
+                'object': obj}
+        conv = {'id': 'id', 'version': 'version', 'mime-type': 'mime_type',
+                'size': 'length', 'hash': 'hash', 'ctime': 'ctime',
+                'policy': 'policy'}
+        for key0, key1 in conv.items():
+            info[key0] = data.get(key1, 'n/a')
         for k, v in data['properties'].iteritems():
             info['meta.' + k] = v
         return zip(*sorted(info.iteritems()))
@@ -628,23 +626,33 @@ class ListObject(ContainerCommandMixin, lister.Lister):
 
             def _gen_results(objects):
                 for obj in objects:
-                    result = (obj['name'], obj['size'],
-                              obj['hash'], obj['version'],
-                              obj['deleted'], obj['mime_type'],
-                              Timestamp(obj['ctime']).isoformat,
-                              obj['policy'],
-                              _format_props(obj.get('properties', {})))
-                    yield result
-            results = _gen_results(obj_gen)
+                    try:
+                        result = (obj['name'], obj['size'],
+                                  obj['hash'], obj['version'],
+                                  obj['deleted'], obj['mime_type'],
+                                  Timestamp(obj['ctime']).isoformat,
+                                  obj['policy'],
+                                  _format_props(obj.get('properties', {})))
+                        yield result
+                    except KeyError as exc:
+                        self.log.warn("Bad object entry, missing '%s': %s",
+                                      exc, obj)
             columns = ('Name', 'Size', 'Hash', 'Version', 'Deleted',
                        'Content-Type', 'Last-Modified', 'Policy', 'Properties')
         else:
-            results = ((obj['name'],
-                        obj['size'] if not obj['deleted'] else 'deleted',
-                        obj['hash'],
-                        obj['version'])
-                       for obj in obj_gen)
+            def _gen_results(objects):
+                for obj in objects:
+                    try:
+                        yield (
+                            obj['name'],
+                            obj['size'] if not obj['deleted'] else 'deleted',
+                            obj['hash'],
+                            obj['version'])
+                    except KeyError as exc:
+                        self.log.warn("Bad object entry, missing '%s': %s",
+                                      exc, obj)
             columns = ('Name', 'Size', 'Hash', 'Version')
+        results = _gen_results(obj_gen)
         return (columns, results)
 
 


### PR DESCRIPTION
##### SUMMARY
In case of corrupt databases, some object entries were returned
incomplete, and that made the CLI crash.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
CLI

##### SDS VERSION
```
openio 4.1.26.dev3
```