### PR TITLE
Python API: close chunk connection after 404 error

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -281,6 +281,7 @@ class ChunkReader(object):
                         chunk, self.reqid, source.status, source.reason)
             self._resp_by_chunk[chunk["url"]] = (source.status,
                                                  str(source.reason))
+            close_source(source)
         return False
 
     def _get_source(self):

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -44,7 +44,7 @@ def close_source(source):
     try:
         source.conn.close()
     except Exception:
-        pass
+        logger.exception("Failed to close %s", source)
 
 
 class IOBaseWrapper(RawIOBase):

--- a/oio/conscience/checker/http.py
+++ b/oio/conscience/checker/http.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from oio.common.http import http_connect
 from oio.common import exceptions as exc
 from oio.conscience.checker.base import BaseChecker
 
@@ -32,15 +31,13 @@ class HttpChecker(BaseChecker):
         self.path = self.checker_conf['uri']
         self.name = '%s|http|%s|%s|%s' % \
             (self.srv_type, self.host, self.port, self.path)
-        self.netloc = '%s:%s' % (self.host, self.port)
-        self.pool_manager = self.agent.pool_manager
+        self.url = '%s:%s/%s' % (self.host, self.port, self.path)
 
     def check(self):
         success = False
         resp = None
         try:
-            conn = http_connect(self.netloc, 'GET', self.path)
-            resp = conn.getresponse()
+            resp = self.agent.pool_manager.request("GET", self.url)
             if resp.status == 200:
                 success = True
             else:

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from oio.common.utils import json
-from oio.common.http import http_connect
 from oio.conscience.stats.base import BaseStat
 
 
@@ -26,7 +25,7 @@ class HttpStat(BaseStat):
         self.path = self.stat_conf['path'].lstrip('/')
         self.host = self.stat_conf['host']
         self.port = self.stat_conf['port']
-        self.netloc = '%s:%s' % (self.host, self.port)
+        self.url = '%s:%s/%s' % (self.host, self.port, self.path)
         if self.parser == 'json':
             # use json parser (account and rdir style)
             self._parse_func = self._parse_stats_json
@@ -65,10 +64,9 @@ class HttpStat(BaseStat):
         result = {}
         resp = None
         try:
-            conn = http_connect(self.netloc, 'GET', self.path)
-            resp = conn.getresponse()
+            resp = self.agent.pool_manager.request("GET", self.url)
             if resp.status == 200:
-                result = self._parse_func(resp.read())
+                result = self._parse_func(resp.data)
             else:
                 raise Exception("status code != 200: %s" % resp.status)
             return result


### PR DESCRIPTION
##### SUMMARY
We suspect an abnormal number of connections in `CLOSE_WAIT` state due to the fact that we do not immediately close the chunk connection after getting a 404 error (missing chunk). This pull request aims at fixing this problem.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.1.27.dev12
```