### PR TITLE
Python API: fix EC data stream leak

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -204,6 +204,7 @@ class ECStream(object):
         self.range_infos = range_infos
         self.meta_length = meta_length
         self.fragment_length = fragment_length
+        self._iter = None
 
     def start(self):
         self._iter = io.chain(self._stream())
@@ -211,8 +212,11 @@ class ECStream(object):
     def close(self):
         if self._iter:
             self._iter.close()
-        for reader in self.readers:
-            reader.close()
+            self._iter = None
+        if self.readers:
+            for reader in self.readers:
+                reader.close()
+            self.readers = None
 
     def _next(self):
         fragment_iterators = []

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -152,6 +152,7 @@ class Closeable(object):
             close_method = getattr(iterator, 'close', None)
             if close_method:
                 close_method()
+        self.iterables = None
 
 
 def chain(iterable):


### PR DESCRIPTION
##### SUMMARY
There was an object reference loop preventing the garbage collector from
releasing some stream object, in the case these streams were not read
until the end.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python API

##### SDS VERSION
```
openio 4.2.2.dev75
```