### PR TITLE
Fix concurrency on object list with flatns

### DIFF
--- a/etc/bootstrap-option-flatns.yml
+++ b/etc/bootstrap-option-flatns.yml
@@ -1,0 +1,2 @@
+config:
+    ns.flat_bits: 8

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -17,9 +17,13 @@ import os
 from logging import getLogger
 from cliff import command, lister, show
 from eventlet import GreenPool
+import eventlet
 from oio.common.http_urllib3 import get_pool_manager
 from oio.common.utils import depaginate
 from oio.common import exceptions
+
+
+eventlet.monkey_patch()
 
 
 class ContainerCommandMixin(object):


### PR DESCRIPTION
##### SUMMARY

Fixes issues with concurrency not used while listing objects with flatns enabled

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio

##### SDS VERSION
`4.2.3`

##### ADDITIONAL INFORMATION
While investigating issue with `openio -v object list --auto --debug`, all HTTP requests were serialized (GET,  reponse, ...)
Once issue fixed, HTTP requests are now interlaced.