### PR TITLE
lifecycle: Check the S3 tags instead of checking the properties 

### DIFF
--- a/tests/functional/cli/lifecycle/test_lifecycle.py
+++ b/tests/functional/cli/lifecycle/test_lifecycle.py
@@ -16,7 +16,6 @@
 import uuid
 from tempfile import NamedTemporaryFile
 from tests.functional.cli import CliTestCase
-from oio.container.lifecycle import TAGGING_KEY
 
 
 class LifecycleCliTest(CliTestCase):
@@ -73,13 +72,10 @@ class LifecycleCliTest(CliTestCase):
             self.openio(
                 'object create %s %s --name test1' % (self.NAME, file_.name))
             self.openio(
-                'object create %s %s --name test2 ' % (self.NAME, file_.name) +
-                '--property "%s=' % TAGGING_KEY +
-                '<Tagging ' +
-                'xmlns=\\"http://s3.amazonaws.com/doc/2006-03-01/\\">' +
-                '<TagSet><Tag>' +
-                '<Value>deprecated</Value><Key>status</Key>' +
-                '</Tag></TagSet></Tagging>"')
+                'object create %s %s --name test2 ' % (self.NAME, file_.name))
+            self.openio(
+                'object set %s test2 --tagging \'{"status":"deprecated"}\''
+                % (self.NAME))
         opts = self.get_opts(['Name', 'Result'])
         output = self.openio('lifecycle apply ' + self.NAME + opts)
         output = output.split('\n')

--- a/tests/functional/cli/lifecycle/test_lifecycle.py
+++ b/tests/functional/cli/lifecycle/test_lifecycle.py
@@ -16,6 +16,7 @@
 import uuid
 from tempfile import NamedTemporaryFile
 from tests.functional.cli import CliTestCase
+from oio.container.lifecycle import TAGGING_KEY
 
 
 class LifecycleCliTest(CliTestCase):
@@ -73,7 +74,12 @@ class LifecycleCliTest(CliTestCase):
                 'object create %s %s --name test1' % (self.NAME, file_.name))
             self.openio(
                 'object create %s %s --name test2 ' % (self.NAME, file_.name) +
-                '--property status=deprecated')
+                '--property "%s=' % TAGGING_KEY +
+                '<Tagging ' +
+                'xmlns=\\"http://s3.amazonaws.com/doc/2006-03-01/\\">' +
+                '<TagSet><Tag>' +
+                '<Value>deprecated</Value><Key>status</Key>' +
+                '</Tag></TagSet></Tagging>"')
         opts = self.get_opts(['Name', 'Result'])
         output = self.openio('lifecycle apply ' + self.NAME + opts)
         output = output.split('\n')

--- a/tests/functional/container/test_lifecycle.py
+++ b/tests/functional/container/test_lifecycle.py
@@ -18,7 +18,8 @@ import time
 from mock import patch
 
 from oio import ObjectStorageApi
-from oio.container.lifecycle import ContainerLifecycle, LIFECYCLE_PROPERTY_KEY
+from oio.container.lifecycle import ContainerLifecycle, \
+    LIFECYCLE_PROPERTY_KEY, TAGGING_KEY
 from tests.utils import BaseTestCase, random_str
 
 
@@ -262,7 +263,17 @@ class TestContainerLifecycle(BaseTestCase):
 
     def test_immediate_expiration_filtered_by_tag(self):
         obj_meta = self._upload_something()
