### PR TITLE
proxy: use appropriate configuration for bulk delete

### DIFF
--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1963,7 +1963,7 @@ _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
 		return _reply_format_error(args,
 				BADREQ("At least one element is needed"));
 
-	if (jarray_len > proxy_bulk_max_create_many)
+	if (jarray_len > proxy_bulk_max_delete_many)
 		return _reply_too_large(args, NEWERROR(HTTP_CODE_PAYLOAD_TO_LARGE,
 				"Payload Too Large"));
 


### PR DESCRIPTION
##### SUMMARY
Before this commit, the maximum number of items deleted in one request was set by `proxy.bulk.max.create_many` instead of `proxy.bulk.max.delete_many`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Proxy

##### SDS VERSION
```
openio 4.1.27.dev7
```