### PR TITLE
lifecycle: Prevent some configurations

### DIFF
--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -124,6 +124,10 @@ class FileNotFound(OioException):
     pass
 
 
+class LifecycleNotFound(OioException):
+    pass
+
+
 class ContainerNotEmpty(OioException):
     pass
 

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -759,7 +759,7 @@ class Transition(LifecycleAction):
     Change object storage policy.
     """
 
-    XML_POLICY = 'StorageClass'
+    STORAGE_POLICY_XML_TAG = 'StorageClass'
 
     def __init__(self, filter_, policy, **kwargs):
         super(Transition, self).__init__(filter_, **kwargs)
@@ -777,13 +777,14 @@ class Transition(LifecycleAction):
         :type transition_elt: `lxml.etree.Element`
         """
         try:
-            policy = transition_elt.findall(cls.XML_POLICY)[-1].text
+            policy = transition_elt.findall(
+                cls.STORAGE_POLICY_XML_TAG)[-1].text
             if policy is None:
                 raise ValueError("Missing value for '%s' element" %
-                                 cls.XML_POLICY)
+                                 cls.STORAGE_POLICY_XML_TAG)
         except IndexError:
             raise ValueError("Missing '%s' element in Transition action" %
-                             cls.XML_POLICY)
+                             cls.STORAGE_POLICY_XML_TAG)
 
         try:
             days_elt = transition_elt.findall('Days')[-1]
@@ -809,7 +810,7 @@ class Transition(LifecycleAction):
 
     def _to_element_tree(self, **kwargs):
         trans_elt = etree.Element('Transition')
-        policy_elt = etree.Element(self.XML_POLICY)
+        policy_elt = etree.Element(self.STORAGE_POLICY_XML_TAG)
         policy_elt.text = self.policy
         trans_elt.append(policy_elt)
         filter_elt = self.filter._to_element_tree(**kwargs)
@@ -893,14 +894,15 @@ class NoncurrentVersionTransition(Transition):
         :type transition_elt: `lxml.etree.Element`
         """
         try:
-            policy = transition_elt.findall(cls.XML_POLICY)[-1].text
+            policy = transition_elt.findall(
+                cls.STORAGE_POLICY_XML_TAG)[-1].text
             if policy is None:
                 raise ValueError("Missing value for '%s' element" %
-                                 cls.XML_POLICY)
+                                 cls.STORAGE_POLICY_XML_TAG)
         except IndexError:
             raise ValueError(
                 "Missing '%s' element in NoncurrentVersionTransition action" %
-                (cls.XML_POLICY))
+                (cls.STORAGE_POLICY_XML_TAG))
 
         try:
             days_elt = transition_elt.findall('NoncurrentDays')[-1]
@@ -917,7 +919,7 @@ class NoncurrentVersionTransition(Transition):
 
     def _to_element_tree(self, **kwargs):
         trans_elt = etree.Element('NoncurrentVersionTransition')
-        policy_elt = etree.Element(self.XML_POLICY)
+        policy_elt = etree.Element(self.STORAGE_POLICY_XML_TAG)
         policy_elt.text = self.policy
         trans_elt.append(policy_elt)
         filter_elt = self.filter._to_element_tree(**kwargs)

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -108,7 +108,7 @@ class ContainerLifecycle(object):
             if res:
                 for action in res:
                     yield obj_meta, rule.id, action[0], action[1]
-                    if action[1] == 'Deleted':
+                    if action[1] == 'Kept':
                         return
             else:
                 yield obj_meta, rule.id, "n/a", "Kept"
@@ -301,7 +301,7 @@ class LifecycleRule(object):
                 try:
                     res = action.apply(obj_meta, **kwargs)
                     results.append((action.__class__.__name__, res))
-                    if res == 'Deleted':
+                    if res != 'Kept':
                         break
                 except OioException as exc:
                     results.append((action.__class__.__name__, exc))

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -247,7 +247,7 @@ class LifecycleRule(object):
             if id_ is None:
                 raise ValueError("Missing value for 'ID' element")
         except IndexError:
-            id_ = "anonymous-rule-%s" % uuid.uuid4().hex
+            id_ = uuid.uuid4().hex
 
         try:
             filter_ = LifecycleRuleFilter.from_element(
@@ -363,10 +363,9 @@ class LifecycleRule(object):
     def _to_element_tree(self, **kwargs):
         rule_elt = etree.Element("Rule")
 
-        if not self.id.startswith('anonymous-rule-'):
-            id_elt = etree.Element("ID")
-            id_elt.text = self.id
-            rule_elt.append(id_elt)
+        id_elt = etree.Element("ID")
+        id_elt.text = self.id
+        rule_elt.append(id_elt)
 
         filter_elt = self.filter._to_element_tree(**kwargs)
         rule_elt.append(filter_elt)

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -535,7 +535,7 @@ class DateActionFilter(LifecycleActionFilter):
 
     def match(self, obj_meta, now=None, **kwargs):
         now = now or time.time()
-        return now > self.date
+        return now > self.date and float(obj_meta['ctime']) < self.date
 
 
 class CountActionFilter(LifecycleActionFilter):

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -90,7 +90,7 @@ class ContainerLifecycle(object):
         self.account = account
         self.container = container
         self.logger = logger or get_logger(None, name=str(self.__class__))
-        self._rules = dict()
+        self.rules = list()
         self.processed_versions = None
 
     def get_configuration(self):
@@ -126,12 +126,12 @@ class ContainerLifecycle(object):
                 tree.tag)
         for rule_elt in tree.findall('Rule'):
             rule = LifecycleRule.from_element(rule_elt, lifecycle=self)
-            self._rules[rule.id] = rule
+            self.rules.append(rule)
 
     def _to_element_tree(self, **kwargs):
         lifecycle_elt = etree.Element('LifecycleConfiguration')
 
-        for rule in self._rules.values():
+        for rule in self.rules:
             rule_elt = rule._to_element_tree(**kwargs)
             lifecycle_elt.append(rule_elt)
 
@@ -148,7 +148,7 @@ class ContainerLifecycle(object):
         configuration that has been loaded previously
         :type xml_str: `str`
         """