-        obj_meta2 = self._upload_something(properties={'status': 'deprecated'})
+        obj_meta2 = self._upload_something(
+            properties={TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>status</Key>
+                        <Value>deprecated</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """})
         self.lifecycle.load_xml("""
         <LifecycleConfiguration>
             <Rule>
@@ -289,8 +300,17 @@ class TestContainerLifecycle(BaseTestCase):
 
     def test_immediate_transition_filtered_by_tag(self):
         obj_meta = self._upload_something(policy='SINGLE')
-        obj_meta2 = self._upload_something(policy='SINGLE',
-                                           properties={'status': 'deprecated'})
+        obj_meta2 = self._upload_something(
+            policy='SINGLE', properties={TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>status</Key>
+                        <Value>deprecated</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """})
         self.lifecycle.load_xml("""
         <LifecycleConfiguration>
             <Rule>

--- a/tests/unit/container/test_lifecycle.py
+++ b/tests/unit/container/test_lifecycle.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from oio.container.lifecycle import Expiration, \
     LifecycleRule, LifecycleRuleFilter, Transition, \
-    NoncurrentVersionExpiration
+    NoncurrentVersionExpiration, TAGGING_KEY
 
 
 class TestContainerLifecycle(unittest.TestCase):
@@ -351,7 +351,20 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         obj_meta = self.obj_meta.copy()
         obj_meta['name'] = 'documents/toto'
-        obj_meta['properties'] = {'key1': 'value1', 'key2': 'value2'}
+        obj_meta['properties'] = {TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                    <Tag>
+                        <Key>key2</Key>
+                        <Value>value2</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """}
         self.assertTrue(filter_.match(obj_meta))
 
     def test_LifecycleRuleFilter_match_bad_prefix(self):
@@ -374,7 +387,20 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         obj_meta = self.obj_meta.copy()
         obj_meta['name'] = 'downloads/toto'
-        obj_meta['properties'] = {'key1': 'value1', 'key2': 'value2'}
+        obj_meta['properties'] = {TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                    <Tag>
+                        <Key>key2</Key>
+                        <Value>value2</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """}
         self.assertFalse(filter_.match(obj_meta))
 
     def test_LifecycleRuleFilter_match_missing_tag(self):
@@ -397,7 +423,16 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         obj_meta = self.obj_meta.copy()
         obj_meta['name'] = 'documents/toto'
-        obj_meta['properties'] = {'key1': 'value1'}
+        obj_meta['properties'] = {TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """}
         self.assertFalse(filter_.match(obj_meta))
 
     def test_LifecycleRuleFilter_match_only_prefix(self):
@@ -412,7 +447,20 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         obj_meta = self.obj_meta.copy()
         obj_meta['name'] = 'documents/toto'
-        obj_meta['properties'] = {'key1': 'value1', 'key2': 'value2'}
+        obj_meta['properties'] = {TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                    <Tag>
+                        <Key>key2</Key>
+                        <Value>value2</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """}
         self.assertTrue(filter_.match(obj_meta))
 
     def test_LifecycleRuleFilter_match_only_tags(self):
@@ -434,7 +482,20 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         obj_meta = self.obj_meta.copy()
         obj_meta['name'] = 'documents/toto'
-        obj_meta['properties'] = {'key1': 'value1', 'key2': 'value2'}
+        obj_meta['properties'] = {TAGGING_KEY: """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                    <Tag>
+                        <Key>key2</Key>
+                        <Value>value2</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """}
         self.assertTrue(filter_.match(obj_meta))
 
     def test_Expiration_match_days(self):
@@ -504,7 +565,29 @@ class TestContainerLifecycle(unittest.TestCase):
         self.assertFalse(rule.match(obj_meta))
         obj_meta['name'] = "documents/foo"
         self.assertFalse(rule.match(obj_meta))
-        obj_meta['properties']['key1'] = 'value1'
+        obj_meta['properties'][TAGGING_KEY] = """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """
         self.assertFalse(rule.match(obj_meta))
-        obj_meta['properties']['key2'] = 'value2'
+        obj_meta['properties'][TAGGING_KEY] = """
+            <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <TagSet>
+                    <Tag>
+                        <Key>key1</Key>
+                        <Value>value1</Value>
+                    </Tag>
+                    <Tag>
+                        <Key>key2</Key>
+                        <Value>value2</Value>
+                    </Tag>
+                </TagSet>
+            </Tagging>
+            """
         self.assertTrue(rule.match(obj_meta))

--- a/tests/unit/container/test_lifecycle.py
+++ b/tests/unit/container/test_lifecycle.py
@@ -117,7 +117,7 @@ class TestContainerLifecycle(unittest.TestCase):
         self.assertIsNotNone(trans)
         self.assertEqual(trans.filter.date, 1155513600)
 
-    def test_LifecycleRuleFilter_from_element_broken_tag(self):
+    def test_LifecycleRuleFilter_from_element_broken(self):
         filter_elt = etree.XML(
             """
             <Filter>
@@ -135,6 +135,45 @@ class TestContainerLifecycle(unittest.TestCase):
                 <Tag>
                     <Value>value</Value>
                 </Tag>
+            </Filter>
+            """)
+        self.assertRaises(ValueError,
+                          LifecycleRuleFilter.from_element, filter_elt)
+
+        filter_elt = etree.XML(
+            """
+            <Filter>
+                <Tag>
+                    <Key>key1</Key>
+                    <Value>value1</Value>
+                </Tag>
+                <Tag>
+                    <Key>key2</Key>
+                    <Value>value2</Value>
+                </Tag>
+            </Filter>
+            """)
+        self.assertRaises(ValueError,
+                          LifecycleRuleFilter.from_element, filter_elt)
+
+        filter_elt = etree.XML(
+            """
+            <Filter>
+                <Prefix>documents/</Prefix>
+                <Tag>
+                    <Key>key2</Key>
+                    <Value>value2</Value>
+                </Tag>
+            </Filter>
+            """)
+        self.assertRaises(ValueError,
+                          LifecycleRuleFilter.from_element, filter_elt)
+
+        filter_elt = etree.XML(
+            """
+            <Filter>
+                <Prefix>documents1/</Prefix>
+                <Prefix>documents2/</Prefix>
             </Filter>
             """)
         self.assertRaises(ValueError,
@@ -172,7 +211,7 @@ class TestContainerLifecycle(unittest.TestCase):
         filter_ = LifecycleRuleFilter.from_element(filter_elt)
         self.assertIsNotNone(filter_)
         self.assertIsNone(filter_.prefix)
-        self.assertIn('key', filter_.tags)
+        self.assertDictEqual({'key': 'value'}, filter_.tags)
         self.assertEqual(filter_.generate_id(), "key=value")
 
         filter_elt = etree.XML(


### PR DESCRIPTION
##### SUMMARY

Check the S3 tags instead of checking the properties when applying Lifecycle

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- `lifecycle`
- `CLI`

##### SDS VERSION

```
openio 4.2.4.dev12
```