### PR TITLE
oio-blob-rebuilder: Minor fixes

### DIFF
--- a/oio/rebuilder/blob_rebuilder.py
+++ b/oio/rebuilder/blob_rebuilder.py
@@ -394,6 +394,8 @@ class BlobRebuilderWorker(RebuilderWorker):
 class Beanstalkd(object):
 
     def __init__(self, addr, tube, logger, **kwargs):
+        if addr is not None and addr.startswith('beanstalk://'):
+            addr = addr[12:]
         self.addr = addr
         self.tube = tube
         self.logger = logger

--- a/oio/rebuilder/blob_rebuilder.py
+++ b/oio/rebuilder/blob_rebuilder.py
@@ -412,6 +412,8 @@ class Beanstalkd(object):
         self.beanstalkd = None
         self.connected = False
         self._connect()
+        # Check the connection
+        self.beanstalkd.stats_tube(self.tube)
 
     def _connect(self, **kwargs):
         self.close()
@@ -444,7 +446,7 @@ class BeanstalkdListener(Beanstalkd):
             self.beanstalkd.delete(job_id)
         except ConnectionError as exc:
             self.connected = False
-            self.logger.debug(
+            self.logger.warn(
                 'Disconnected from %s using tube %s (job=%s): %s',
                 self.addr, self.tube, job_id, exc)
             if 'Invalid URL' in str(exc):
@@ -501,7 +503,7 @@ class BeanstalkdSender(Beanstalkd):
             return True
         except ConnectionError as exc:
             self.connected = False
-            self.logger.debug(
+            self.logger.warn(
                 'Disconnected from %s using tube %s (job=%s): %s',
                 self.addr, self.tube, job_id, exc)
             if 'Invalid URL' in str(exc):


### PR DESCRIPTION
##### SUMMARY

- Accept the 'beanstalk://' prefix for the beanstalk IP
- Stop if there is no response
- Check the beanstalk connection
- Reuse the beanstalk connection 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `oio-blob-rebuilder`

##### SDS VERSION

```
openio 4.2.3.dev40
```