### PR TITLE
Return the total size in the Content-Range header

### DIFF
--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -339,7 +339,7 @@ func (rr *rawxRequest) downloadChunk() {
 	// Prepare the headers of the reply
 	if rangeInf != nil {
 		rr.rep.Header().Set("Content-Range", fmt.Sprintf("bytes %v-%v/%v",
-			rangeInf.offset, rangeInf.last, rangeInf.size))
+			rangeInf.offset, rangeInf.last, chunkSize))
 		rr.rep.Header().Set("Content-Length", fmt.Sprintf("%v", rangeInf.size))
 		rr.replyCode(http.StatusPartialContent)
 	} else {

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -212,7 +212,7 @@ func_tests () {
 
 	# Create a file just bigger than chunk size
 	SOURCE=$(mktemp)
-	dd if=/dev/urandom of=$SOURCE bs=128K count=9
+	dd if=/dev/urandom of=$SOURCE bs=128K count=100
 
 	# Run the test-suite of the C API
 	${WRKDIR}/core/tool_roundtrip $SOURCE


### PR DESCRIPTION
##### SUMMARY

Return the total size of the chunk in the [Content-Range header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `rawx`

##### SDS VERSION

```
openio 4.2.2.dev133
```