### PR TITLE
Add options to blob-mover

### DIFF
--- a/bin/oio-blob-mover
+++ b/bin/oio-blob-mover
@@ -21,29 +21,94 @@ import argparse
 from oio.blob.mover import BlobMover
 from oio.common.daemon import run_daemon
 
+
 def make_arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('config', help="Configuration file")
-    parser.add_argument('--number', type=int,
-                        help="Number of chunk to move")
+    parser.add_argument('--namespace', '--ns', help="Namespace")
+    parser.add_argument('--volume', help="Volume to move")
+    parser.add_argument('config', help="Configuration file or empty file")
+    parser.add_argument('--generate-config', action='store_true',
+                        help="Generate configuration file with given arguments")
+    parser.add_argument('--edit-config', action='store_true',
+                        help="Edit configuration file with given arguments")
+    parser.add_argument('--limit', type=int,
+                        help="Number of chunks to move")
     parser.add_argument('--usage-target', type=int,
-                        help="Percentage of disk usage target")
-    parser.add_argument('--daemon', type=int,
-                        help="Interval to run the mover in seconds.")
+                        help="Target percentage of volume usage")
+    parser.add_argument('--daemon', action='store_true',
+                        help="Run mover as a daemon.")
+    parser.add_argument('--report-interval', type=int,
+                        help="Interval between passes in seconds")
+    parser.add_argument('--usage-check-interval', type=int,
+                        help="Interval between disk usage check in seconds")
     parser.add_argument('--verbose', '-v', action='store_true',
                         help="More verbose output")
+    parser.add_argument('--user', help='run daemon as user')
+    parser.add_argument('--bytes-per-second', type=int,
+                        help="Throttle: max byte per second")
+    parser.add_argument('--chunks-per-second', type=int,
+                        help="Throttle: max chunks per second")
+    levels = ['DEBUG', 'INFO', 'WARN', 'ERROR']
+    parser.add_argument('--log-level', choices=levels,
+                        help="Log level")
+    parser.add_argument('--log-syslog-prefix', help="Syslog prefix")
+    parser.add_argument('--log-facility', help="Log facility")
+    parser.add_argument('--log-address', help="Log address")
+
     return parser
+
+
+def generate_config_file(path, mode):
+    args = make_arg_parser().parse_args()
+
+    def add_value(dic, key, value):
+        if value is not None:
+            dic[key] = value
+
+    def dic_to_string(dic, header):
+        for key in dic:
+            header += key + " = " + str(dic[key]) + "\n"
+        return header
+
+    def create_content():
+        header = "\n[blob-mover]\n"
+        cont = dict()
+        add_value(cont, 'namespace', args.namespace)
+        add_value(cont, 'volume', args.volume)
+        add_value(cont, 'log_level', args.log_level)
+        add_value(cont, 'log_facility', args.log_facility)
+        add_value(cont, 'log_address', args.log_address)
+        add_value(cont, 'syslog_prefix', args.log_syslog_prefix)
+        add_value(cont, 'usage_target', args.usage_target)
+        add_value(cont, 'usage_check_interval',
+                  args.usage_check_interval)
+        add_value(cont, 'report_interval', args.report_interval)
+        add_value(cont, 'bytes_per_second', args.bytes_per_second)
+        add_value(cont, 'chunks_per_second', args.chunks_per_second)
+        add_value(cont, 'user', args.user)
+        return dic_to_string(cont, header)
+
+    with open(path, mode) as conf:
+        cont = create_content()
+        conf.write(cont)
+    return path
+
 
 def main():
     args = make_arg_parser().parse_args()
-    config = args.config
-    number = args.number
+    limit = args.limit
     usage_target = args.usage_target
     daemon = args.daemon
