### PR TITLE
Include object metadata in events for indexing

### DIFF
--- a/etc/event-handlers.conf-sample
+++ b/etc/event-handlers.conf-sample
@@ -2,6 +2,9 @@
 [handler:storage.content.new]
 pipeline = noop
 
+[handler:storage.content.update]
+pipeline = noop
+
 [handler:storage.content.broken]
 pipeline = content_rebuild
 

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1253,7 +1253,7 @@ meta2_backend_get_properties(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_del_properties(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gchar **propv)
+		struct oio_url_s *url, gchar **propv, struct bean_ALIASES_s **out)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -1265,7 +1265,7 @@ meta2_backend_del_properties(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
-			if (!(err = m2db_del_properties(sq3, url, propv)))
+			if (!(err = m2db_del_properties(sq3, url, propv, out)))
 				m2db_increment_version(sq3);
 			err = sqlx_transaction_end(repctx, err);
 		}
@@ -1277,7 +1277,7 @@ meta2_backend_del_properties(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_set_properties(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		gboolean flush, GSList *beans, m2_onbean_cb cb, gpointer u0)
+		gboolean flush, GSList *beans, struct bean_ALIASES_s **out)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -1291,7 +1291,7 @@ meta2_backend_set_properties(struct meta2_backend_s *m2b, struct oio_url_s *url,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
-			if (!(err = m2db_set_properties(sq3, url, flush, beans, cb, u0)))
+			if (!(err = m2db_set_properties(sq3, url, flush, beans, out)))
 				m2db_increment_version(sq3);
 			err = sqlx_transaction_end(repctx, err);
 		}

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -172,12 +172,12 @@ GError* meta2_backend_get_properties(struct meta2_backend_s *m2b,
 		m2_onbean_cb cb, gpointer u0);
 
 GError* meta2_backend_del_properties(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gchar **propv);
+		struct oio_url_s *url, gchar **propv, struct bean_ALIASES_s **out);
 
 /** Helper for testing purpose */
 GError* meta2_backend_set_properties(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, gboolean flush, GSList *beans,
-		m2_onbean_cb cb, gpointer u0);
+		struct bean_ALIASES_s **out);
 
 /* Back-Links listing ------------------------------------------------------- */
 

--- a/meta2v2/meta2_gridd_dispatcher.c
+++ b/meta2v2/meta2_gridd_dispatcher.c
@@ -383,6 +383,7 @@ static gridd_filter M2V2_PROPSET_FILTERS[] =
 	meta2_filter_extract_body_beans,
 	meta2_filter_check_ns_is_master,
 	meta2_filter_action_set_content_properties,
+	meta2_filter_reply_success,
 	NULL
 };
 

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -710,8 +710,10 @@ m2db_get_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 
 GError*
 m2db_set_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
-		gboolean flush, GSList *beans, m2_onbean_cb cb, gpointer u0)
+		gboolean flush, GSList *beans, struct bean_ALIASES_s **out)
 {
+	EXTRA_ASSERT(out != NULL);
+
 	struct bean_ALIASES_s *alias = NULL;
 	GError *err = m2db_get_alias1(sq3, url, M2V2_FLAG_NOPROPS
 			|M2V2_FLAG_NORECURSION, &alias);
@@ -743,45 +745,50 @@ m2db_set_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 			err = _db_delete_bean (sq3->db, prop);
 		} else {
 			err = _db_save_bean (sq3->db, prop);
-			if (!err && cb)
-				cb(u0, _bean_dup(prop));
 		}
 	}
 
-	_bean_clean(alias);
+	*out = alias;
 	return err;
 }
 
 GError*
