### PR TITLE
meta2: allow older versions

### DIFF
--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -1575,13 +1575,16 @@ GError* m2db_put_alias(struct m2db_put_args_s *args, GSList *beans,
 		g_clear_error(&err);
 	}
 
+	gint64 max_versions = m2db_get_max_versions(args->sq3,
+	                                            args->ns_max_versions);
+
 	/* Manage the potential conflict with the latest alias in place. */
 	if (version > 0) {
 		const gint64 latest_version = latest? ALIASES_get_version(latest) : 0;
 		/* version explicitely specified */
 		if (version == latest_version) {
 			err = NEWERROR(CODE_CONTENT_EXISTS, "Alias already saved");
-		} else if (version < latest_version) {
+		} else if (version < latest_version && !VERSIONS_ENABLED(max_versions)) {
 			err = NEWERROR(CODE_CONTENT_PRECONDITION,
 					"New object version is older than latest version");
 		}
@@ -1592,11 +1595,8 @@ GError* m2db_put_alias(struct m2db_put_args_s *args, GSList *beans,
 			version ++;
 	}
 
-	gint64 max_versions = m2db_get_max_versions(args->sq3,
-												args->ns_max_versions);
-
 	/* Check the operation respects the rules of versioning for the container */
-	if (latest) {
+	if (!err && latest) {
 		if (VERSIONS_DISABLED(max_versions)) {
 			if (ALIASES_get_deleted(latest) || ALIASES_get_version(latest) > 0) {
 				GRID_DEBUG("Versioning DISABLED but clues of SUSPENDED");

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -909,7 +909,6 @@ static void
 test_content_put_lower_version(void)
 {
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
-		(void) maxver;
 		GSList *beans = NULL;
 		GError *err;
 
@@ -931,7 +930,11 @@ test_content_put_lower_version(void)
 		CLOCK++;
 		_set_content_id(u);
 		err = meta2_backend_put_alias(m2, u, beans, NULL, NULL, NULL, NULL);
-		g_assert_error(err, GQ(), CODE_CONTENT_PRECONDITION);
+		if (VERSIONS_ENABLED(maxver)) {
+			g_assert_no_error(err);
+		} else {
+			g_assert_error(err, GQ(), CODE_CONTENT_PRECONDITION);
+		}
 		_bean_cleanl2(beans);
 		g_clear_error(&err);
 


### PR DESCRIPTION
##### SUMMARY
If versioning is enabled, allow older versions than current version of object to support parallel
writs on same object for S3 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meta2

##### SDS VERSION
```
openio --version
4.2.2dev13
```

##### ADDITIONAL INFORMATION

Please note that current version has drawback if max_version is 1: latest object written
always be kept even if oldest.
