### PR TITLE
Clean Python API, improve oio-blob-indexer and some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,25 @@ dist: trusty
 language: go
 go:
   - 1.10.x
-install:
-  - sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse"
-  - sudo apt-add-repository "deb http://mirror.openio.io/pub/repo/openio/sds/17.04/ubuntu/trusty ./"
+addons:
+  apt:
+    sources:
+    - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+    - sourceline: 'deb http://mirror.openio.io/pub/repo/openio/sds/17.04/ubuntu/trusty ./'
+    update: true
+
+before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes openio-gridinit openio-asn1c
-  - sudo apt-get install -y --force-yes flex bison curl lcov libglib2.0-dev libzookeeper-mt-dev libzmq3-dev libcurl4-gnutls-dev libapreq2-dev libsqlite3-dev attr libattr1-dev apache2 apache2-dev libapache2-mod-wsgi liblzo2-dev libjson-c-dev libleveldb1 libleveldb-dev libattr1-dev python-all-dev python-virtualenv liberasurecode-dev zookeeper zookeeper-bin zookeeperd beanstalkd
-  - sudo apt-get install -y --force-yes gdb
+  - sudo apt-get install -y --force-yes flex bison curl lcov libglib2.0-dev libzookeeper-mt-dev libzmq3-dev libcurl4-gnutls-dev libapreq2-dev libsqlite3-dev attr libattr1-dev apache2 apache2-dev libapache2-mod-wsgi liblzo2-dev libjson-c-dev libleveldb1 libleveldb-dev libattr1-dev python-all-dev python-virtualenv liberasurecode-dev zookeeper zookeeper-bin zookeeperd beanstalkd openio-gridinit openio-asn1c gdb
+
+install:
   - sudo service beanstalkd stop
   - virtualenv $HOME/oio && source $HOME/oio/bin/activate
   - pip install --upgrade pip setuptools virtualenv tox
   - pip install --upgrade -r all-requirements.txt -r test-requirements.txt
   - pip install --upgrade zkpython
-  - go get gopkg.in/ini.v1
-  - go get gopkg.in/tylerb/graceful.v1
+  - go get gopkg.in/ini.v1 gopkg.in/tylerb/graceful.v1
+
 env:
   - TEST_SUITE=3copies,with-service-id
   - TEST_SUITE=ec,with-random-service-id
@@ -30,6 +35,7 @@ env:
   - TEST_SUITE=worm
   - TEST_SUITE=build,unit,copyright,variables
   - TEST_SUITE=rebuilder,mover,with-service-id
+
 script:
   - sudo bash -c "echo '/tmp/core.%p.%E' > /proc/sys/kernel/core_pattern"
   - ulimit -c unlimited -S
@@ -46,6 +52,7 @@ script:
   - make coverage_init
   - ./tools/oio-travis-tests.sh
   - make coverage
+
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f cmake_coverage.output
   - codecov

--- a/oio/__init__.py
+++ b/oio/__init__.py
@@ -36,32 +36,7 @@ import importlib
 import sys
 
 
-class LazyLoader(object):
-    """Delay module or class loading."""
-
-    def __init__(self, module, name=None):
-        self.mod_name = module
-        self.class_name = name
-        self.value = None
-
-    def __ensure_value(self):
-        if self.value is None:
-            mod = importlib.import_module(self.mod_name)
-            if self.class_name:
-                self.value = getattr(mod, self.class_name)
-            else:
-                self.value = mod
-
-    def __getattr__(self, name):
-        self.__ensure_value()
-        return getattr(self.value, name)
-
-    def __call__(self, *args, **kwargs):
-        self.__ensure_value()
-        return self.value(*args, **kwargs)
-
-
-class OioModule(object):
+class ObjectStorageApi(object):
 
     oio = importlib.import_module('oio')
     object_storage = None
@@ -88,5 +63,5 @@ except pkg_resources.DistributionNotFound:
     __canonical_version__ = _version_info.version_string()
 
 
-sys.modules[__name__] = OioModule()
+sys.modules[__name__] = ObjectStorageApi()
 __all__ = ["ObjectStorageApi"]

--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -134,8 +134,15 @@ class AccountClient(HttpApi):
         _resp, body = self.account_request(account, 'GET', 'show', **kwargs)
         return body
 
-    # FIXME: document this
     def account_update(self, account, metadata, to_delete, **kwargs):
