### PR TITLE
oio-blob-indexer: sleep when no rdir assigned to local volume

### DIFF
--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -160,6 +160,10 @@ class SourceReadTimeout(OioTimeout):
 
 
 class VolumeException(OioException):
+    """
+    Exception raised when someone is trying to contact a rdir service,
+    but there is none assigned to the specified rawx.
+    """
     pass
 
 


### PR DESCRIPTION
##### SUMMARY
Log an error, then sleep when no rdir assigned to local volume.
Fix #1512

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio-blob-indexer

##### SDS VERSION
```
openio 4.1.27
```
