### PR TITLE
CLI: Allow CID for object and container commands

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -22,7 +22,6 @@ import warnings
 import time
 import random
 from urllib import unquote
-
 from oio.common import exceptions as exc
 from oio.api.ec import ECWriteHandler
 from oio.api.io import MetachunkPreparer
@@ -643,7 +642,7 @@ class ObjectStorageApi(object):
     @ensure_headers
     @ensure_request_id
     def object_touch(self, account, container, obj,
-                     version=None, cid=None, **kwargs):
+                     version=None, **kwargs):
         """
         Trigger a notification about an object
         (as if it just had been created).
@@ -655,7 +654,7 @@ class ObjectStorageApi(object):
         :param obj: name of the object to touch
         """
         self.container.content_touch(account, container, obj,
-                                     version=version, cid=cid, **kwargs)
+                                     version=version, **kwargs)
 
     @ensure_headers
     @ensure_request_id
@@ -804,7 +803,7 @@ class ObjectStorageApi(object):
     @handle_object_not_found
     @ensure_headers
     @ensure_request_id
-    def object_locate(self, account, container, obj, cid=None,
+    def object_locate(self, account, container, obj,
                       version=None, chunk_info=False, properties=True,
                       **kwargs):
         """
@@ -826,7 +825,7 @@ class ObjectStorageApi(object):
         """
         obj_meta, chunks = self.container.content_locate(
             account, container, obj, properties=properties,
-            version=version, cid=cid, **kwargs)
+            version=version, **kwargs)
 
         # FIXME(FVE): converting to float does not sort properly
         # the chunks of the same metachunk
@@ -922,7 +921,7 @@ class ObjectStorageApi(object):
     @ensure_headers
     @ensure_request_id
     def object_fetch(self, account, container, obj, version=None, ranges=None,
-                     key_file=None, cid=None, **kwargs):
+                     key_file=None, **kwargs):
         """
         Download an object.
 
@@ -950,12 +949,25 @@ class ObjectStorageApi(object):
         if perfdata is not None:
             req_start = monotonic_time()
 
+        # Check cid format
+        cid_arg = kwargs.get('cid')
+        if cid_arg is not None:
+            cid_arg = cid_arg.upper()
+            cid_seq = cid_arg.split('.', 1)
+            try:
+                int(cid_seq[0], 16)
+                if len(cid_seq) > 1:
+                    int(cid_seq[1], 10)
+            except ValueError:
+                raise exc.OioException("Invalid cid: " + cid_arg)
+
         meta, raw_chunks = self.object_locate(
-            account, container, obj, version=version, cid=cid, **kwargs)
+            account, container, obj, version=version, **kwargs)
         chunk_method = meta['chunk_method']
         storage_method = STORAGE_METHODS.load(chunk_method)
         chunks = _sort_chunks(raw_chunks, storage_method.ec)
-        meta['container_id'] = cid or cid_from_name(account, container).upper()
+        meta['container_id'] = (
+            cid_arg or cid_from_name(account, container).upper())
         meta['ns'] = self.namespace
         if storage_method.ec:
             stream = fetch_stream_ec(chunks, ranges, storage_method, **kwargs)

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -643,7 +643,7 @@ class ObjectStorageApi(object):
     @ensure_headers
     @ensure_request_id
     def object_touch(self, account, container, obj,
-                     version=None, **kwargs):
+                     version=None, cid=None, **kwargs):
         """
         Trigger a notification about an object
         (as if it just had been created).
@@ -655,7 +655,7 @@ class ObjectStorageApi(object):
         :param obj: name of the object to touch
         """
         self.container.content_touch(account, container, obj,
-                                     version=version, **kwargs)
+                                     version=version, cid=cid, **kwargs)
 
     @ensure_headers
     @ensure_request_id
@@ -804,7 +804,7 @@ class ObjectStorageApi(object):
     @handle_object_not_found
     @ensure_headers
     @ensure_request_id
-    def object_locate(self, account, container, obj,
+    def object_locate(self, account, container, obj, cid=None,
                       version=None, chunk_info=False, properties=True,
                       **kwargs):
         """
@@ -826,7 +826,7 @@ class ObjectStorageApi(object):
         """
         obj_meta, chunks = self.container.content_locate(
             account, container, obj, properties=properties,
-            version=version, **kwargs)
+            version=version, cid=cid, **kwargs)
 
         # FIXME(FVE): converting to float does not sort properly
         # the chunks of the same metachunk
@@ -922,7 +922,7 @@ class ObjectStorageApi(object):
     @ensure_headers
     @ensure_request_id
     def object_fetch(self, account, container, obj, version=None, ranges=None,
-                     key_file=None, **kwargs):
+                     key_file=None, cid=None, **kwargs):
         """
         Download an object.
 
@@ -951,11 +951,11 @@ class ObjectStorageApi(object):
             req_start = monotonic_time()
 
         meta, raw_chunks = self.object_locate(
-            account, container, obj, version=version, **kwargs)
+            account, container, obj, version=version, cid=cid, **kwargs)
         chunk_method = meta['chunk_method']
         storage_method = STORAGE_METHODS.load(chunk_method)
         chunks = _sort_chunks(raw_chunks, storage_method.ec)