-        if not self._rules:
+        if not self.rules:
             raise ValueError('You must call `load_xml()`'
                              ' parameter before saving')
         self.api.container_set_properties(
@@ -165,7 +165,7 @@ class ContainerLifecycle(object):
 
         :notice: you must consume the results or the rules won't be applied.
         """
-        for rule in self._rules.values():
+        for rule in self.rules:
             res = rule.apply(obj_meta, **kwargs)
             if res:
                 for action in res:

--- a/tests/functional/cli/lifecycle/test_lifecycle.py
+++ b/tests/functional/cli/lifecycle/test_lifecycle.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+import time
 import uuid
 from tempfile import NamedTemporaryFile
 from tests.functional.cli import CliTestCase
@@ -31,12 +32,13 @@ class LifecycleCliTest(CliTestCase):
                     </Tag>
                 </Filter>
                 <Expiration>
-                    <Days>0</Days>
+                    <Date>%s</Date>
                 </Expiration>
                 <Status>enabled</Status>
             </Rule>
         </LifecycleConfiguration>
-        """
+        """ % time.strftime("%Y-%m-%dT%H:%M:%S",
+                            time.localtime(time.time()-86400))
 
     @classmethod
     def setUpClass(cls):
@@ -80,7 +82,7 @@ class LifecycleCliTest(CliTestCase):
         output = self.openio('lifecycle apply ' + self.NAME + opts)
         output = output.split('\n')
         self.assertIn('test1', output[0])
-        self.assertIn('n/a', output[0])  # Not matched by filter
+        self.assertIn('Kept', output[0])  # Not matched by filter
         self.assertIn('test2', output[1])
         self.assertIn('Deleted', output[1])
         self.openio('object delete %s test1' % self.NAME)

--- a/tests/functional/cli/lifecycle/test_lifecycle.py
+++ b/tests/functional/cli/lifecycle/test_lifecycle.py
@@ -24,6 +24,7 @@ class LifecycleCliTest(CliTestCase):
     CONF = """
         <LifecycleConfiguration>
             <Rule>
+                <ID>0123456789abcdef</ID>
                 <Filter>
                     <Prefix>documents/</Prefix>
                 </Filter>

--- a/tests/functional/container/test_lifecycle.py
+++ b/tests/functional/container/test_lifecycle.py
@@ -105,8 +105,8 @@ class TestContainerLifecycle(BaseTestCase):
         self.api.container_create(self.account, self.container,
                                   properties=props)
         self.lifecycle.load()
-        self.assertEqual(1, len(self.lifecycle._rules))
-        rule = self.lifecycle._rules.get('rule1')
+        self.assertEqual(1, len(self.lifecycle.rules))
+        rule = self.lifecycle.rules[0]
         self.assertIsNotNone(rule)
         self.assertEqual('rule1', rule.id)
         self.assertIsNotNone(rule.filter)

--- a/tests/functional/container/test_lifecycle.py
+++ b/tests/functional/container/test_lifecycle.py
@@ -976,7 +976,7 @@ class TestContainerLifecycle(BaseTestCase):
         self.lifecycle.load()
 
         results = [x for x in self.lifecycle.execute()]
-        self.assertEqual(6, len(results))
+        self.assertEqual(5, len(results))
         for res in results:
             self.assertEqual('Kept', res[3])
         self.api.object_show(self.account, self.container, obj_meta['name'])
@@ -984,7 +984,7 @@ class TestContainerLifecycle(BaseTestCase):
         self.api.object_show(self.account, self.container, obj_meta3['name'])
 
         results = [x for x in self.lifecycle.execute(now=time.time()+86400)]
-        self.assertEqual(5, len(results))
+        self.assertEqual(6, len(results))
         self.api.object_show(self.account, self.container, obj_meta['name'])
         self.assertRaises(NoSuchObject, self.api.object_show,
                           self.account, self.container, obj_meta2['name'])

--- a/tests/functional/container/test_lifecycle.py
+++ b/tests/functional/container/test_lifecycle.py
@@ -791,9 +791,10 @@ class TestContainerLifecycle(BaseTestCase):
         obj_meta_copy, _, _, status = results[0]
         self.assertEqual(obj_meta, obj_meta_copy)
         self.assertEqual('Kept', status)
-        self.assertRaises(NoSuchObject, self.api.object_show,
-                          self.account, self.container, obj_meta_v2['name'],
-                          version=obj_meta_v2['version'])
+        self.assertRaises(NoSuchObject, self.api.object_locate,
+                          self.account, self.container, obj_meta_v2['name'])
+        self.api.object_show(self.account, self.container, obj_meta_v2['name'],
+                             version=obj_meta_v2['version'])
         self.api.object_show(self.account, self.container, obj_meta['name'],
                              version=obj_meta['version'])
 
@@ -1066,10 +1067,28 @@ class TestContainerLifecycle(BaseTestCase):
 
         results = [x for x in self.lifecycle.execute(now=time.time()+86400)]
         self.assertEqual(6, len(results))
-        self.api.object_show(self.account, self.container, obj_meta['name'])
-        self.assertRaises(NoSuchObject, self.api.object_show,
+        self.api.object_locate(
+            self.account, self.container, obj_meta['name'])
+        self.api.object_show(
+            self.account, self.container, obj_meta['name'],
+            version=obj_meta['version'])
+        self.assertRaises(NoSuchObject, self.api.object_locate,
                           self.account, self.container, obj_meta2['name'])
-        self.assertRaises(NoSuchObject, self.api.object_show,
+        self.api.object_show(
+            self.account, self.container, obj_meta2['name'],
+            version=obj_meta2['version'])
+        self.assertRaises(NoSuchObject, self.api.object_locate,
                           self.account, self.container, obj_meta3['name'])
+        self.api.object_show(
+            self.account, self.container, obj_meta3['name'],
+            version=obj_meta3['version'])
 
-        self.api.object_delete(self.account, self.container, obj_meta['name'])
+        self.api.object_delete(
+            self.account, self.container, obj_meta['name'],
+            version=obj_meta['version'])
+        self.api.object_delete(
+            self.account, self.container, obj_meta2['name'],
+            version=obj_meta2['version'])
+        self.api.object_delete(
+            self.account, self.container, obj_meta3['name'],
+            version=obj_meta3['version'])

--- a/tests/unit/container/test_lifecycle.py
+++ b/tests/unit/container/test_lifecycle.py
@@ -1165,7 +1165,6 @@ class TestContainerLifecycle(unittest.TestCase):
         rule = LifecycleRule.from_element(rule_elt)
         self.assertIsNotNone(rule)
         self.assertIsNotNone(rule.id)
-        self.assertTrue(rule.id.startswith('anonymous-rule-'))
         self.assertIsNotNone(rule.filter)
         self.assertTrue(rule.enabled)
         self.assertEqual(6, len(rule.actions))
@@ -1353,13 +1352,13 @@ class TestContainerLifecycle(unittest.TestCase):
         self.assertEqual(EXPECTED, str(filter_))
 
     def test_LifecycleRule_to_string(self):
-        EXPECTED = '<Rule><Filter></Filter>' \
+        EXPECTED = '<Rule><ID>Test</ID><Filter></Filter>' \
             + '<Status>Disabled</Status>' \
             + '<Expiration><Days>10</Days></Expiration>' \
             + '</Rule>'
         filter_ = LifecycleRuleFilter(None, {})
         actions = [Expiration(DaysActionFilter(10))]
-        rule = LifecycleRule('anonymous-rule-01234', filter_, False, actions)
+        rule = LifecycleRule('Test', filter_, False, actions)
         self.assertEqual(EXPECTED, str(rule))
 
         EXPECTED = '<Rule><ID>Test</ID><Filter></Filter>' \


### PR DESCRIPTION
##### SUMMARY

- Prevent some configurations
  * `Date` and `Days` must not be mixed in the same Rule
  * `Date` in the Expiration action must be later than `Date` in the Transition action
  * `Days` in the Expiration action must be greater than `Days` in the Transition action
  * `NoncurrentDays` and `NoncurrentCount` must not be mixed  in the same Rule
  * `NoncurrentDays` in the NoncurrentVersionExpiration action must be greater than `NoncurrentDays` in the NoncurrentVersionTransition action
  * `NoncurrentCount` in the NoncurrentVersionExpiration action must be greater than `NoncurrentCount` in the NoncurrentVersionTransition action
- Allow multiple Transition and NoncurrentVersionTransition actions
- Apply Expiration and Transition actions only on the current version
- Format the Lifecycle configuration
- Add deleted flag when applying Expiration action with versioning
- Apply the rules in the same order as the configuration

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Lifecycle

##### SDS VERSION

```
openio 4.3.1.dev9
```