### PR TITLE
rawx: close FD after removing fullpath xattr

### DIFF
--- a/rawx-lib/src/attr_handler.c
+++ b/rawx-lib/src/attr_handler.c
@@ -338,6 +338,7 @@ remove_fullpath_from_attr(const char *p, GError **error,
 				NULL);
 		const int rc = fremovexattr(fd, xname);
 		g_free(xname);
+		close(fd);
 		return rc != -1;
 	}
 }


### PR DESCRIPTION
##### SUMMARY
When removing fullpath from rawx, the FD was not closed

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

rawx

##### SDS VERSION
```
4.2.0c0
```