-    verbose=args.verbose
-    run_daemon(BlobMover, config, number=number,
+    verbose = args.verbose
+    config = args.config
+    if args.generate_config:
+        config = generate_config_file(config, 'w')
+    if args.edit_config:
+        config = generate_config_file(config, 'a')
+    run_daemon(BlobMover, config, limit=limit,
                usage_target=usage_target, daemon=daemon,
                verbose=verbose)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/oio-blob-mover
+++ b/bin/oio-blob-mover
@@ -16,12 +16,34 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import argparse
+
 from oio.blob.mover import BlobMover
 from oio.common.daemon import run_daemon
-from oio.common.configuration import parse_options
-from optparse import OptionParser
+
+def make_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config', help="Configuration file")
+    parser.add_argument('--number', type=int,
+                        help="Number of chunk to move")
+    parser.add_argument('--usage-target', type=int,
+                        help="Percentage of disk usage target")
+    parser.add_argument('--daemon', type=int,
+                        help="Interval to run the mover in seconds.")
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help="More verbose output")
+    return parser
+
+def main():
+    args = make_arg_parser().parse_args()
+    config = args.config
+    number = args.number
+    usage_target = args.usage_target
+    daemon = args.daemon
+    verbose=args.verbose
+    run_daemon(BlobMover, config, number=number,
+               usage_target=usage_target, daemon=daemon,
+               verbose=verbose)
 
 if __name__ == '__main__':
-    parser = OptionParser("%prog CONFIG [options]")
-    config, options = parse_options(parser)
-    run_daemon(BlobMover, config, **options)
+    main()