-m2db_del_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url, gchar **namev)
+m2db_del_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
+		gchar **namev, struct bean_ALIASES_s **out)
 {
-	GError *err;
-	GPtrArray *tmp;
-
 	EXTRA_ASSERT(sq3 != NULL);
 	EXTRA_ASSERT(url != NULL);
 	EXTRA_ASSERT(namev != NULL);
+	EXTRA_ASSERT(out != NULL);
 
-	tmp = g_ptr_array_new();
-	err = m2db_get_properties(sq3, url, _bean_buffer_cb, tmp);
+	struct bean_ALIASES_s *alias = NULL;
+	GPtrArray *tmp = g_ptr_array_new();
+	GError *err = m2db_get_properties(sq3, url, _bean_buffer_cb, tmp);
 	if (!err) {
-		for (guint i = 0; !err && i < tmp->len; ++i) {
+		for (guint i = 0; i < tmp->len; ++i) {
 			struct bean_PROPERTIES_s *bean = tmp->pdata[i];
-			if (DESCR(bean) != &descr_struct_PROPERTIES)
+			if (DESCR(bean) != &descr_struct_PROPERTIES) {
+				if (alias == NULL && DESCR(bean) == &descr_struct_ALIASES) {
+					alias = _bean_dup(bean);
+				}
 				continue;
+			}
 			if (namev && *namev) {
 				/* explicit properties to be deleted */
 				for (gchar **p = namev; *p; ++p) {
-					if (!strcmp(*p, PROPERTIES_get_key(bean)->str))
-						_db_delete_bean (sq3->db, bean);
+					if (!strcmp(*p, PROPERTIES_get_key(bean)->str)) {
+						_db_delete_bean(sq3->db, bean);
+						break;
+					}
 				}
 			} else {
 				/* all properties to be deleted */
-				_db_delete_bean (sq3->db, bean);
+				_db_delete_bean(sq3->db, bean);
 			}
 		}
 	}
 
+	*out = alias;
 	_bean_cleanv2(tmp);
 	return err;
 }

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -137,10 +137,10 @@ GError* m2db_get_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 		m2_onbean_cb cb, gpointer u);
 
 GError* m2db_del_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
-		gchar **namev);
+		gchar **namev, struct bean_ALIASES_s **out);
 
 GError* m2db_set_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
-		gboolean flush, GSList *beans, m2_onbean_cb cb, gpointer u0);
+		gboolean flush, GSList *beans, struct bean_ALIASES_s **out);
 
 GError* m2db_drain_content(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 		m2_onbean_cb cb, gpointer u0);

--- a/meta2v2/meta2_utils_json_out.c
+++ b/meta2v2/meta2_utils_json_out.c
@@ -79,7 +79,8 @@ encode_property (GString *g, gpointer bean)
 	g_string_append_c(g, ',');
 	OIO_JSON_append_gstr(g, "key", PROPERTIES_get_key(bean));
 	g_string_append_c(g, ',');
-	OIO_JSON_append_gba(g, "value", PROPERTIES_get_value(bean));
+	GByteArray *properties = PROPERTIES_get_value(bean);
+	OIO_JSON_append_blob(g, "value", (gchar*)properties->data, properties->len);
 }
 
 static void

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -1027,7 +1027,7 @@ class ObjectStorageApi(object):
         # stacklevel=5 because we are using 3 decorators
         warnings.warn("You'd better use object_get_properties()",
                       DeprecationWarning, stacklevel=5)