+        """
+        Update metadata of the specified account.
+
+        :param metadata: dictionary of properties that must be set or updated.
+        :type metadata: `dict`
+        :param to_delete: list of property keys that must be removed.
+        :type to_delete: `list`
+        """
         data = json.dumps({"metadata": metadata, "to_delete": to_delete})
         self.account_request(account, 'POST', 'update', data=data, **kwargs)
 

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -40,6 +40,9 @@ def access_log(func):
 
 
 class Account(WerkzeugApp):
+
+    # pylint: disable=no-member
+
     def __init__(self, conf, backend, logger=None):
         self.conf = conf
         self.backend = backend
@@ -63,6 +66,7 @@ class Account(WerkzeugApp):
         super(Account, self).__init__(self.url_map, self.logger)
 
     def _get_account_id(self, req):
+        """Fetch account name from request query string."""
         account_id = req.args.get('id')
         if not account_id:
             raise BadRequest('Missing Account ID')
@@ -71,9 +75,11 @@ class Account(WerkzeugApp):
     # ACCT{{
     # GET /status
     # ~~~~~~~~~~~
-    # Return a summary of the target ACCOUNT service. The body of the reply
+    # Return a summary of the target account service. The body of the reply
     # will present a count of the objects in the databse, formatted as a JSON
     # object.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -81,6 +87,8 @@ class Account(WerkzeugApp):
     #    Host: 127.0.0.1:6021
     #    User-Agent: curl/7.55.1
     #    Accept: */*
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -101,7 +109,9 @@ class Account(WerkzeugApp):
     # ACCT{{
     # PUT /v1.0/account/create?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Create new account named account_name
+    # Create a new account with the specified name.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -109,6 +119,8 @@ class Account(WerkzeugApp):
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -133,7 +145,9 @@ class Account(WerkzeugApp):
     # ACCT{{
     # GET /v1.0/account/list
     # ~~~~~~~~~~~~~~~~~~~~~~
-    # Get list of existing accounts
+    # Get the list of existing accounts.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -141,6 +155,8 @@ class Account(WerkzeugApp):
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -162,9 +178,11 @@ class Account(WerkzeugApp):
         return Response(json.dumps(accounts), mimetype='text/json')
 
     # ACCT{{
-    # PUT /v1.0/account/delete?id=<account_name>
+    # POST /v1.0/account/delete?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Delete account named account_name
+    # Delete the specified account.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -173,9 +191,11 @@ class Account(WerkzeugApp):
     #    User-Agent: curl/7.47.0
     #    Accept: */*
     #
+    # Sample response:
+    #
     # .. code-block:: http
     #
-    #    HTTP/1.1 204 NO CONTENT
+    #    HTTP/1.1 204 No Content
     #    Server: gunicorn/19.9.0
     #    Date: Wed, 01 Aug 2018 12:17:25 GMT
     #    Connection: keep-alive
@@ -193,17 +213,12 @@ class Account(WerkzeugApp):
             return Response(status=204)
 
     # ACCT{{
-    # PUT /v1.0/account/update?id=<account_name>
+    # POST /v1.0/account/update?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #
-    # .. code-block:: json
+    # Update metadata of the specified account.
     #
-    #    {
-    #      "metadata": {"key":"value"},
-    #      "to_delete": ["key"]
-    #    }
-    #
-    # Update metadata of account named account_name
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -213,6 +228,15 @@ class Account(WerkzeugApp):
     #    Accept: */*
     #    Content-Length: 41
     #    Content-Type: application/x-www-for-urlencoded
+    #
+    # .. code-block:: json
+    #
+    #    {
+    #      "metadata": {"key":"value"},
+    #      "to_delete": ["key"]
+    #    }
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -237,7 +261,9 @@ class Account(WerkzeugApp):
     # ACCT{{
     # GET /v1.0/account/show?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Get information about an account named account_name
+    # Get information about the specified account.
+    #
+    # Sample request:
     #
     # .. code-block:: http
     #
@@ -245,6 +271,8 @@ class Account(WerkzeugApp):
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
+    #
+    # Sample response:
     #
     # .. code-block:: http
     #
@@ -387,8 +415,22 @@ class Account(WerkzeugApp):
         return Response(result)
 
     # ACCT{{
