### PR TITLE
Revert "Prevent urllib3 1.24"

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -9,6 +9,6 @@ PyYAML>=3.10
 redis>=2.10.3
 requests!=2.13.0
 simplejson>=2.0.9
-urllib3>=1.13.1,<1.24
+urllib3>=1.13.1
 werkzeug>=0.9.1
 zkpython


### PR DESCRIPTION
##### SUMMARY

Requests now supports urllib3 v1.24: https://github.com/requests/requests/blob/master/HISTORY.md#2200-2018-10-18

##### ISSUE TYPE

 - Bugfix Pull Request

##### SDS VERSION

```
openio 4.2.4.dev6
```