### PR TITLE
Update blob-auditor usage

### DIFF
--- a/bin/oio-blob-auditor
+++ b/bin/oio-blob-auditor
@@ -16,12 +16,87 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import argparse
+
 from oio.blob.auditor import BlobAuditor
 from oio.common.daemon import run_daemon
-from oio.common.configuration import parse_options
-from optparse import OptionParser
+
+
+def make_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--namespace', '--ns', help="Namespace")
+    parser.add_argument('--volume', help="Volume to audit")
+    parser.add_argument('config', help="Configuration file or empty file")
+    parser.add_argument('--generate-config', action='store_true',
+                        help="Generate configuration file with given arguments")
+    parser.add_argument('--append-config', action='store_true',
+                        help="Append given arguments on configuration file")
+    parser.add_argument('--daemon', action='store_true',
+                        help="Run auditor as a daemon.")
+    parser.add_argument('--report-interval', type=int,
+                        help="Interval between passes in seconds")
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help="More verbose output")
+    parser.add_argument('--user', help='run auditor as user')
+    parser.add_argument('--bytes-per-second', type=int,
+                        help="Throttle: max byte per second")
+    parser.add_argument('--chunks-per-second', type=int,
+                        help="Throttle: max chunks per second")
+    levels = ['DEBUG', 'INFO', 'WARN', 'ERROR']
+    parser.add_argument('--log-level', choices=levels,
+                        help="Log level")
+    parser.add_argument('--log-syslog-prefix', help="Syslog prefix")
+    parser.add_argument('--log-facility', help="Log facility")
+    parser.add_argument('--log-address', help="Log address")
+
+    return parser
+
+
+def generate_config_file(path, mode):
+    args = make_arg_parser().parse_args()
+
+    def add_value(dic, key, value):
+        if value is not None:
+            dic[key] = value
+
+    def dic_to_string(dic, header):
+        for key in dic:
+            header += key + " = " + str(dic[key]) + "\n"
+        return header
+
+    def create_content():
+        header = "[blob-auditor]\n"
+        cont = dict()
+        add_value(cont, 'namespace', args.namespace)
+        add_value(cont, 'volume', args.volume)
+        add_value(cont, 'log_level', args.log_level)
+        add_value(cont, 'log_facility', args.log_facility)
+        add_value(cont, 'log_address', args.log_address)
+        add_value(cont, 'syslog_prefix', args.log_syslog_prefix)
+        add_value(cont, 'report_interval', args.report_interval)
+        add_value(cont, 'bytes_per_second', args.bytes_per_second)
+        add_value(cont, 'chunks_per_second', args.chunks_per_second)
+        add_value(cont, 'user', args.user)
+        return dic_to_string(cont, header)
+
+    with open(path, mode) as conf:
+        cont = create_content()
+        conf.write(cont)
+    return path
+
+
+def main():
+    args = make_arg_parser().parse_args()
+    daemon = args.daemon
+    verbose = args.verbose
+    config = args.config
+
+    if args.generate_config:
+        config = generate_config_file(config, 'w')
+    if args.append_config:
+        config = generate_config_file(config, 'a')
+    run_daemon(BlobAuditor, config, daemon=daemon, verbose=verbose)
+
 
 if __name__ == '__main__':
-    parser = OptionParser("%prog CONFIG [options]")
-    config, options = parse_options(parser)
-    run_daemon(BlobAuditor, config, **options)
+    main()

--- a/oio/blob/auditor.py
+++ b/oio/blob/auditor.py
@@ -232,13 +232,17 @@ class BlobAuditor(Daemon):
         self.volume = volume
 
     def run(self, *args, **kwargs):
-        while True:
+        work = True
+        while work:
+            work = False
             try:
                 worker = BlobAuditorWorker(self.conf, self.logger, self.volume)
                 worker.audit_pass()
             except Exception as e:
                 self.logger.exception('ERROR in audit: %s' % e)
-            self._sleep()
+            if kwargs.get('daemon'):
+                work = True
+                self._sleep()
 
     def _sleep(self):
         time.sleep(SLEEP_TIME)


### PR DESCRIPTION
##### SUMMARY
Change blob-auditor usage

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
oio-blob-auditor

##### SDS VERSION
```
openio 4.2.2.dev37
```


##### ADDITIONAL INFORMATION

The auditor can be used as a command line.

To run auditor as daemon, you can specify `--daemon` option .
`--generate-config` can be used to edit configuration file or create a new one with the values of other options.