### PR TITLE
Decache stale entries and retry upon "base not managed" errors

### DIFF
--- a/proxy/common.h
+++ b/proxy/common.h
@@ -254,8 +254,8 @@ typedef GByteArray * (request_packer_f) (const struct sqlx_name_s *);
 
 #define PACKER_VOID(N) GByteArray * N (const struct sqlx_name_s *_u UNUSED)
 
-GError * gridd_request_replicated (struct req_args_s *args,
-		struct client_ctx_s *, request_packer_f);
+GError * gridd_request_replicated_with_retry (struct req_args_s *args,
+		struct client_ctx_s *ctx, request_packer_f pack);
 
 GError * KV_read_properties (struct json_object *j, gchar ***out,
 		const char *section, gboolean fail_if_empty);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -73,7 +73,7 @@ _resolve_meta2(struct req_args_s *args, enum proxy_preference_e how,
 		*out_list = NULL;
 	}
 
-	GError *err = gridd_request_replicated (args, &ctx, pack);
+	GError *err = gridd_request_replicated_with_retry(args, &ctx, pack);
 
 	if (err) {
 		GRID_DEBUG("M2V2 call failed: %d %s", err->code, err->message);
@@ -1891,7 +1891,7 @@ enum http_rc_e action_container_show (struct req_args_s *args) {
 	CLIENT_CTX(ctx,args,NAME_SRVTYPE_META2,1);
 
 	PACKER_VOID(_pack) { return sqlx_pack_PROPGET(_u, DL()); }
-	err = gridd_request_replicated (args, &ctx, _pack);
+	err = gridd_request_replicated_with_retry (args, &ctx, _pack);
 	if (err) {
 		client_clean (&ctx);
 		return _reply_m2_error (args, err);

--- a/proxy/sqlx_actions.c
+++ b/proxy/sqlx_actions.c
@@ -34,8 +34,7 @@ static enum http_rc_e
 _sqlx_action_noreturn_TAIL (struct req_args_s *args, struct client_ctx_s *ctx,
 		request_packer_f pack)
 {
-	GError *err = gridd_request_replicated (args, ctx, pack);
-
+	GError *err = gridd_request_replicated_with_retry(args, ctx, pack);
 	if (err) {
 		client_clean (ctx);
 		return _reply_common_error (args, err);
@@ -226,8 +225,7 @@ action_sqlx_propget (struct req_args_s *args, struct json_object *jargs)
 	CLIENT_CTX(ctx, args, dirtype, seq);
 
 	PACKER_VOID(_pack) { return sqlx_pack_PROPGET(_u, DL()); }
-	err = gridd_request_replicated (args, &ctx, _pack);
-
+	err = gridd_request_replicated_with_retry(args, &ctx, _pack);
 	if (err) {
 		client_clean (&ctx);
 		return _reply_common_error (args, err);

--- a/proxy/transport_http.c
+++ b/proxy/transport_http.c
@@ -634,7 +634,7 @@ http_notify_input(struct network_client_s *clt)
 				done = TRUE;
 			}
 			else if (r.close_after_request) {
-				GRID_DEBUG("No connection keep-alive, closing.");
+				GRID_TRACE("No connection keep-alive, closing.");
 				network_client_allow_input(clt, FALSE);
 				network_client_close_output(clt, 0);
 				done = TRUE;

--- a/server/network_server.c
+++ b/server/network_server.c
@@ -1434,7 +1434,7 @@ network_client_close_output(struct network_client_s *clt, int now)
 		return;
 
 	if (!(clt->flags & NETCLIENT_OUT_CLOSED)) {
-		GRID_DEBUG("fd=%d Closing output", clt->fd);
+		GRID_TRACE("fd=%d Closing output", clt->fd);
 		if (!now) {
 			if (!(clt->flags & NETCLIENT_OUT_CLOSE_PENDING)) {
 				network_client_send_slab(clt, data_slab_make_eof());


### PR DESCRIPTION
##### SUMMARY
Properly reacts to "code=431" errors that indicate stale entries in the local cache of the `resolver` of the `oio-proxy`.

In addition, lowers the verbosity level of 2 traces.

##### ISSUE TYPE
`fix`

##### COMPONENT NAME
`oio-proxy`, `server`

##### SDS VERSION
`openio 4.2.2.dev47`
