### PR TITLE
Specify expected IP on log when service xattr differ

### DIFF
--- a/metautils/lib/volume_lock.c
+++ b/metautils/lib/volume_lock.c
@@ -52,9 +52,12 @@ retry:
 
 	if (!err) {
 		if (strlen(v) != (gsize)realsize)
-			err = NEWERROR(CODE_INTERNAL_ERROR, "XATTR size differ");
+			err = NEWERROR(CODE_INTERNAL_ERROR,
+					"XATTR size differ, expected IP is %s",
+					buf);
 		else if (0 != memcmp(v,buf,realsize))
-			err = NEWERROR(CODE_INTERNAL_ERROR, "XATTR differ");
+			err = NEWERROR(CODE_INTERNAL_ERROR,
+				        "XATTR differ, expected IP is %s", buf);
 	}
 
 	g_free(buf);


### PR DESCRIPTION
##### SUMMARY
Fixes OS-83

##### ISSUE TYPE
 - Bugfix Pull Request

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.2.2.dev37
```