### PR TITLE
CLI: fix 'directory decommission'

### DIFF
--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from logging import getLogger
+from logging import getLogger, INFO
 from cliff.command import Command
 from eventlet import Queue, GreenPile
 from oio.common.configuration import load_namespace_conf
@@ -171,7 +171,9 @@ class DirectoryRebalance(DirectoryCmd):
 
 
 class DirectoryDecommission(DirectoryCmd):
-    """Decommission a Meta1 service (or only some bases)."""
+    """
+    Decommission a Meta1 service (or only some bases).
+    """
 
     def get_parser(self, prog_name):
         parser = super(DirectoryDecommission, self).get_parser(prog_name)
@@ -179,16 +181,32 @@ class DirectoryDecommission(DirectoryCmd):
                             help='Address of service to decommission')
         parser.add_argument('base', metavar='<BASE>', nargs='*',
                             help="Name of bases to decommission")
+        parser.add_argument('--ignore-replicas-number-errors',
+                            action='store_true',
+                            help=("Continue even if the number of replicas "
+                                  "is not as expected. Dangerous."))
+
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
+        # Ensure we see 'info' logs.
+        if self.log.getEffectiveLevel() > INFO:
+            self.log.setLevel(INFO)
         mapping = self.get_prefix_mapping(parsed_args)
         mapping.load(read_timeout=parsed_args.meta0_timeout)
+        self.log.info("meta1_digits=%d", mapping.digits)
         moved = mapping.decommission(parsed_args.addr,
                                      bases_to_remove=parsed_args.base)
-        mapping.apply(moved, read_timeout=parsed_args.meta0_timeout)
-        self.log.info("Moved %s", moved)
+        if (mapping.check_replicas() or
+                parsed_args.ignore_replicas_number_errors):
+            mapping.apply(moved=moved, read_timeout=parsed_args.meta0_timeout)
+            self.log.info("Moved %s", sorted(moved))
+        else:
+            self.log.warn("Did nothing due to errors.")
+            self.log.warn("If the errors are not related to the bases "
+                          "you want to decommission, try to rebalance.")
+            return 1
 
 
 class DirectoryWarmup(DirectoryCmd):

--- a/oio/directory/meta0.py
+++ b/oio/directory/meta0.py
@@ -356,8 +356,11 @@ class Meta0PrefixMapping(MetaMapping):
             svc = self.services[svc]
         saved_score = svc["score"]
         svc["score"] = 0
-        if not bases_to_remove:
-            bases_to_remove = list(svc.get("bases", list()))
+        if bases_to_remove:
+            # Remove extra digits and duplicates
+            bases_to_remove = {b[:self.digits] for b in bases_to_remove}
+        else:
+            bases_to_remove = set(svc.get('bases', list()))
         if not strategy:
             strategy = self.find_services_less_bases
         for base in bases_to_remove:
@@ -372,7 +375,7 @@ class Meta0PrefixMapping(MetaMapping):
             new_svcs = strategy(known=self.services_by_base[base])
             self.assign_services(base, new_svcs)
         svc["score"] = saved_score
-        return set(bases_to_remove)
+        return bases_to_remove
 
     def rebalance(self, max_loops=65536):
         """Reassign bases from the services which manage the most"""


### PR DESCRIPTION
##### SUMMARY
- Accept 'long' base names when meta1_digits < 4.
- Check the number of replicas.
- Make it more verbose by default.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 4.2.3.dev2
```
