### PR TITLE
Check bind address

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -89,6 +89,10 @@ add_executable(test_stats_holder test_stats_holder.c)
 target_link_libraries(test_stats_holder server ${COMMON})
 add_test(NAME server/stats COMMAND test_stats_holder)
 
+add_executable(test_network_server test_network_server.c)
+target_link_libraries(test_network_server ${COMMON} server)
+add_test(NAME server/server_core COMMAND test_network_server)
+
 add_executable(test_sqliterepo_version test_sqliterepo_version.c)
 target_link_libraries(test_sqliterepo_version sqliterepo ${COMMON})
 add_test(NAME sqliterepo/version COMMAND test_sqliterepo_version)
@@ -120,4 +124,3 @@ add_test(NAME events/abstract COMMAND test_events_queue)
 add_executable(test_events_beanstalkd test_events_beanstalkd.c)
 target_link_libraries(test_events_beanstalkd ${COMMON} oioevents server)
 add_test(NAME events/beanstalkd COMMAND test_events_beanstalkd)
-

--- a/tests/unit/test_network_server.c
+++ b/tests/unit/test_network_server.c
@@ -1,0 +1,86 @@
+/*
+OpenIO SDS unit tests
+Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+#include <errno.h>
+
+#include <glib.h>
+
+#include <core/oio_core.h>
+#include <core/internals.h>
+
+#include <server/network_server.h>
+
+#define GQ_SERVER() g_quark_from_static_string("oio.srv")
+
+
+static void
+_do_nothing(gpointer u UNUSED, struct network_client_s *client UNUSED)
+{
+}
+
+static void
+_test_bad_bind_address(const char *netloc)
+{
+	GError *err = NULL;
+	struct network_server_s *srv = network_server_init();
+	g_assert_nonnull(srv);
+	network_server_bind_host(srv, netloc, NULL, _do_nothing);
+	err = network_server_open_servers(srv);
+	g_assert_error(err, GQ_SERVER(), EINVAL);
+	g_clear_error(&err);
+	network_server_clean(srv);
+}
+
+static void
+test_bad_bind_address_quotes(void)
+{
+	_test_bad_bind_address("\"127.0.0.1\":12345");
+}
+
+static void
+test_bad_bind_address_257(void)
+{
+	_test_bad_bind_address("257.0.0.1:12345");
+}
+
+static void
+test_bad_bind_address_empty_ip(void)
+{
+	_test_bad_bind_address(":12345");
+}
+
+static void
+test_bad_bind_address_empty_brackets(void)
+{
+	_test_bad_bind_address("[]:12345");
+}
+
+int
+main(int argc, char **argv)
+{
+	OIO_TEST_INIT(argc, argv);
+	g_test_add_func("/server/core/bad_bind_address/empty_brackets",
+			test_bad_bind_address_empty_brackets);
+	g_test_add_func("/server/core/bad_bind_address/empty_ip",
+			test_bad_bind_address_empty_ip);
+	g_test_add_func("/server/core/bad_bind_address/quotes",
+			test_bad_bind_address_quotes);
+	g_test_add_func("/server/core/bad_bind_address/257",
+			test_bad_bind_address_257);
+	return g_test_run();
+}


### PR DESCRIPTION
##### SUMMARY
We have seen the `bind_addr` of rdir server be set to `"127.0.0.1"` (with quotes) instead of `127.0.0.1`. In that case, the server is listening on `0.0.0.0` (thus all available network interfaces).

This PR fixes this behavior: an error is now returned.

Jira: OS-76

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
server

##### SDS VERSION
```
openio 4.2.1.dev2
```