### PR TITLE
Python API: close chunks download connection

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -495,16 +495,11 @@ class ChunkReader(object):
                     yield result
             except StopIteration:
                 pass
-            finally:
-                if body_iter:
-                    body_iter.close()
 
         except green.ChunkReadTimeout:
             logger.exception("Failure during chunk read (reqid=%s)",
                              self.reqid)
             raise
-        except GeneratorExit:
-            pass
         except Exception:
             logger.exception("Failure during read")
             raise

--- a/oio/common/storage_functions.py
+++ b/oio/common/storage_functions.py
@@ -229,7 +229,11 @@ def fetch_stream_ec(chunks, ranges, storage_method, **kwargs):
                 storage_method, chunks[pos],
                 meta_start, meta_end, **kwargs)
             stream = handler.get_stream()
-            for part_info in stream:
-                for dat in part_info['iter']:
-                    yield dat
-            stream.close()
+            try:
+                for part_info in stream:
+                    for dat in part_info['iter']:
+                        yield dat
+            finally:
+                # This must be done in a finally block to handle the case
+                # when the reader does not read until the end of the stream.
+                stream.close()


### PR DESCRIPTION
##### SUMMARY
In the case when the reader does not read data until the end, some connections where never closed.
Fortunately, this happened only when downloading EC objets.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
```
openio 4.2.2.dev73
```
