### PR TITLE
CLI: fix 'openio object list --auto --no-paging'

### DIFF
--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -278,7 +278,10 @@ class Account(WerkzeugApp):
     # ACCT{{
     # GET /v1.0/account/containers?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Get information about containers on account named account_name
+    #
+    # Get information about the containers belonging to the specified account.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -286,6 +289,8 @@ class Account(WerkzeugApp):
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -328,6 +333,7 @@ class Account(WerkzeugApp):
             prefix=prefix, delimiter=delimiter)
 
         info['listing'] = user_list
+        # TODO(FVE): add "truncated" entry telling if the listing is truncated
         result = json.dumps(info)
         return Response(result, mimetype='text/json')
 

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -561,6 +561,7 @@ class ListObject(ContainerCommandMixin, lister.Lister):
                         account=account, **kwargs),
                 depaginate(self.app.client_manager.storage.container_list,
                            item_key=lambda x: x[0],
+                           marker_key=lambda x: x[-1][0],
                            account=account,
                            marker=container_marker)):
             for element in object_list:


### PR DESCRIPTION
##### SUMMARY
Autocontainer object listings were truncated to the objects from the first 1000 containers. This pull request fixes the problem.

Jira: OS-164

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 4.2.3.dev7
```