-    # GET /v1.0/account/container/reset?id=<account_name>
+    # POST /v1.0/account/container/reset?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #
+    # Reset statistics of the specified container.
+    # Usually followed by a "container touch" operation.
+    #
+    # Request example:
+    #
+    # .. code-block:: http
+    #
+    #    POST /v1.0/account/container/reset?id=myaccount HTTP/1.1
+    #    Host: 127.0.0.1:6013
+    #    User-Agent: curl/7.47.0
+    #    Accept: */*
+    #    Content-Length: 45
+    #    Content-Type: application/x-www-form-urlencoded
     #
     # .. code-block:: json
     #
@@ -397,16 +439,7 @@ class Account(WerkzeugApp):
     #      "mtime": 1234567891011
     #    }
     #
-    # Reset container of an account named account_name
-    #
-    # .. code-block:: http
-    #
-    #    GET /v1.0/account/container/reset?id=myaccount HTTP/1.1
-    #    Host: 127.0.0.1:6013
-    #    User-Agent: curl/7.47.0
-    #    Accept: */*
-    #    Content-Length: 45
-    #    Content-Type: application/x-www-form-urlencoded
+    # Response example:
     #
     # .. code-block:: http
     #

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -38,7 +38,8 @@ class HttpApi(object):
     towards the same endpoint, with a pool of connections.
     """
 
-    def __init__(self, endpoint=None, pool_manager=None, **kwargs):
+    def __init__(self, endpoint=None, pool_manager=None,
+                 connection='keep-alive', **kwargs):
         """
         :param pool_manager: an optional pool manager that will be reused
         :type pool_manager: `urllib3.PoolManager`
@@ -51,6 +52,8 @@ class HttpApi(object):
             metrics of time spent to resolve the meta2 address and
             to do the meta2 request.
         :type perfdata: `dict`
