### PR TITLE
4.2.x access logs

### DIFF
--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -578,7 +578,7 @@ _client_call_handler(struct req_ctx_s *req_ctx)
 	}
 	void _send_reply(gint code, gchar *msg) {
 		EXTRA_ASSERT(!req_ctx->final_sent);
-		GRID_DEBUG("fd=%d REPLY code=%d message=%s", req_ctx->client->fd, code, msg);
+		GRID_TRACE("fd=%d REPLY code=%d message=%s", req_ctx->client->fd, code, msg);
 
 		MESSAGE answer = metaXServer_reply_simple(req_ctx->request, code, msg);
 		if (body) {

--- a/server/transport_gridd.c
+++ b/server/transport_gridd.c
@@ -205,7 +205,7 @@ network_client_log_access(struct log_item_s *item)
 {
 	struct req_ctx_s *r = item->req_ctx;
 
-	if (r->access_disabled && CODE_IS_OK(item->code))
+	if (r->access_disabled && CODE_IS_OK(item->code) && !GRID_DEBUG_ENABLED())
 		return;
 
 	if (!r->tv_end)


### PR DESCRIPTION
##### SUMMARY
Allows an operator to inspect access logs of (previously hidden) traces, under DEBUG verbosity.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`server`

##### SDS VERSION
`openio 4.2.2.dev47`