-        return self.container.content_show(
+        return self.container.content_get_properties(
             account, container, obj, version=version, **kwargs)
 
     def object_update(self, account, container, obj, metadata,

--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -146,7 +146,7 @@ class BlobConverter(object):
         if content_id or not search:
             return content_id
 
-        properties = self.container_client.content_show(
+        properties = self.container_client.content_get_properties(
             cid=cid, path=path, version=version)
         content_id = properties['id']
         cid, path, version, content_id = self._save_content(

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -34,7 +34,7 @@ def extract_content_headers_meta(headers):
             short_key = key[len(CONTENT_HEADER_PREFIX):]
             # FIXME(FVE): this will fail when someone creates a property with
             # same name as one of our system metadata.
-            # content_prepare() and content_show() are safe but
+            # content_prepare() and content_get_properties() are safe but
             # content_locate() protocol has to send properties in the body
             # instead of the response headers.
             if short_key.startswith("x-") or short_key not in SYSMETA_KEYS:
@@ -579,9 +579,9 @@ class ContainerClient(ProxyClient):
         obj_meta = extract_content_headers_meta(resp.headers)
         return obj_meta, body
 
-    def content_show(self, account=None, reference=None, path=None,
-                     properties=None, cid=None, content=None, version=None,
-                     **kwargs):
+    def content_get_properties(
+            self, account=None, reference=None, path=None, properties=None,
+            cid=None, content=None, version=None, **kwargs):
         """
         Get a description of the content along with its user properties.
         """
@@ -595,16 +595,6 @@ class ContainerClient(ProxyClient):
         obj_meta = extract_content_headers_meta(resp.headers)
         obj_meta.update(body)
         return obj_meta
-
-    def content_get_properties(self, account=None, reference=None, path=None,
-                               properties=[], cid=None, version=None,
-                               **kwargs):
-        """
-        Get the dictionary of properties set on a content.
-        """
-        return self.content_show(account, reference, path,
-                                 properties=properties, cid=cid,
-                                 version=version, **kwargs)
 
     def content_set_properties(self, account=None, reference=None, path=None,
                                properties={}, cid=None, version=None,

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -23,8 +23,9 @@ from oio.common.easy_value import boolean_value
 
 
 CONTENT_HEADER_PREFIX = 'x-oio-content-meta-'
-SYSMETA_KEYS = ("chunk-method", "ctime", "deleted", "hash", "hash-method",
-                "id", "length", "mime-type", "name", "policy", "version")
+SYSMETA_KEYS = ("chunk-method", "ctime", "mtime", "deleted", "hash",
+                "hash-method", "id", "length", "mime-type", "name", "policy",
+                "version")
 
 
 def extract_content_headers_meta(headers):

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -15,7 +15,6 @@
 
 
 from oio.common.exceptions import ClientException, OioTimeout
-from oio.common.logger import get_logger
 from oio.account.client import AccountClient
 from oio.event.evob import Event, EventError
 from oio.event.consumer import EventTypes
@@ -32,11 +31,8 @@ CONTAINER_EVENTS = [
 
 class AccountUpdateFilter(Filter):
 
-    def __init__(self, app, conf, **kwargs):
-        self.logger = get_logger(conf)
-        super(AccountUpdateFilter, self).__init__(app, conf,
-                                                  logger=self.logger, **kwargs)
-        self.account = AccountClient(conf, logger=self.logger)
+    def init(self):
+        self.account = AccountClient(self.conf, logger=self.logger)
 
     def process(self, env, cb):
         event = Event(env)

--- a/oio/event/filters/base.py
+++ b/oio/event/filters/base.py
@@ -18,6 +18,7 @@ from oio.common.logger import get_logger
 
 
 class Filter(object):
+
     def __init__(self, app, conf, logger=None):
         self.app = app
         self.app_env = app.app_env

--- a/oio/event/filters/bury.py
+++ b/oio/event/filters/bury.py
@@ -21,9 +21,6 @@ from oio.common.exceptions import ExplicitBury
 class BuryFilter(Filter):
     """Bury all events"""
 
-    def init(self):
-        pass
-
     def process(self, env, cb):
         raise ExplicitBury()
 

--- a/oio/event/filters/content_cleaner.py
+++ b/oio/event/filters/content_cleaner.py
@@ -28,8 +28,7 @@ from oio.common.utils import request_id
 class ContentReaperFilter(Filter):
     """Filter that deletes chunks on content deletion events"""
 
-    def __init__(self, *args, **kwargs):
-        super(ContentReaperFilter, self).__init__(*args, **kwargs)
+    def init(self):
         self.handlers = {
                 "plain": self._handle_rawx,
                 "ec": self._handle_rawx,

--- a/oio/event/filters/logger.py
+++ b/oio/event/filters/logger.py
@@ -19,9 +19,6 @@ from oio.event.filters.base import Filter
 class LoggerFilter(Filter):
     """Log all events with 'info' level"""
 
-    def init(self):
-        pass
-
     def process(self, env, cb):
         self.logger.info("got event: %s", str(env))
         return self.app(env, cb)

--- a/oio/event/filters/notify.py
+++ b/oio/event/filters/notify.py
@@ -21,6 +21,7 @@ from oio.event.filters.base import Filter
 
 
 class NotifyFilter(Filter):
+
     def init(self):
         queue_url = self.conf.get('queue_url')
         if not queue_url:

--- a/oio/event/filters/webhook.py
+++ b/oio/event/filters/webhook.py
@@ -23,6 +23,7 @@ from oio.event.filters.base import Filter
 
 
 class WebhookFilter(Filter):
+
     def init(self):
         self.endpoint = self.conf.get('endpoint')
         # TODO configure pool manager

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -437,6 +437,8 @@ _populate_headers_with_alias (struct req_args_s *args, struct bean_ALIASES_s *al
 			g_strdup(ALIASES_get_deleted(alias) ? "True" : "False"));
 	args->rp->add_header(PROXYD_HEADER_PREFIX "content-meta-ctime",
 			g_strdup_printf("%"G_GINT64_FORMAT, ALIASES_get_ctime(alias)));
+	args->rp->add_header(PROXYD_HEADER_PREFIX "content-meta-mtime",
+			g_strdup_printf("%"G_GINT64_FORMAT, ALIASES_get_mtime(alias)));
 }
 
 static gint32

--- a/tests/functional/content/test_content.py
+++ b/tests/functional/content/test_content.py
@@ -260,10 +260,10 @@ class TestContentFactory(BaseTestCase):
         changed_content = self.content_factory.change_policy(
             old_content.container_id, old_content.content_id, new_policy)
 
-        self.assertRaises(NotFound, self.container_client.content_show,
-                          self.account,
-                          cid=old_content.container_id,
-                          content=old_content.content_id)
+        self.assertRaises(
+            NotFound, self.container_client.content_get_properties,
+            self.account, cid=old_content.container_id,
+            content=old_content.content_id)
 
         new_content = self.content_factory.get(self.container_id,
                                                changed_content.content_id)

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -734,6 +734,7 @@ test_content_put_prop_get(void)
 {
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GSList *beans;
+		struct bean_ALIASES_s *alias = NULL;
 		guint expected;
 		GPtrArray *tmp;
 		GError *err;
@@ -754,9 +755,10 @@ test_content_put_prop_get(void)
 
 		/* set some properties */
 		beans = _props_generate(u, 1, 10);
-		err = meta2_backend_set_properties(m2, u, TRUE, beans, NULL, NULL);
+		err = meta2_backend_set_properties(m2, u, TRUE, beans, &alias);
 		g_assert_no_error(err);
 		_bean_cleanl2(beans);
+		_bean_clean(alias);
 
 		/* versioned or not, a container doesn't generate a new version of the
 		 * content when a property is set on it. */
@@ -1158,6 +1160,7 @@ test_props_gotchas()
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GError *err;
 		GSList *beans;
+		struct bean_ALIASES_s *alias = NULL;
 		(void) maxver;
 
 		err = meta2_backend_get_properties(m2, u, 0, NULL, NULL);
@@ -1165,10 +1168,11 @@ test_props_gotchas()
 		g_clear_error(&err);
 
 		beans = _props_generate(u, 1, 10);
-		err = meta2_backend_set_properties(m2, u, FALSE, beans, NULL, NULL);
+		err = meta2_backend_set_properties(m2, u, FALSE, beans, &alias);
 		g_assert_error(err, GQ(), CODE_CONTENT_NOTFOUND);
 		g_clear_error(&err);
 		_bean_cleanl2(beans);
+		_bean_clean(alias);
 	}
 	_container_wraper_allversions("NS", test);
 }
@@ -1179,6 +1183,7 @@ test_props_set_simple()
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GError *err;
 		GSList *beans;
+		struct bean_ALIASES_s *alias = NULL;
 		(void) maxver;
 
 		CLOCK_START = CLOCK = oio_ext_rand_int();
@@ -1196,10 +1201,11 @@ test_props_set_simple()
 		/* set it properties */
 		beans = _props_generate(u, 1, 10);
 		CLOCK ++;
-		err = meta2_backend_set_properties(m2, u, FALSE, beans, NULL, NULL);
+		err = meta2_backend_set_properties(m2, u, FALSE, beans, &alias);
 		CLOCK ++;
 		g_assert_no_error(err);
 		_bean_cleanl2(beans);
+		_bean_clean(alias);
 
 		CHECK_ALIAS_VERSION(m2,u,CLOCK_START);
 	}

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -776,6 +776,10 @@ template_event_agent_handlers = """
 # pipeline = replication
 pipeline = noop
 
+[handler:storage.content.update]
+# pipeline = webhook
+pipeline = noop
+
 [handler:storage.content.append]
 # pipeline = replication
 pipeline = noop
@@ -823,6 +827,9 @@ use = egg:oio#account_update
 
 [filter:volume_index]
 use = egg:oio#volume_index
+
+[filter:webhook]
+use = egg:oio#webhook
 
 [filter:replication]
 use = egg:oio#notify


### PR DESCRIPTION
##### SUMMARY

Include object metadata in events for indexing:
- `content.new`: Use the properties in events
- `content.update`: Load the properties with the `webhook` filter (`event-agent`)
  * It's a new event type
  * It is sent when changing the properties

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- `meta2`
- `event-agent`

##### SDS VERSION

```
openio 4.2.2.dev151
```