+        :keyword connection: 'keep-alive' to keep connections open (default)
+            or 'close' to explicitly close them.
         """
         super(HttpApi, self).__init__()
         self.endpoint = endpoint
@@ -64,6 +67,7 @@ class HttpApi(object):
 
         self.admin_mode = true_value(kwargs.get('admin_mode', False))
         self.perfdata = kwargs.get('perfdata')
+        self.connection = connection
 
     def _direct_request(self, method, url, headers=None, data=None, json=None,
                         params=None, admin_mode=False, pool_manager=None,
@@ -142,6 +146,10 @@ class HttpApi(object):
         perfdata = kwargs.get('perfdata', self.perfdata)
         if perfdata is not None:
             out_headers[PERFDATA_HEADER] = 'enabled'
+
+        # Explicitly keep or close the connection
+        if 'Connection' not in out_headers:
+            out_headers['Connection'] = self.connection
 
         out_kwargs['headers'] = out_headers
         out_kwargs['body'] = data

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -1242,6 +1242,11 @@ class ObjectStorageApi(object):
     @ensure_headers
     @ensure_request_id
     def container_refresh(self, account, container, attempts=3, **kwargs):
+        """
+        Reset statistics of the specified container,
+        and trigger an event that will update them.
+        If the container does not exist, remove it from account.
+        """
         for i in range(attempts):
             try:
                 self.account.container_reset(account, container, time.time(),
@@ -1251,8 +1256,8 @@ class ObjectStorageApi(object):
                     raise
         try:
             self.container.container_touch(account, container, **kwargs)
-        except exc.ClientException as e:
-            if e.status != 406 and e.status != 431:
+        except exc.ClientException as err:
+            if err.status != 406 and err.status != 431:
                 raise
             # CODE_USER_NOTFOUND or CODE_CONTAINER_NOTFOUND
             metadata = dict()

--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -74,8 +74,9 @@ class BlobConverter(object):
         self.name_by_cid = CacheDict()
         self.content_id_by_name = CacheDict()
         # client
-        self.container_client = ContainerClient(conf)
-        self.content_factory = ContentFactory(conf, logger=self.logger)
+        self.container_client = ContainerClient(conf, **kwargs)
+        self.content_factory = ContentFactory(conf, self.container_client,
+                                              logger=self.logger)
         # stats/logs
         self.errors = 0
         self.passes = 0

--- a/oio/cli/account/account.py
+++ b/oio/cli/account/account.py
@@ -100,7 +100,7 @@ class CreateAccount(lister.Lister):
 
 
 class SetAccount(command.Command):
-    """Set account properties"""
+    """Set account properties."""
 
     log = getLogger(__name__ + '.SetAccount')
 
@@ -118,7 +118,7 @@ class SetAccount(command.Command):
             '--property',
             metavar='<key=value>',
             action=KeyValueAction,
-            help='Property to add/update for this account'
+            help='Property to add/update to this account'
         )
         return parser
 
@@ -132,7 +132,7 @@ class SetAccount(command.Command):
 
 
 class UnsetAccount(command.Command):
-    """Unset account properties"""
+    """Unset account properties."""
 
     log = getLogger(__name__ + '.UnsetAccount')
 
@@ -144,7 +144,7 @@ class UnsetAccount(command.Command):
             help='Account to modify',
         )
         parser.add_argument(
-            '--property',
+            '-p', '--property',
             metavar='<key>',
             action='append',
             default=[],

--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -73,11 +73,11 @@ def ratelimit(run_time, max_rate, increment=1, rate_buffer=5):
     if now - run_time > rate_buffer * clock_accuracy:
         run_time = now
     elif run_time - now > time_per_request:
-        eventlet.sleep((run_time - now) / clock_accuracy)
+        sleep((run_time - now) / clock_accuracy)
     return run_time + time_per_request
 
 
-class ContextPool(eventlet.GreenPool):
+class ContextPool(GreenPool):
     def __enter__(self):
         return self
 

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -572,11 +572,16 @@ class Beanstalk(object):
             else:
                 raise
 
-    def wait_until_empty(self, tube, timeout=float('inf'), poll_interval=0.2):
+    def wait_until_empty(self, tube, timeout=float('inf'), poll_interval=0.2,
+                         initial_delay=0.0):
         """
         Wait until the the specified tube is empty, or the timeout expires.
         """
+        # TODO(FVE): check tube stats to ensure some jobs have passed through
+        # and then get rid of the initial_delay
         self.watch(tube)
+        if initial_delay > 0.0:
+            sleep(initial_delay)
         job_id, _ = self.peek_ready()
         deadline = time() + timeout
         while job_id is not None and time() < deadline:

--- a/oio/rebuilder/blob_rebuilder.py
+++ b/oio/rebuilder/blob_rebuilder.py
@@ -19,7 +19,6 @@ import uuid
 from datetime import datetime
 from socket import gethostname
 
-from oio.api.base import HttpApi
 from oio.common.json import json
 from oio.common.green import threading
 from oio.common.easy_value import int_value, true_value
@@ -42,7 +41,6 @@ class BlobRebuilder(Rebuilder):
     def __init__(self, conf, logger, volume, try_chunk_delete=False,
                  beanstalkd_addr=None, **kwargs):
         super(BlobRebuilder, self).__init__(conf, logger, volume, **kwargs)
-        self.http = HttpApi(**kwargs)
         # rdir
         self.rdir_client = RdirClient(conf, logger=self.logger)
         self.rdir_fetch_limit = int_value(conf.get('rdir_fetch_limit'), 100)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,9 @@
-flake8
-coverage
-nose
-mock>=1.0
-fixtures>=1.4.0
-gcovr
-codecov
 beanstalkc
+codecov
+coverage
+fixtures>=1.4.0
+flake8
+gcovr
+mock>=1.0
+nose
+nose-timer

--- a/tests/functional/blob/test_auditor.py
+++ b/tests/functional/blob/test_auditor.py
@@ -16,7 +16,6 @@
 import random
 
 from oio.api.object_storage import ObjectStorageApi
-from oio.conscience.client import ConscienceClient
 from oio.blob.client import BlobClient
 from oio.common.utils import cid_from_name
 from oio.common.exceptions import OrphanChunk
@@ -33,7 +32,6 @@ class TestBlobAuditor(BaseTestCase):
         self.cid = cid_from_name(self.account, self.container)
         self.path = random_str(16)
         self.api = ObjectStorageApi(self.ns)
-        self.conscience = ConscienceClient(self.conf)
         self.blob_client = BlobClient(self.conf)
 
         self.api.container_create(self.account, self.container)

--- a/tests/functional/blob/test_converter.py
+++ b/tests/functional/blob/test_converter.py
@@ -16,7 +16,6 @@
 import random
 
 from oio.api.object_storage import ObjectStorageApi
-from oio.conscience.client import ConscienceClient
 from oio.common.utils import cid_from_name
 from oio.common.fullpath import encode_fullpath
 from oio.common.constants import chunk_xattr_keys, \
@@ -34,7 +33,6 @@ class TestBlobConverter(BaseTestCase):
         self.container = random_str(16)
         self.path = random_str(16)
         self.api = ObjectStorageApi(self.ns)
-        self.conscience = ConscienceClient(self.conf)
 
         self.api.container_create(self.account, self.container)
         _, chunks = self.api.container.content_prepare(

--- a/tests/functional/blob/test_indexer.py
+++ b/tests/functional/blob/test_indexer.py
@@ -21,7 +21,6 @@ from time import sleep
 from oio.rdir.client import RdirClient
 from oio.blob.client import BlobClient
 from oio.blob.indexer import BlobIndexer
-from oio.conscience.client import ConscienceClient
 from oio.common.constants import OIO_VERSION
 from oio.common.fullpath import encode_fullpath
 from oio.common.utils import cid_from_name, paths_gen
@@ -38,7 +37,6 @@ class TestBlobIndexer(BaseTestCase):
         self.blob_client = BlobClient(self.conf)
         _, self.rawx_path, rawx_addr, _ = \
             self.get_service_url('rawx')
-        self.conscience = ConscienceClient(self.conf)
         services = self.conscience.all_services('rawx')
         self.rawx_id = None
         for rawx in services:

--- a/tests/functional/directory/test_refmapping.py
+++ b/tests/functional/directory/test_refmapping.py
@@ -18,7 +18,6 @@ from time import sleep
 
 from oio import ObjectStorageApi
 from oio.directory.meta1 import Meta1RefMapping
-from oio.conscience.client import ConscienceClient
 from tests.functional.cli import execute
 from tests.utils import BaseTestCase, random_str
 
@@ -28,7 +27,6 @@ class TestMeta1RefMapping(BaseTestCase):
     def setUp(self):
         super(TestMeta1RefMapping, self).setUp()
         self.api = ObjectStorageApi(self.ns)
-        self.conscience = ConscienceClient({"namespace": self.ns})
         self.account = "test_refmapping"
         self.reference = "refmapping-" + random_str(4)
         self.logger = logging.getLogger('test')

--- a/tests/functional/rdir/test_server.py
+++ b/tests/functional/rdir/test_server.py
@@ -48,7 +48,7 @@ def _write_config(path, config):
 class RdirTestCase(CommonTestCase):
     def setUp(self):
         super(RdirTestCase, self).setUp()
-        self.http_pool = get_pool_manager(max_retries=10, backoff_factor=0.05)
+        self._http_pool = get_pool_manager(max_retries=10, backoff_factor=0.05)
         self.garbage_files = list()
         self.garbage_procs = list()
 

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -50,6 +50,8 @@ function trap_exit {
 	#pip list
 	BEANSTALK=$(oio-test-config.py -t beanstalkd)
 	if [ ! -z "${BEANSTALK}" ]; then
+		# some tests stop all services, we must start beanstalk to dump events
+		gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock start @beanstalkd
 		oio-dump-buried-events.py ${BEANSTALK}
 	fi
 	gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock status3

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,17 @@ skipdist = True
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-setenv = VIRTUAL_ENV={envdir}
+setenv =
+    NOSE_ARGS = {env:NOSE_ARGS:} --with-timer --timer-ok=1 --timer-warning=10 --timer-top-n=10
+    VIRTUAL_ENV = {envdir}
 deps =
     -r{toxinidir}/all-requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = nosetests {posargs:tests/unit}
-passenv = TRAVIS CIRCLECI OIO_*
+passenv = TRAVIS CIRCLECI OIO_* NOSE_ARGS
 
 [testenv:coverage]
-commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {posargs:tests/unit}
+commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {env:NOSE_ARGS:} {posargs:tests/unit}
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
##### SUMMARY
- Remove an unused class in root package of Python API.
- Explicitly set `Connection: keep-alive` header in requests toward rdir, account and proxy. This should drastically reduce the number of connections made by some tools like `oio-blob-indexer`.
- Share a connection pool between several objects in `oio-blob-indexer`.
- Display each test's duration.
- Improve some tests using events: make them faster and more reliable.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API
- oio-blob-indexer
- CI

##### SDS VERSION
```
openio 4.3.1.dev6
```