### PR TITLE
meta2: fix memory leak

### DIFF
--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -464,7 +464,9 @@ m2db_get_alias(struct sqlx_sqlite3_s *sq3, struct oio_url_s *u,
 		}
 	}
 
-	err = _alias_fetch_info(sq3, flags, tmp, cb, u0);
+	if (!err) {
+		err = _alias_fetch_info(sq3, flags, tmp, cb, u0);
+	}
 
 	_bean_cleanv2(tmp);
 	return err;


### PR DESCRIPTION
##### SUMMARY

Fix a meta2 memory leak

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meta2

##### SDS VERSION
```
4.2.3
```


##### ADDITIONAL INFORMATION

Previous error was overwritten by next function call
(Please note that it seems that seems always triggered so fixing this may show other errors)