### PR TITLE
Adapt to recent libattr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,7 @@ option_or_system(JSONC json-c json.h)
 
 if (NOT SDK_ONLY)
 option_or_system(APACHE2 modules/mod_webdav.so httpd.h)
-option_or_system(ATTR attr attr/xattr.h)
+option_or_system(ATTR attr attr/libattr.h)
 option_or_system(ZK zookeeper_mt zookeeper.h)
 option_or_system(ZLIB z zlib.h)
 option_or_system(ZMQ zmq zmq.h zmq_utils.h)

--- a/metautils/lib/volume_lock.c
+++ b/metautils/lib/volume_lock.c
@@ -19,7 +19,7 @@ License along with this library.
 
 #include <errno.h>
 #include <sys/types.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include "metautils.h"
 #include "volume_lock.h"

--- a/rawx-lib/src/attr_handler.c
+++ b/rawx-lib/src/attr_handler.c
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include <metautils/lib/metautils.h>
 
@@ -309,7 +309,8 @@ get_compression_info_in_attr(const char *p, GError ** error, GHashTable *table)
 
 	int rc = lgetxattr(p, ATTR_DOMAIN "." ATTR_NAME_CHUNK_METADATA_COMPRESS, buf, sizeof(buf));
 	if (rc < 0) {
-		if (errno != ENOATTR) {
+		// ENOATTR == ENODATA
+		if (errno != ENODATA) {
 			GSETCODE(error, errno, "Failed to get compression attr: %s", strerror(errno));
 			return FALSE;
 		}


### PR DESCRIPTION
##### SUMMARY
libattr 2.4.48 removed `attr/xattr.h`, which contained roughly the same
things as `sys/xattr.h`.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- rawx
- metautils

##### SDS VERSION
```
openio 4.2.2.dev57
```