-        meta['container_id'] = cid_from_name(account, container).upper()
+        meta['container_id'] = cid or cid_from_name(account, container).upper()
         meta['ns'] = self.namespace
         if storage_method.ec:
             stream = fetch_stream_ec(chunks, ranges, storage_method, **kwargs)

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -299,6 +299,13 @@ class FlushContainer(ContainerCommandMixin, command.Command):
  on the event system"""
         )
         self.patch_parser_container(parser)
+        parser.add_argument(
+            '--quickly',
+            action='store_true',
+            dest='quick',
+            help="""Flush container quickly, may put high pressure
+ on the event system"""
+)
         return parser
 
     def take_action(self, parsed_args):

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -82,7 +82,7 @@ class ContainerCommandMixin(object):
         parser.add_argument(
             'container',
             metavar='<container>',
-            help=("Name or cid of the container to interact with.\n")
+            help=("Name or CID of the container to interact with.\n")
         )
 
     def take_action_container(self, parsed_args):
@@ -115,7 +115,7 @@ class ContainersCommandMixin(object):
             'containers',
             metavar='<containers>',
             nargs='+',
-            help=("Names or cids of the containers to interact with.\n")
+            help=("Names or CIDs of the containers to interact with.\n")
         )
 
 
@@ -173,8 +173,9 @@ class CreateContainer(SetPropertyCommandMixin, lister.Lister):
 
 class SetContainer(SetPropertyCommandMixin,
                    ContainerCommandMixin, command.Command):
-    """Set container properties, quota, storage policy,
-    status or versioning."""
+    """
+    Set container properties, quota, storage policy, status or versioning.
+    """
 
     log = getLogger(__name__ + '.SetContainer')
 

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -67,6 +67,53 @@ class SetPropertyCommandMixin(object):
 """
         )
 
+class ContainerCommandMixin(object):
+    """Command taking a container or CID as parameter"""
+
+    def patch_parser_container(self, parser):
+        parser.add_argument(
+            '--cid',
+            dest='is_cid',
+            default=False,
+            help="Interpret container as a CID",
+            action='store_true'
+        )
+        parser.add_argument(
+            'container',
+            metavar='<container>',
+            help=("Name or cid of the container to interact with.\n")
+        )
+
+    def take_action_container(self, parsed_args):
+        parsed_args.cid = None
+        if parsed_args.is_cid:
+            parsed_args.cid = parsed_args.container
+            parsed_args.container = None
+
+class ContainersCommandMixin(object):
+    """Command taking some containers or CIDs as parameter"""
+
+    def patch_parser_container(self, parser):
+        parser.add_argument(
+            '--cid',
+            dest='is_cid',
+            default=False,
+            help="Interpret containers as a CID",
+            action='store_true'
+        )
+        parser.add_argument(
+            'containers',
+            metavar='<containers>',
+            nargs='+',
+            help=("Names or cids of the containers to interact with.\n")
+        )
+
+    def take_action_container(self, parsed_args):
+        parsed_args.cid = None
+        if parsed_args.is_cid:
+            parsed_args.cid = parsed_args.container
+            parsed_args.container = None
+
 
 class CreateContainer(SetPropertyCommandMixin, lister.Lister):
     """Create an object container."""
@@ -120,21 +167,17 @@ class CreateContainer(SetPropertyCommandMixin, lister.Lister):
         return ('Name', 'Created'), (r for r in results)
 
 
-class SetContainer(SetPropertyCommandMixin, command.Command):
-    """
-    Set container properties, quota, storage policy, status or versioning.
-    """
+
+class SetContainer(SetPropertyCommandMixin,
+                   ContainerCommandMixin, command.Command):
+    """Set container properties, quota, storage policy or versioning."""
 
     log = getLogger(__name__ + '.SetContainer')
 
     def get_parser(self, prog_name):
         parser = super(SetContainer, self).get_parser(prog_name)
         self.patch_parser(parser)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to modify'
-        )
+        self.patch_parser_container(parser)
         parser.add_argument(
             '--clear',
             dest='clear',
@@ -152,6 +195,7 @@ class SetContainer(SetPropertyCommandMixin, command.Command):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
 
+        super(SetContainer, self).take_action_container(parsed_args)
         properties = parsed_args.property
         system = dict()
         if parsed_args.quota is not None:
@@ -176,67 +220,72 @@ class SetContainer(SetPropertyCommandMixin, command.Command):
             parsed_args.container,
             properties,
             clear=parsed_args.clear,
-            system=system
+            system=system,
+            cid=parsed_args.cid
         )
 
 
-class TouchContainer(command.Command):
+class TouchContainer(ContainersCommandMixin, command.Command):
     """Touch an object container, triggers asynchronous treatments on it."""
 
     log = getLogger(__name__ + '.TouchContainer')
 
     def get_parser(self, prog_name):
         parser = super(TouchContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'containers',
-            metavar='<container>',
-            nargs='+',
-            help='Container(s) to touch'
-        )
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
+        if parsed_args.is_cid:
+            for container in parsed_args.containers:
+                self.app.client_manager.storage.container_touch(
+                    self.app.client_manager.account,
+                    None, cid=container
+                )
+        else:
+            for container in parsed_args.containers:
+                self.app.client_manager.storage.container_touch(
+                    self.app.client_manager.account,
+                    container
+                )
 
-        for container in parsed_args.containers:
-            self.app.client_manager.storage.container_touch(
-                self.app.client_manager.account,
-                container
-            )
 
