### PR TITLE
rdir: Remove rtime

### DIFF
--- a/oio/cli/volume/client.py
+++ b/oio/cli/volume/client.py
@@ -53,7 +53,7 @@ class VolumeClientCli(object):
         info = self.volume.status(volume)
         data = {}
         containers = info.get('container')
-        data['chunk'] = info.get('chunk').get('total')
+        data['chunk'] = info.get('chunk')
         for ct in containers:
             data['container.%s' % ct] = json.dumps(containers[ct])
         return data

--- a/oio/cli/volume/client.py
+++ b/oio/cli/volume/client.py
@@ -44,8 +44,8 @@ class VolumeClientCli(object):
     def volume_admin_show(self, volume):
         return self.volume.admin_show(volume)
 
-    def volume_admin_clear(self, volume):
-        return self.volume.admin_clear(volume)
+    def volume_admin_clear(self, volume, **kwargs):
+        return self.volume.admin_clear(volume, **kwargs)
 
     def volume_show(self, volume):
         from oio.common.json import json

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -272,8 +272,11 @@ class RdirClient(HttpApi):
 
     @ensure_headers
     @ensure_request_id
-    def _rdir_request(self, volume, method, action, create=False, **kwargs):
-        params = {'vol': volume}
+    def _rdir_request(self, volume, method, action, create=False, params=None,
+                      **kwargs):
+        if params is None:
+            params = dict()
+        params['vol'] = volume
         if create:
             params['create'] = '1'
         uri = self._make_uri(action, volume, req_id=kwargs.get('X-oio-req-id'))
@@ -379,10 +382,12 @@ class RdirClient(HttpApi):
                                          **kwargs)
         return body
 
-    def admin_clear(self, volume, clear_all=False, **kwargs):
-        body = {'all': clear_all}
+    def admin_clear(self, volume, clear_all=False, before_incident=False,
+                    repair=False, **kwargs):
+        params = {'all': clear_all, 'before_incident': before_incident,
+                  'repair': repair}
         _resp, resp_body = self._rdir_request(
-            volume, 'POST', 'admin/clear', json=body, **kwargs)
+            volume, 'POST', 'admin/clear', params=params, **kwargs)
         return resp_body
 
     def status(self, volume, **kwargs):

--- a/tests/functional/rdir/test_server.py
+++ b/tests/functional/rdir/test_server.py
@@ -202,7 +202,7 @@ class TestRdirServer(RdirTestCase):
         resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status, 200)
         reference = [
-            [_key(rec), {'mtime': rec['mtime'], 'rtime': 0}]
+            [_key(rec), {'mtime': rec['mtime']}]
         ]
         self.assertListEqual(self.json_loads(resp.data), reference)
 
@@ -243,7 +243,7 @@ class TestRdirServer(RdirTestCase):
         resp = self._post("/v1/rdir/fetch", params={'vol': self.vol})
         self.assertEqual(resp.status, 200)
         self.assertEqual(self.json_loads(resp.data), [
-            [_key(rec), {'mtime': rec['mtime'], 'rtime': 0}]
+            [_key(rec), {'mtime': rec['mtime']}]
         ])
 
     def test_push_missing_fields(self):

--- a/tools/oio-test-rebuilder.sh
+++ b/tools/oio-test-rebuilder.sh
@@ -432,7 +432,7 @@ oio_blob_rebuilder()
     exit 1
   else
     echo >&2 "Remove the incident for the rawx ${RAWX_ID_TO_REBUILD}"
-    $CLI volume admin clear "${RAWX_ID_TO_REBUILD}"
+    $CLI volume admin clear "${RAWX_ID_TO_REBUILD} --before-incident"
 
     printf "${GREEN}\noio-blob-rebuilder: OK\n${NO_COLOR}"
   fi


### PR DESCRIPTION
##### SUMMARY

- `rdir`: remove `rtime`
- `CLI`: add options to clean a `rdir`
  * `--all`: clear all chunks entries
  * `--before-incident`: clear all chunks entries before incident date
  * `--repair`: repair all chunks entries

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `rdir`
- `CLI`

##### SDS VERSION

```
openio 4.2.2.dev10
```