--- a/bin/oio-blob-mover
+++ b/bin/oio-blob-mover
@@ -32,7 +32,7 @@ def make_arg_parser():
     parser.add_argument('--edit-config', action='store_true',
                         help="Edit configuration file with given arguments")
     parser.add_argument('--limit', type=int,
-                        help="Number of chunks to move")
+                        help="Limit of chunks to move")
     parser.add_argument('--usage-target', type=int,
                         help="Target percentage of volume usage")
     parser.add_argument('--daemon', action='store_true',
@@ -86,6 +86,7 @@ def generate_config_file(path, mode):
         add_value(cont, 'bytes_per_second', args.bytes_per_second)
         add_value(cont, 'chunks_per_second', args.chunks_per_second)
         add_value(cont, 'user', args.user)
+        add_value(cont, 'limit', args.limit)
         return dic_to_string(cont, header)
 
     with open(path, mode) as conf:
@@ -96,18 +97,15 @@ def generate_config_file(path, mode):
 
 def main():
     args = make_arg_parser().parse_args()
-    limit = args.limit
-    usage_target = args.usage_target
     daemon = args.daemon
     verbose = args.verbose
     config = args.config
+
     if args.generate_config:
         config = generate_config_file(config, 'w')
     if args.edit_config:
         config = generate_config_file(config, 'a')
-    run_daemon(BlobMover, config, limit=limit,
-               usage_target=usage_target, daemon=daemon,
-               verbose=verbose)
+    run_daemon(BlobMover, config, daemon=daemon, verbose=verbose)
 
 
 if __name__ == '__main__':

--- a/oio/blob/mover.py
+++ b/oio/blob/mover.py
@@ -122,7 +122,7 @@ class BlobMoverWorker(object):
                 self.bytes_processed = 0
                 self.last_reported = now
             mover_time += (now - loop_time)
-            if self.limit !=0 and self.total_chunks_processed >= self.limit:
+            if self.limit != 0 and self.total_chunks_processed >= self.limit:
                 break
         elapsed = (time.time() - start_time) or 0.000001
         self.logger.info(
@@ -216,11 +216,10 @@ class BlobMover(Daemon):
         while work:
             try:
                 worker = BlobMoverWorker(self.conf, self.logger, self.volume)
-                usage_target = self.conf.get('usage_target')
                 worker.mover_pass(**kwargs)
                 work = False
-            except Exception as e:
-                self.logger.exception('ERROR in mover: %s' % e)
+            except Exception as err:
+                self.logger.exception('ERROR in mover: %s', err)
             if kwargs.get('daemon'):
                 work = True
                 self._sleep()

--- a/oio/blob/mover.py
+++ b/oio/blob/mover.py
@@ -30,7 +30,6 @@ from oio.common.constants import STRLEN_CHUNKID
 from oio.common.fullpath import decode_fullpath
 from oio.content.factory import ContentFactory
 
-SLEEP_TIME = 30
 READ_BUFFER_SIZE = 65535
 
 
@@ -65,13 +64,16 @@ class BlobMoverWorker(object):
         self.container_client = ContainerClient(conf, logger=self.logger)
         self.content_factory = ContentFactory(conf)
 
-    def mover_pass(self):
+    def mover_pass(self, usage_target=None, number=None, **kwargs):
         start_time = report_time = time.time()
 
         total_errors = 0
         mover_time = 0
 
         paths = paths_gen(self.volume)
+
+        if usage_target is not None:
+            self.usage_target = usage_target
 
         for path in paths:
             loop_time = time.time()
@@ -121,6 +123,8 @@ class BlobMoverWorker(object):
                 self.bytes_processed = 0
                 self.last_reported = now
             mover_time += (now - loop_time)
+            if number is not None and self.total_chunks_processed >= number:
+                break
         elapsed = (time.time() - start_time) or 0.000001
         self.logger.info(
             '%(elapsed).02f '
@@ -197,25 +201,25 @@ class BlobMoverWorker(object):
 
 
 class BlobMover(Daemon):
-    def __init__(self, conf, **kwargs):
+    def __init__(self, conf, daemon=None, **kwargs):
         super(BlobMover, self).__init__(conf)
         self.logger = get_logger(conf)
         volume = conf.get('volume')
         if not volume:
             raise exc.ConfigurationException('No volume specified for mover')
         self.volume = volume
-        global SLEEP_TIME
-        if SLEEP_TIME > int(conf.get('report_interval', 3600)):
-            SLEEP_TIME = int(conf.get('report_interval', 3600))
+        if daemon > int(conf.get('report_interval', 3600)):
+            daemon = int(conf.get('report_interval', 3600))
 
     def run(self, *args, **kwargs):
-        while True:
+        work = True
+        while work:
             try:
                 worker = BlobMoverWorker(self.conf, self.logger, self.volume)
-                worker.mover_pass()
+                worker.mover_pass(**kwargs)
+                work = False
             except Exception as e:
                 self.logger.exception('ERROR in mover: %s' % e)
-            self._sleep()
-
-    def _sleep(self):
-        time.sleep(SLEEP_TIME)
+            if kwargs.get('daemon') is not None:
+                work = True
+                time.sleep(kwargs.get('daemon'))

--- a/oio/blob/mover.py
+++ b/oio/blob/mover.py
@@ -78,8 +78,8 @@ class BlobMoverWorker(object):
 
             now = time.time()
             if now - self.last_usage_check >= self.usage_check_interval:
-                used, total = statfs(self.volume)
-                usage = (float(used) / total) * 100
+                free_ratio = statfs(self.volume)
+                usage = (1-float(free_ratio)) * 100
                 if usage <= self.usage_target:
                     self.logger.info(
                         'current usage %.2f%%: target reached (%.2f%%)', usage,

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -87,6 +87,11 @@ def paths_gen(volume_path):
 
 
 def statfs(volume):
+    """
+    :param volume: path to the mount point to get stats from.
+    :returns: the free space ratio.
+    :rtype: `float`
+    """
     st = os.statvfs(volume)
     free_inodes = st.f_ffree
     total_inodes = st.f_files

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -88,9 +88,19 @@ def paths_gen(volume_path):
 
 def statfs(volume):
     st = os.statvfs(volume)
-    total = st.f_blocks * st.f_frsize
-    used = (st.f_blocks - st.f_bfree) * st.f_frsize
-    return used, total
+    free_inodes = st.f_ffree
+    total_inodes = st.f_files
+    free_blocks = st.f_bavail
+    total_blocks = st.f_blocks
+    if total_inodes > 0:
+        inode_ratio = float(free_inodes)/float(total_inodes)
+    else:
+        inode_ratio = 1
+    if total_blocks > 0:
+        block_ratio = float(free_blocks)/float(total_blocks)
+    else:
+        block_ratio = 1
+    return min(inode_ratio, block_ratio)
 
 
 class RingBuffer(list):


### PR DESCRIPTION
##### SUMMARY

Add options to `oio-blob-mover`.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- `oio-blob-mover`

##### SDS VERSION

```
openio 4.2.2.dev4
```

##### ADDITIONAL INFORMATION

The mover can be used as a command line.

To run mover as daemon, you can specify `--daemon` option with the interval.
You can also move only some chunk with `--limit` option.
You can specify disk usage target with  `--usage-target` option.

`--generate-config` can be used to edit configuration file or create a new one with the values of other options.