-
-class DeleteContainer(command.Command):
+class DeleteContainer(ContainersCommandMixin, command.Command):
     """Delete an object container."""
 
     log = getLogger(__name__ + '.DeleteContainer')
 
     def get_parser(self, prog_name):
         parser = super(DeleteContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'containers',
-            metavar='<container>',
-            nargs='+',
-            help='Container(s) to delete'
-        )
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
 
-        for container in parsed_args.containers:
-            self.app.client_manager.storage.container_delete(
-                self.app.client_manager.account,
-                container
-            )
+        if parsed_args.is_cid:
+            for container in parsed_args.containers:
+                self.app.client_manager.storage.container_delete(
+                    self.app.client_manager.account,
+                    None, cid=container
+                )
+        else:
+            for container in parsed_args.containers:
+                self.app.client_manager.storage.container_delete(
+                    self.app.client_manager.account,
+                    container
+                )
 
 
-class FlushContainer(command.Command):
+class FlushContainer(ContainerCommandMixin, command.Command):
     """Flush an object container."""
 
     log = getLogger(__name__ + '.FlushContainer')
 
     def get_parser(self, prog_name):
         parser = super(FlushContainer, self).get_parser(prog_name)
+<<<<<<< HEAD
         parser.add_argument(
             'container',
             metavar='<container>',
@@ -249,42 +298,46 @@ class FlushContainer(command.Command):
             help="""Flush container quickly, may put high pressure
  on the event system"""
         )
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-
+        super(FlushContainer, self).take_action_container(parsed_args)
+        if parsed_args.cid is not None:
+            data = self.app.client_manager.storage.container_get_properties(
+                self.app.client_manager.account,
+                parsed_args.container,
+                cid=parsed_args.cid
+            )
+            parsed_args.container = data['system']['sys.user.name']
         self.app.client_manager.storage.container_flush(
             self.app.client_manager.account, parsed_args.container,
             fast=parsed_args.quick)
 
 
-class ShowContainer(show.ShowOne):
+class ShowContainer(ContainerCommandMixin, show.ShowOne):
     """Display information about an object container."""
 
     log = getLogger(__name__ + '.ShowContainer')
 
     def get_parser(self, prog_name):
         parser = super(ShowContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Name of the container to display information about'
-        )
-
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
 
         account = self.app.client_manager.account
-
+        super(ShowContainer, self).take_action_container(parsed_args)
         # The command is named 'show' but we must call
         # container_get_properties() because container_show() does
         # not return system properties (and we need them).
         data = self.app.client_manager.storage.container_get_properties(
             account,
-            parsed_args.container
+            parsed_args.container,
+            cid=parsed_args.cid
         )
 
         sys = data['system']
@@ -405,18 +458,14 @@ class ListContainer(lister.Lister):
         return columns, ((v[0], v[2], v[1]) for v in listing)
 
 
-class UnsetContainer(command.Command):
+class UnsetContainer(ContainerCommandMixin, command.Command):
     """Unset container properties."""
 
     log = getLogger(__name__ + '.UnsetContainer')
 
     def get_parser(self, prog_name):
         parser = super(UnsetContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to modify'
-        )
+        self.patch_parser_container(parser)
         parser.add_argument(
             '--property',
             metavar='<key>',
@@ -453,6 +502,7 @@ class UnsetContainer(command.Command):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
 
+        super(UnsetContainer, self).take_action_container(parsed_args)
         properties = parsed_args.property
         system = dict()
         if parsed_args.storage_policy:
@@ -468,41 +518,40 @@ class UnsetContainer(command.Command):
             self.app.client_manager.storage.container_del_properties(
                 self.app.client_manager.account,
                 parsed_args.container,
-                properties)
+                properties, cid=parsed_args.cid)
         if system:
             self.app.client_manager.storage.container_set_properties(
                 self.app.client_manager.account,
                 parsed_args.container,
-                system=system)
+                system=system, cid=parsed_args.cid)
 
 
-class SaveContainer(command.Command):
+class SaveContainer(ContainerCommandMixin, command.Command):
     """Save all objects of a container locally."""
 
     log = getLogger(__name__ + '.SaveContainer')
 
     def get_parser(self, prog_name):
         parser = super(SaveContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to save')
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         import os
 
         self.log.debug('take_action(%s)', parsed_args)
+        super(SaveContainer, self).take_action_container(parsed_args)
 
         account = self.app.client_manager.account
         container = parsed_args.container
+        cid = parsed_args.cid
         objs = self.app.client_manager.storage.object_list(
-            account, container)
+            account, container, cid=cid)
 
         for obj in objs['objects']:
             obj_name = obj['name']
             _, stream = self.app.client_manager.storage.object_fetch(
-                account, container, obj_name, properties=False)
+                account, container, obj_name, properties=False, cid=cid)
 
             if not os.path.exists(os.path.dirname(obj_name)):
                 if len(os.path.dirname(obj_name)) > 0:
@@ -512,32 +561,28 @@ class SaveContainer(command.Command):
                     f.write(chunk)
 
 
-class LocateContainer(show.ShowOne):
+class LocateContainer(ContainerCommandMixin, show.ShowOne):
     """Locate the services in charge of a container."""
 
     log = getLogger(__name__ + '.LocateContainer')
 
     def get_parser(self, prog_name):
         parser = super(LocateContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to show'
-        )
-
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
+        super(LocateContainer, self).take_action_container(parsed_args)
 
         account = self.app.client_manager.account
         container = parsed_args.container
