### PR TITLE
 sqlx: fix bug when overwriting a deleted property with the same value

### DIFF
--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -98,8 +98,10 @@ sqlx_admin_set_str(struct sqlx_sqlite3_s *sq3, const gchar *k, const gchar *v)
 
 	/* Avoid replacing the value if the same is already present */
 	struct _cache_entry_s *prev = g_tree_lookup(sq3->admin, k);
-	if (prev && len == prev->len && (!len || !memcmp(v, prev->buffer, len)))
+	if (prev && !prev->flag_deleted && len == prev->len
+			&& (!len || !memcmp(v, prev->buffer, len))) {
 		return FALSE;
+	}
 
 	/* If the new value is not longer than the previous, we can even reuse
 	 * the same buffer */

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -281,6 +281,31 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
             exc.NoSuchContainer, self.api.container_set_properties,
             self.account, name, metadata)
 
+    def test_container_unset_set_same_property(self):
+        name = random_str(32)
+
+        metadata = {
+            random_str(32): random_str(32),
+        }
+
+        res = self._create(name)
+        self.assertEqual(res, True)
+
+        # container_set_properties a property
+        self.api.container_set_properties(self.account, name, metadata)
+        data = self._get_properties(name)
+        self.assertEqual(data['properties'], metadata)
+
+        # container_unset_properties the property
+        self.api.container_del_properties(self.account, name, metadata.keys())
+        data = self._get_properties(name)
+        self.assertEqual(len(data['properties']), 0)
+
+        # container_set_properties the same property with the same value
+        self.api.container_set_properties(self.account, name, metadata)
+        data = self._get_properties(name)
+        self.assertEqual(data['properties'], metadata)
+
     def _wait_account_meta2(self):
         # give account and meta2 time to catch their breath
         wait = False


### PR DESCRIPTION
##### SUMMARY

Check if cache entry is deleted to set a new entry.

Before:
```
$ openio container create toto --property test=1
+------+---------+
| Name | Created |
+------+---------+
| toto | True    |
+------+---------+
$ openio container unset toto --property test
$ openio container set toto --property test=1
$ openio container show toto
+----------------+--------------------------------------------------------------------+
| Field          | Value                                                              |
+----------------+--------------------------------------------------------------------+
| account        | myaccount                                                          |
| base_name      | 8B78B3245B74710F3ACC1BEF4978E621F5E764E01FFB5621D23C4EECA2B7BB3D.1 |
| bytes_usage    | 0B                                                                 |
| container      | toto                                                               |
| ctime          | 1537559520                                                         |
| max_versions   | Namespace default                                                  |
| objects        | 0                                                                  |
| quota          | Namespace default                                                  |
| status         | Enabled                                                            |
| storage_policy | Namespace default                                                  |
+----------------+--------------------------------------------------------------------+
```

After:
```
$ openio container create toto --property test=1
+------+---------+
| Name | Created |
+------+---------+
| toto | True    |
+------+---------+
$ openio container unset toto --property test
$ openio container set toto --property test=1
$ openio container show toto
+----------------+--------------------------------------------------------------------+
| Field          | Value                                                              |
+----------------+--------------------------------------------------------------------+
| account        | myaccount                                                          |
| base_name      | 8B78B3245B74710F3ACC1BEF4978E621F5E764E01FFB5621D23C4EECA2B7BB3D.1 |
| bytes_usage    | 0B                                                                 |
| container      | toto                                                               |
| ctime          | 1537559632                                                         |
| max_versions   | Namespace default                                                  |
| meta.test      | 1                                                                  |
| objects        | 0                                                                  |
| quota          | Namespace default                                                  |
| status         | Enabled                                                            |
| storage_policy | Namespace default                                                  |
+----------------+--------------------------------------------------------------------+
```

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `meta2`

##### SDS VERSION

```
openio 4.2.2.dev79
```

##### ADDITIONAL INFORMATION

Jira: OS-143