### PR TITLE
tests: fix broken tests against account service

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ mock>=1.0
 fixtures>=1.4.0
 gcovr
 codecov
+beanstalkc

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -642,7 +642,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         time.sleep(1)  # ensure container event have been processed
         # container_refresh on existing container with data
         self.api.container_refresh(account, name)
-        time.sleep(1)  # ensure container event have been processed
+        time.sleep(15)  # ensure container event have been processed
         res = self.api.container_list(account, prefix=name)
         name_container, nb_objects, nb_bytes, _, mtime = res[0]
         self.assertEqual(name, name_container)

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -283,12 +283,12 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         while True:
             try:
                 for service in cluster.all_services("account"):
-                    if int(service['score']) < 7:
+                    if int(service['score']) < 50:
                         wait = True
                         continue
                 if not wait:
                     for service in cluster.all_services("meta2"):
-                        if int(service['score']) < 7:
+                        if int(service['score']) < 50:
                             wait = True
                             continue
                     if not wait:

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,4 +49,5 @@ install(PROGRAMS
 			${CMAKE_CURRENT_BINARY_DIR}/oio-bootstrap.py
 			oio-test-config.py
 			oio-reset.sh
+			oio-dump-buried-events.py
         DESTINATION bin)

--- a/tools/oio-dump-buried-events.py
+++ b/tools/oio-dump-buried-events.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# oio-election-dump.py
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import beanstalkc
+
+
+def dump_buried(host, port):
+    beanstalk = beanstalkc.Connection(host=host, port=int(port))
+
+    beanstalk.use('oio')
+
+    while True:
+        job = beanstalk.peek_buried()
+        if not job:
+            break
+        print("job")
+        print(job.stats())
+        print(job.body)
+        job.delete()
+
+
+if __name__ == "__main__":
+    host, port = sys.argv[1].split(':')
+    dump_buried(host, port)

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -48,6 +48,10 @@ function dump_syslog {
 function trap_exit {
 	set +e
 	#pip list
+	BEANSTALK=$(oio-test-config.py -t beanstalkd)
+	if [ ! -z "${BEANSTALK}" ]; then
+		oio-dump-buried-events.py ${BEANSTALK}
+	fi
 	gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3
 	#dump_syslog
 	oio-gdb.py


### PR DESCRIPTION
##### SUMMARY

Tests using account service and event-agent were broken due to short timeout or trying to launch
test with while low score on account service 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

tests

##### SDS VERSION
```
4.2.x
```


##### ADDITIONAL INFORMATION

A new tool has been added to dump buried events on failure.