-
+        cid = parsed_args.cid
         data = self.app.client_manager.storage.container_get_properties(
-            account, container)
+            account, container, cid=cid)
 
         data_dir = self.app.client_manager.storage.directory.list(
-            account, container)
+            account, container, cid=cid)
 
         info = {
             'account': data['system']['sys.account'],
@@ -565,18 +610,14 @@ class LocateContainer(show.ShowOne):
         return zip(*sorted(info.iteritems()))
 
 
-class PurgeContainer(command.Command):
+class PurgeContainer(ContainerCommandMixin, command.Command):
     """Purge exceeding object versions."""
 
     log = getLogger(__name__ + '.PurgeContainer')
 
     def get_parser(self, prog_name):
         parser = super(PurgeContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to purge',
-        )
+        self.patch_parser_container(parser)
         parser.add_argument(
             '--max-versions',
             metavar='<n>',
@@ -592,38 +633,41 @@ class PurgeContainer(command.Command):
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
+        super(PurgeContainer, self).take_action_container(parsed_args)
 
         account = self.app.client_manager.account
         self.app.client_manager.storage.container_purge(
-            account, parsed_args.container, maxvers=parsed_args.max_versions
+            account, parsed_args.container,
+            maxvers=parsed_args.max_versions,
+            cid=parsed_args.cid
         )
 
 
-class RefreshContainer(command.Command):
+class RefreshContainer(ContainerCommandMixin, command.Command):
     """ Refresh counters of an account (triggers asynchronous treatments) """
 
     log = getLogger(__name__ + '.RefreshContainer')
 
     def get_parser(self, prog_name):
         parser = super(RefreshContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to refresh',
-        )
+        self.patch_parser_container(parser)
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-
+        super(RefreshContainer, self).take_action_container(parsed_args)
         account = self.app.client_manager.account
+        if parsed_args.cid is not None:
+            data = self.app.client_manager.storage.container_get_properties(
+                account, None, cid=parsed_args.cid)
+            parsed_args.container = data['system']['sys.user.name']
         self.app.client_manager.storage.container_refresh(
             account=account,
             container=parsed_args.container
         )
 
 
-class SnapshotContainer(lister.Lister):
+class SnapshotContainer(ContainerCommandMixin, lister.Lister):
     """
     Take a snapshot of a container.
 
@@ -636,11 +680,7 @@ class SnapshotContainer(lister.Lister):
 
     def get_parser(self, prog_name):
         parser = super(SnapshotContainer, self).get_parser(prog_name)
-        parser.add_argument(
-            'container',
-            metavar='<container>',
-            help='Container to snapshot'
-        )
+        self.patch_parser_container(parser)
         parser.add_argument(
             '--dst-account',
             metavar='<account>',
@@ -664,15 +704,21 @@ class SnapshotContainer(lister.Lister):
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-
+        super(SnapshotContainer, self).take_action_container(parsed_args)
         account = self.app.client_manager.account
         container = parsed_args.container
+        cid = parsed_args.cid
         dst_account = parsed_args.dst_account or account
+        if cid is not None:
+            data = self.app.client_manager.storage.container_get_properties(
+                account, container, cid=cid)
+            container = data['system']['sys.user.name']
         dst_container = (parsed_args.dst_container or
                          (container + "-" + Timestamp(time()).normal))
         batch = parsed_args.chunk_batch_size
 
         self.app.client_manager.storage.container_snapshot(
-            account, container, dst_account, dst_container, batch=batch)
+            account, container, dst_account,
+            dst_container, batch=batch)
         lines = [(dst_account, dst_container, "OK")]
         return ('Account', 'Container', 'Status'), lines

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -139,7 +139,7 @@ class CreateObject(ContainerCommandMixin, lister.Lister):
         super(CreateObject, self).take_action(parsed_args)
 
         container = parsed_args.container
-        cid =  parsed_args.cid
+        cid = parsed_args.cid
         policy = parsed_args.policy
         objs = parsed_args.objects
         names = parsed_args.name
@@ -301,8 +301,10 @@ class DeleteObject(ContainerCommandMixin, lister.Lister):
                 container = parsed_args.container
                 cid = parsed_args.cid
                 if cid is not None:
-                    data = self.app.client_manager.storage.container_get_properties(
-                        self.app.client_manager.account, None, cid=cid)
+                    data = (
+                        self.app.client_manager.storage.
+                        container_get_properties(
+                            self.app.client_manager.account, None, cid=cid))
                     container = data['system']['sys.user.name']
                 results = self.app.client_manager.storage.object_delete_many(
                     account,
@@ -885,6 +887,11 @@ class LinkObject(ObjectCommandMixin, command.Command):
             parsed_args.link_account = account
         if not parsed_args.link_container:
             parsed_args.link_container = container
+            parsed_args.cid = None
+        cid = None
+        if parsed_args.is_cid:
+            cid = container
+            container = None
 
         self.app.client_manager.storage.object_link(
             account, container, parsed_args.object,
@@ -892,5 +899,5 @@ class LinkObject(ObjectCommandMixin, command.Command):
             parsed_args.link_object, maxvers=parsed_args.object_version,
             target_content_id=parsed_args.content_id,
             link_content_id=parsed_args.link_content_id,
-            properties_directive=directive, **kwargs
+            properties_directive=directive, cid=cid, **kwargs
         )

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -500,7 +500,7 @@ class ContainerClient(ProxyClient):
             return results
         except exceptions.NotFound:
             for obj in paths:
-                rc = self.content_delete(account, reference, obj, cid=cid
+                rc = self.content_delete(account, reference, obj, cid=cid,
                                          **kwargs)
                 results.append((obj, rc))
             return results
@@ -568,7 +568,7 @@ class ContainerClient(ProxyClient):
         :keyword autocreate: create container if it doesn't exist
         """
         uri = self._make_uri('content/prepare')
-        params = self._make_params(account, reference, path,
+        params = self._make_params(account, reference, path, cid=cid,
                                    content=content_id)
         data = {'size': size}
         if stgpol:

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -500,7 +500,7 @@ class ContainerClient(ProxyClient):
             return results
         except exceptions.NotFound:
             for obj in paths:
-                rc = self.content_delete(account, reference, obj, cid=cid,
+                rc = self.content_delete(account, reference, obj, cid=cid
                                          **kwargs)
                 results.append((obj, rc))
             return results
@@ -568,7 +568,7 @@ class ContainerClient(ProxyClient):
         :keyword autocreate: create container if it doesn't exist
         """
         uri = self._make_uri('content/prepare')
-        params = self._make_params(account, reference, path, cid=cid,
+        params = self._make_params(account, reference, path,
                                    content=content_id)
         data = {'size': size}
         if stgpol:

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -28,6 +28,7 @@ class ContainerTest(CliTestCase):
     def setUpClass(cls):
         opts = cls.get_opts(['Name'])
         output = cls.openio('container create ' + cls.NAME + opts)
+        cls.CID = cls._get_cid_from_name(cls.NAME)
         cls.assertOutput(cls.NAME + '\n', output)
 
     @classmethod
@@ -35,25 +36,59 @@ class ContainerTest(CliTestCase):
         output = cls.openio('container delete ' + cls.NAME)
         cls.assertOutput('', output)
 
-    def test_container_show(self):
+    @classmethod
+    def _get_cid_from_name(self, name):
+        opts = self.get_opts([], 'json')
+        output = self.openio('container show ' + name + opts)
+        data = self.json_loads(output)
+        return data['base_name']
+
+    def _test_container_show(self, with_cid=False):
         opts = self.get_opts(['container'])
-        output = self.openio('container show ' + self.NAME + opts)
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
+        output = self.openio('container show '+ cid_opt + name + opts)
         self.assertEqual(self.NAME + '\n', output)
 
-    def test_container_show_table(self):
+    def test_container_show(self):
+        self._test_container_show()
+
+    def test_container_show_with_cid(self):
+        self._test_container_show(with_cid=True)
+
+    def _test_container_show_table(self, with_cid=False):
         opts = self.get_opts([], 'table')
-        output = self.openio('container show ' + self.NAME + opts)
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
+        output = self.openio('container show ' + cid_opt +name + opts)
         regex = "|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes_usage", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
+
+    def test_container_show_table(self):
+        self._test_container_show_table()
+
+    def test_container_show_table_with_cid(self):
+        self._test_container_show_table(with_cid=True)
 
     def test_container_list(self):
         opts = self.get_opts(['Name'])
         output = self.openio('container list ' + opts)
         self.assertIn(self.NAME, output)
 
-    def test_container_refresh(self):
-        self.openio('container refresh ' + self.NAME)
+    def _test_container_refresh(self, with_cid=False):
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
+        self.openio('container refresh ' + cid_opt + name)
         opts = self.get_opts([], 'json')
         output = self.openio('container list ' + opts)
         containers = self.json_loads(output)
@@ -64,10 +99,21 @@ class ContainerTest(CliTestCase):
                 return
         self.fail("No container %s" % self.NAME)
 
-    def test_container_snapshot(self):
+    def test_container_refresh(self):
+        self._test_container_refresh()
+
+    def test_container_refresh_with_cid(self):
+        self._test_container_refresh(with_cid=True)
+
+    def _test_container_snapshot(self, with_cid=False):
         # Snapshot should reply the name of the snapshot on success
         opts = self.get_opts([], 'json')
-        output = self.openio('container snapshot ' + self.NAME + opts)
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
+        output = self.openio('container snapshot ' + cid_opt + name + opts)
         output = self.json_loads(output)[0]
         self.assertEqual(output['Status'], "OK")
         # Snapshot should reply Missing container on non existant container
@@ -79,7 +125,7 @@ class ContainerTest(CliTestCase):
         dst_container = random_str(16)
         opts += " --dst-account " + dst_account
         opts += " --dst-container " + dst_container
-        output = self.openio('container snapshot ' + self.NAME + opts)
+        output = self.openio('container snapshot ' +  cid_opt + name + opts)
         output = self.json_loads(output)[0]
         self.assertEqual(output['Account'], dst_account)
         self.assertEqual(output['Container'], dst_container)
@@ -88,13 +134,36 @@ class ContainerTest(CliTestCase):
         #   specified name
         self.assertRaises(CommandFailed,
                           self.openio,
-                          ('container snapshot ' + self.NAME + opts))
+                          ('container snapshot ' + cid_opt + name + opts))
 
-    def test_container_purge(self):
-        output = self.openio('container purge ' + self.NAME)
+    def test_container_snapshot(self):
+        self._test_container_snapshot()
+
+    def test_container_snapshot_with_cid(self):
+        self._test_container_snapshot(with_cid=True)
+
+    def _test_container_purge(self, with_cid=False):
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
+        output = self.openio('container purge ' + cid_opt  +name)
         self.assertEqual('', output)
 
-    def test_container_flush(self):
+    def test_container_purge(self):
+        self._test_container_purge()
+
+    def test_container_purge_with_cid(self):
+        self._test_container_purge(with_cid=True)
+
+
+    def _test_container_flush(self, with_cid=False):
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write('test_exists')
             f.flush()
@@ -103,10 +172,16 @@ class ContainerTest(CliTestCase):
                 obj_name = random_str(16)
                 self.openio('object create ' + self.NAME
                             + ' ' + obj + ' --name ' + obj_name)
-        output = self.openio('container flush ' + self.NAME)
+        output = self.openio('container flush ' + cid_opt +name)
         self.assertEqual('', output)
         output = self.openio('object list ' + self.NAME)
         self.assertEqual('\n', output)
+
+    def test_container_flush(self):
+        self._test_container_flush()
+
+    def test_container_flush_with_cid(self):
+        self._test_container_flush(with_cid=True)
 
     def test_container_flush_quickly(self):
         with tempfile.NamedTemporaryFile(delete=False) as f:

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -45,12 +45,12 @@ class ContainerTest(CliTestCase):
 
     def _test_container_show(self, with_cid=False):
         opts = self.get_opts(['container'])
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
             name = self.CID
-        output = self.openio('container show '+ cid_opt + name + opts)
+        output = self.openio('container show ' + cid_opt + name + opts)
         self.assertEqual(self.NAME + '\n', output)
 
     def test_container_show(self):
@@ -61,12 +61,12 @@ class ContainerTest(CliTestCase):
 
     def _test_container_show_table(self, with_cid=False):
         opts = self.get_opts([], 'table')
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
             name = self.CID
-        output = self.openio('container show ' + cid_opt +name + opts)
+        output = self.openio('container show ' + cid_opt + name + opts)
         regex = "|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes_usage", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
@@ -83,7 +83,7 @@ class ContainerTest(CliTestCase):
         self.assertIn(self.NAME, output)
 
     def _test_container_refresh(self, with_cid=False):
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
@@ -108,7 +108,7 @@ class ContainerTest(CliTestCase):
     def _test_container_snapshot(self, with_cid=False):
         # Snapshot should reply the name of the snapshot on success
         opts = self.get_opts([], 'json')
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
@@ -125,7 +125,7 @@ class ContainerTest(CliTestCase):
         dst_container = random_str(16)
         opts += " --dst-account " + dst_account
         opts += " --dst-container " + dst_container
-        output = self.openio('container snapshot ' +  cid_opt + name + opts)
+        output = self.openio('container snapshot ' + cid_opt + name + opts)
         output = self.json_loads(output)[0]
         self.assertEqual(output['Account'], dst_account)
         self.assertEqual(output['Container'], dst_container)
@@ -143,12 +143,12 @@ class ContainerTest(CliTestCase):
         self._test_container_snapshot(with_cid=True)
 
     def _test_container_purge(self, with_cid=False):
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
             name = self.CID
-        output = self.openio('container purge ' + cid_opt  +name)
+        output = self.openio('container purge ' + cid_opt + name)
         self.assertEqual('', output)
 
     def test_container_purge(self):
@@ -157,9 +157,8 @@ class ContainerTest(CliTestCase):
     def test_container_purge_with_cid(self):
         self._test_container_purge(with_cid=True)
 
-
     def _test_container_flush(self, with_cid=False):
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
@@ -172,7 +171,7 @@ class ContainerTest(CliTestCase):
                 obj_name = random_str(16)
                 self.openio('object create ' + self.NAME
                             + ' ' + obj + ' --name ' + obj_name)
-        output = self.openio('container flush ' + cid_opt +name)
+        output = self.openio('container flush ' + cid_opt + name)
         self.assertEqual('', output)
         output = self.openio('object list ' + self.NAME)
         self.assertEqual('\n', output)
@@ -184,7 +183,7 @@ class ContainerTest(CliTestCase):
         self._test_container_flush(with_cid=True)
 
     def _test_container_flush_quickly(self, with_cid=False):
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
@@ -195,13 +194,13 @@ class ContainerTest(CliTestCase):
             obj = f.name
             for i in range(10):
                 obj_name = random_str(16)
-                self.openio('object create ' +  cid_opt + name
+                self.openio('object create ' + cid_opt + name
                             + ' ' + obj + ' --name ' + obj_name)
-        output = self.openio('container flush --quickly ' +  cid_opt + name )
+        output = self.openio('container flush --quickly ' + cid_opt + name)
         self.assertEqual('', output)
         output = self.openio('object list ' + cid_opt + name)
         self.assertEqual('\n', output)
-        
+
     def test_container_flush_quickly(self):
         self._test_container_flush_quickly()
 
@@ -209,7 +208,7 @@ class ContainerTest(CliTestCase):
         self._test_container_flush_quickly(with_cid=True)
 
     def _test_container_set_status(self, with_cid=False):
-        cid_opt=''
+        cid_opt = ''
         name = self.NAME
         if with_cid:
             cid_opt = '--cid '
@@ -223,7 +222,8 @@ class ContainerTest(CliTestCase):
         output = self.openio('container show ' + cid_opt + name + opts)
         output = self.json_loads(output)
         self.assertEqual(output['status'], "Frozen")
-        output = self.openio('container set --status enabled ' + cid_opt + name)
+        output = self.openio('container set --status enabled ' +
+                             cid_opt + name)
         self.assertEqual('', output)
         output = self.openio('container show ' + cid_opt + name + opts)
         output = self.json_loads(output)

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -183,32 +183,54 @@ class ContainerTest(CliTestCase):
     def test_container_flush_with_cid(self):
         self._test_container_flush(with_cid=True)
 
-    def test_container_flush_quickly(self):
+    def _test_container_flush_quickly(self, with_cid=False):
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write('test_exists')
             f.flush()
             obj = f.name
             for i in range(10):
                 obj_name = random_str(16)
-                self.openio('object create ' + self.NAME
+                self.openio('object create ' +  cid_opt + name
                             + ' ' + obj + ' --name ' + obj_name)
-        output = self.openio('container flush --quickly ' + self.NAME)
+        output = self.openio('container flush --quickly ' +  cid_opt + name )
         self.assertEqual('', output)
-        output = self.openio('object list ' + self.NAME)
+        output = self.openio('object list ' + cid_opt + name)
         self.assertEqual('\n', output)
+        
+    def test_container_flush_quickly(self):
+        self._test_container_flush_quickly()
 
-    def test_container_set_status(self):
+    def test_container_flush_quickly_with_cid(self):
+        self._test_container_flush_quickly(with_cid=True)
+
+    def _test_container_set_status(self, with_cid=False):
+        cid_opt=''
+        name = self.NAME
+        if with_cid:
+            cid_opt = '--cid '
+            name = self.CID
         opts = ' -f json'
-        output = self.openio('container show ' + self.NAME + opts)
+        output = self.openio('container show ' + cid_opt + name + opts)
         output = self.json_loads(output)
         self.assertEqual(output['status'], "Enabled")
-        output = self.openio('container set --status frozen ' + self.NAME)
+        output = self.openio('container set --status frozen ' + cid_opt + name)
         self.assertEqual('', output)
-        output = self.openio('container show ' + self.NAME + opts)
+        output = self.openio('container show ' + cid_opt + name + opts)
         output = self.json_loads(output)
         self.assertEqual(output['status'], "Frozen")
-        output = self.openio('container set --status enabled ' + self.NAME)
+        output = self.openio('container set --status enabled ' + cid_opt + name)
         self.assertEqual('', output)
-        output = self.openio('container show ' + self.NAME + opts)
+        output = self.openio('container show ' + cid_opt + name + opts)
         output = self.json_loads(output)
         self.assertEqual(output['status'], "Enabled")
+
+    def test_container_set_status(self):
+        self._test_container_set_status()
+
+    def test_container_set_status_with_cid(self):
+        self._test_container_set_status(with_cid=True)

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -36,15 +36,28 @@ class ObjectTest(CliTestCase):
     """Functional tests for objects."""
 
     CONTAINER_NAME = uuid.uuid4().hex
+    
+    @classmethod
+    def _get_cid_from_name(self, name):
+        opts = self.get_opts([], 'json')
+        output = self.openio('container show ' + name + opts)
+        data = self.json_loads(output)
+        return data['base_name']
 
-    def test_obj(self):
+    def __test_obj(self, name, with_cid=False):
         with tempfile.NamedTemporaryFile() as f:
             test_content = 'test content'
             f.write(test_content)
             f.flush()
-            self._test_obj(f.name, test_content, self.CONTAINER_NAME)
-        self._test_many_obj()
-
+            self._test_obj(f.name, test_content, name, with_cid=with_cid)
+        self._test_many_obj(with_cid=with_cid)
+        
+    def test_obj(self):
+        self.__test_obj(uuid.uuid4().hex)
+        
+    def test_obj_with_cid(self):
+        self.__test_obj(uuid.uuid4().hex, with_cid=True)
+        
     def test_obj_without_autocreate(self):
         with tempfile.NamedTemporaryFile() as f:
             test_content = 'test content'
@@ -57,11 +70,16 @@ class ObjectTest(CliTestCase):
                 'object create --no-autocreate ' +
                 uuid.uuid4().hex + ' ' + f.name)
 
-    def _test_many_obj(self):
+    def _test_many_obj(self, with_cid=False):
         cname = self.CONTAINER_NAME
+        cid_opt = ''
+        if with_cid:
+            cname = self._get_cid_from_name(self.CONTAINER_NAME)
+            cid_opt = '--cid '
         opts = self.get_opts([], 'json')
         obj_name_exists = ''
         obj_name_also_exists = ''
+        
         # delete 2 existent
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write('test_exists')
@@ -73,16 +91,16 @@ class ObjectTest(CliTestCase):
             f.flush()
             obj_file_also_exists = f.name
             obj_name_also_exists = os.path.basename(f.name)
-        self.openio('object create ' + ' ' + cname +
+        self.openio('object create ' + cid_opt +' ' + cname +
                     ' ' + obj_file_exists + ' ' + obj_file_also_exists
                     + ' ' + opts)
-        output = self.openio('object delete ' + cname + ' ' + obj_name_exists
-                             + ' ' + obj_name_also_exists + opts)
+        output = self.openio('object delete ' + cid_opt+ cname + ' ' +
+                             obj_name_exists + ' ' + obj_name_also_exists + opts)
         data_json = self.json_loads(output)
         self.assertEqual(data_json[0]['Deleted'], True)
         self.assertEqual(data_json[1]['Deleted'], True)
         # delete 2 nonexistent
-        output = self.openio('object delete ' + cname + ' ' +
+        output = self.openio('object delete ' + cid_opt +cname + ' ' +
                              'should_not_exists' + ' ' +
                              'should_also_not_exists' + opts)
         data_json = self.json_loads(output)
@@ -94,10 +112,10 @@ class ObjectTest(CliTestCase):
             f.flush()
             obj_file_exists = f.name
             obj_name_exists = os.path.basename(f.name)
-        self.openio('object create ' + ' ' + cname +
+        self.openio('object create ' + cid_opt +' ' + cname +
                     ' ' + obj_file_exists + opts)
-        output = self.openio('object delete ' + cname + ' ' + obj_name_exists
-                             + ' should_not_exists' + opts)
+        output = self.openio('object delete ' + cid_opt + cname + ' ' +
+                             obj_name_exists + ' should_not_exists' + opts)
         data_json = self.json_loads(output)
         self.assertEqual(data_json[0]['Deleted'], True)
         self.assertEqual(data_json[1]['Deleted'], False)
@@ -110,7 +128,8 @@ class ObjectTest(CliTestCase):
     def _test_auto_container(self, test_content):
         self._test_obj('/etc/fstab', test_content, '06EE0', auto='--auto')
 
-    def _test_obj(self, obj_file, test_content, cname, auto=''):
+    def _test_obj(self, obj_file, test_content, cname, auto='', with_cid=False):
+        cid_opt=''
         checksum = md5(test_content).hexdigest().upper()
         opts = self.get_opts([], 'json')
         output = self.openio('container create ' + cname + opts)
@@ -118,6 +137,10 @@ class ObjectTest(CliTestCase):
         self.assertThat(len(data), Equals(1))
         self.assert_list_fields(data, HEADERS)
         self.assertThat(data[0]['Name'], Equals(cname))
+        cname_or_cid = cname
+        if with_cid:
+            cname_or_cid = self._get_cid_from_name(cname)
+            cid_opt = '--cid '
         # TODO ensure a clean environment before the test, and proper cleanup
         # after, so that we can check the container is properly created
         if not auto:
@@ -151,7 +174,7 @@ class ObjectTest(CliTestCase):
         self.assertThat(item['Hash'], Equals(checksum))
 
         opts = self.get_opts([], 'json')
-        output = self.openio('object list ' + cname + opts)
+        output = self.openio('object list ' + cid_opt + cname_or_cid + opts)
         listing = self.json_loads(output)
         self.assert_list_fields(listing, OBJ_HEADERS)
         self.assertThat(len(data), Equals(2))
@@ -160,42 +183,53 @@ class ObjectTest(CliTestCase):
         self.assertThat(item['Size'], Equals(len(test_content)))
         self.assertThat(item['Hash'], Equals(checksum))
 
-        output = self.openio('object save ' + cname + ' ' + obj_name)
+        output = self.openio('object save ' + cid_opt + cname_or_cid + ' ' + obj_name)
         self.addCleanup(os.remove, obj_name)
         self.assertOutput('', output)
 
         tmp_file = 'tmp_obj'
-        output = self.openio('object save ' + cname +
+        output = self.openio('object save ' + cid_opt + cname_or_cid +
                              ' ' + obj_name + ' --file ' + tmp_file)
         self.addCleanup(os.remove, tmp_file)
         self.assertOutput('', output)
 
         opts = self.get_opts([], 'json')
-        output = self.openio('object show ' + cname + ' ' + obj_name + opts)
+        output = self.openio('object show ' + cid_opt + cname_or_cid + ' ' + obj_name + opts)
         data = self.json_loads(output)
         self.assert_show_fields(data, OBJ_FIELDS)
         self.assertThat(data['object'], Equals(obj_name))
         self.assertThat(data['size'], Equals(str(len(test_content))))
         self.assertThat(data['hash'], Equals(checksum))
 
-        output = self.openio('object delete ' + cname + ' ' + obj_name + opts)
+        output = self.openio('object delete ' + cid_opt + cname_or_cid + ' ' + obj_name + opts)
         self.assertEqual(True, self.json_loads(output)[0]['Deleted'])
 
-    def test_drain(self):
+    def _test_drain(self, with_cid=False):
         cname = random_str(16)
+        cid_opt = ''
+        if with_cid:
+            self.openio(' '.join(['container create', cname]))
+            cname = self._get_cid_from_name(cname)
+            cid_opt = '--cid'
+
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write('test_exists')
             f.flush()
             obj = f.name
             obj_name = random_str(16)
-            self.openio(' '.join(['object create ', cname, obj,
+            self.openio(' '.join(['object create ', cid_opt, cname, obj,
                                   '--name ', obj_name]))
-            self.openio(' '.join(['object drain ', cname, ' ', obj_name]))
+            self.openio(' '.join(['object drain ', cid_opt, cname, ' ', obj_name]))
 
         self.assertRaises(CommandFailed,
                           self.openio,
-                          ' '.join(['object drain', cname,
+                          ' '.join(['object drain', cid_opt, cname,
                                     'should not exist']))
+    def test_drain(self):
+        self._test_drain()
+
+    def test_drain_with_cid(self):
+        self._test_drain(with_cid=True)
 
     def test_autocontainer_object_listing(self):
         obj_count = 7


### PR DESCRIPTION
##### SUMMARY
Allow use CID instead of container name to openio object and container command
Fix OB-143

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
CLI
##### SDS VERSION
```
openio 4.2.1.dev25
```