### PR TITLE
Fix Python API concurrency

### DIFF
--- a/bin/oio-account-server
+++ b/bin/oio-account-server
@@ -16,10 +16,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import eventlet.hubs
+
+from oio.common.green import eventlet_hubs, get_hub
+
 from optparse import OptionParser
 from oio.common.configuration import parse_options, read_conf
-from oio.common.green import get_hub
 from oio.account.server import create_app
 from oio.common.wsgi import Application, ServiceLogger
 
@@ -27,7 +28,7 @@ from oio.common.wsgi import Application, ServiceLogger
 if __name__ == '__main__':
     parser = OptionParser("%prog CONFIG [options]")
     conf_file, options = parse_options(parser)
-    eventlet.hubs.use_hub(get_hub())
+    eventlet_hubs.use_hub(get_hub())
     conf = read_conf(conf_file, 'account-server')
     app = create_app(conf)
     Application(app, conf, logger_class=ServiceLogger).run()

--- a/bin/oio-event-agent
+++ b/bin/oio-event-agent
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import eventlet.hubs
+
+from oio.common.green import eventlet_hubs, get_hub
+
 from optparse import OptionParser
 from oio.common.configuration import parse_options
 from oio import __canonical_version__
-from oio.common.green import get_hub
 from oio.event.agent import Runner
 from oio.event.consumer import EventWorker
 
@@ -31,5 +32,5 @@ For a sample configuration file, see
 https://github.com/open-io/oio-sds/blob/%s/etc/event-agent.conf-sample"""
     parser = OptionParser(doc % __canonical_version__)
     config, options = parse_options(parser)
-    eventlet.hubs.use_hub(get_hub())
+    eventlet_hubs.use_hub(get_hub())
     Runner(config, EventWorker, **options).run()

--- a/etc/bootstrap-option-flatns.yml
+++ b/etc/bootstrap-option-flatns.yml
@@ -1,0 +1,2 @@
+config:
+    ns.flat_bits: 8

--- a/oio/api/backblaze.py
+++ b/oio/api/backblaze.py
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import eventlet
+
 import logging
 import hashlib
 from tempfile import TemporaryFile
@@ -20,7 +23,8 @@ from urlparse import urlparse
 from oio.api import io
 from oio.common.exceptions import SourceReadError, OioException
 from oio.api.backblaze_http import Backblaze, BackblazeException
-import eventlet
+
+
 logger = logging.getLogger(__name__)
 WORD_LENGTH = 10
 TRY_REQUEST_NUMBER = 3

--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -13,12 +13,13 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+from oio.common.green import Queue, Timeout, GreenPile
+
 import collections
 import math
 import hashlib
 import logging
 from urlparse import urlparse
-from eventlet import Queue, Timeout, GreenPile
 from socket import error as SocketError
 from greenlet import GreenletExit
 from oio.common import exceptions

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -13,12 +13,14 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
 from __future__ import absolute_import
+from oio.common.green import sleep, Timeout
+
 from io import BufferedReader, RawIOBase, IOBase
 import itertools
 import logging
 from urlparse import urlparse
-from eventlet import sleep, Timeout
 from socket import error as SocketError
 from oio.common import exceptions as exc
 from oio.common.http import parse_content_type,\

--- a/oio/api/replication.py
+++ b/oio/api/replication.py
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import Queue, Timeout, GreenPile
+
 import logging
 import hashlib
-from eventlet import Timeout, GreenPile
 from socket import error as SocketError
-from eventlet.queue import Queue
 from urlparse import urlparse
 from oio.common import exceptions as exc
 from oio.common.exceptions import SourceReadError

--- a/oio/blob/auditor.py
+++ b/oio/blob/auditor.py
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from oio.common.green import ratelimit
+
 from contextlib import closing
 from string import hexdigits
 import hashlib
@@ -26,7 +28,6 @@ from oio.common import exceptions as exc
 from oio.common.utils import paths_gen
 from oio.common.easy_value import int_value
 from oio.common.logger import get_logger
-from oio.common.green import ratelimit
 from oio.common.constants import STRLEN_CHUNKID
 
 

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -14,11 +14,12 @@
 # License along with this library.
 
 
+from oio.common.green import GreenPile
+
 import random
 from functools import wraps
 from urllib import unquote
 
-from eventlet import GreenPile
 from oio.common.http_urllib3 import get_pool_manager, \
     oio_exception_from_httperror, urllib3
 from oio.common import exceptions as exc, utils

--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from oio.common.green import ratelimit
+
 import time
 import os
 import tempfile
@@ -30,7 +32,6 @@ from oio.common.xattr import modify_xattr
 from oio.common.exceptions import ContentNotFound, OrphanChunk, \
     ConfigurationException
 from oio.common.logger import get_logger
-from oio.common.green import ratelimit
 from oio.common.easy_value import int_value, is_hexa, true_value
 from oio.container.client import ContainerClient
 from oio.content.factory import ContentFactory

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from oio.common.green import ratelimit
+
 import time
 from datetime import datetime
 from random import random
@@ -26,7 +28,6 @@ from oio.common import exceptions as exc
 from oio.common.utils import paths_gen, request_id
 from oio.common.easy_value import int_value, true_value
 from oio.common.logger import get_logger
-from oio.common.green import ratelimit
 from oio.common.exceptions import OioNetworkException, VolumeException
 from oio.common.constants import STRLEN_CHUNKID
 from oio.blob.converter import BlobConverter

--- a/oio/blob/mover.py
+++ b/oio/blob/mover.py
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+from oio.common.green import ratelimit
+
 from string import hexdigits
 import time
 
@@ -25,7 +28,6 @@ from oio.common import exceptions as exc
 from oio.common.utils import paths_gen, statfs, cid_from_name
 from oio.common.easy_value import int_value, true_value
 from oio.common.logger import get_logger
-from oio.common.green import ratelimit
 from oio.common.constants import STRLEN_CHUNKID
 from oio.common.fullpath import decode_fullpath
 from oio.content.factory import ContentFactory

--- a/oio/check_service/check_meta2.py
+++ b/oio/check_service/check_meta2.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-from eventlet import sleep
+
+from oio.common.green import sleep
+
 from oio.check_service.common import CheckService, random_buffer
 from oio.account.client import AccountClient
 from oio.container.client import ContainerClient

--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -13,9 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+from oio.common.green import Queue, GreenPile, sleep
+
 from logging import getLogger, INFO
 from cliff.command import Command
-from eventlet import Queue, GreenPile
 from oio.common.configuration import load_namespace_conf
 from oio.common.exceptions import ClientException
 from oio.common import green
@@ -289,7 +291,6 @@ class WarmupWorker(object):
                 return
             self.log.warn("%d %s", rep.status, prefix)
             if rep.status == 503:
-                from eventlet import sleep
                 sleep(i * 0.5)
             else:
                 break

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -13,10 +13,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+from oio.common.green import GreenPool
+
 import os
 from logging import getLogger
 from cliff import command, lister, show
-from eventlet import GreenPool
 from oio.common.http_urllib3 import get_pool_manager
 from oio.common.utils import depaginate
 from oio.common import exceptions

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -33,13 +33,11 @@ class ProxyClient(HttpApi):
 
     _slot_time = 0.5
 
-    def __init__(self, conf, pool_manager=None, request_prefix="",
+    def __init__(self, conf, request_prefix="",
                  no_ns_in_url=False, endpoint=None,
                  request_attempts=REQUEST_ATTEMPTS,
                  logger=None, **kwargs):
         """
-        :param pool_manager: an optional pool manager that will be reused
-        :type pool_manager: `urllib3.PoolManager`
         :param request_prefix: text to insert in between endpoint and
             requested URL
         :type request_prefix: `str`

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -13,12 +13,14 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import sleep
+
 from oio.common.logger import get_logger
 from oio.common.configuration import load_namespace_conf, validate_service_conf
 from oio.api.base import HttpApi
 from oio.common.exceptions import Conflict, OioException, ServiceBusy
 from random import randrange
-from eventlet import sleep
 
 
 REQUEST_ATTEMPTS = 1

--- a/oio/common/daemon.py
+++ b/oio/common/daemon.py
@@ -14,17 +14,17 @@
 # License along with this library.
 
 
+from oio.common.green import eventlet_hubs, get_hub
+
 import sys
 import signal
 
 import os
 from re import sub
 
-import eventlet.hubs
 from oio.common.utils import drop_privileges
 from oio.common.configuration import read_conf
 from oio.common.logger import redirect_stdio, get_logger
-from oio.common.green import get_hub
 
 
 class Daemon(object):
@@ -67,7 +67,7 @@ class Daemon(object):
 
 
 def run_daemon(klass, conf_file, section_name=None, **kwargs):
-    eventlet.hubs.use_hub(get_hub())
+    eventlet_hubs.use_hub(get_hub())
     if section_name is None:
         section_name = sub(r'([a-z])([A-Z])', r'\1-\2', klass.__name__).lower()
     conf = read_conf(

--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -14,13 +14,20 @@
 # License along with this library.
 
 
-import time
-import logging
 import eventlet
 
-import eventlet.semaphore
-from eventlet.green import threading
-from eventlet import Timeout
+import time
+import logging
+
+import eventlet.hubs as eventlet_hubs # noqa
+from eventlet import sleep, patcher, greenthread # noqa
+from eventlet import Queue, Timeout, GreenPile, GreenPool # noqa
+from eventlet.green import threading, socket # noqa
+from eventlet.green.httplib import HTTPConnection, HTTPResponse, _UNKNOWN # noqa
+from eventlet.event import Event # noqa
+from eventlet.queue import Empty, LifoQueue # noqa
+
+eventlet.monkey_patch(os=False)
 
 logging.thread = eventlet.green.thread
 logging.threading = threading

--- a/oio/common/http_eventlet.py
+++ b/oio/common/http_eventlet.py
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import socket, HTTPConnection, HTTPResponse, _UNKNOWN
+
 import logging
-import socket
 
 from urllib import quote
-from eventlet.green.httplib import HTTPConnection, HTTPResponse, _UNKNOWN
 
 
 class CustomHTTPResponse(HTTPResponse):

--- a/oio/common/http_urllib3.py
+++ b/oio/common/http_urllib3.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import patcher
+
 from urlparse import urlparse
-from eventlet import patcher
 from urllib3 import exceptions as urllibexc
 from oio.common.exceptions import reraise, \
     OioException, OioNetworkException, OioTimeout

--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -13,11 +13,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+from oio.common.green import GreenPool, sleep
+
 import re
 import os
-
 import pkg_resources
-from eventlet import GreenPool, sleep
 
 from oio.common.daemon import Daemon
 from oio.common.http_urllib3 import get_pool_manager

--- a/oio/conscience/checker/base.py
+++ b/oio/conscience/checker/base.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from eventlet import Timeout
+
+from oio.common.green import Timeout
+
 from oio.common.utils import RingBuffer
 from oio.common.easy_value import float_value
 

--- a/oio/conscience/checker/tcp.py
+++ b/oio/conscience/checker/tcp.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from eventlet.green import socket
+
+from oio.common.green import socket
+
 from oio.common import exceptions as exc
 from oio.conscience.checker.base import BaseChecker
 

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -17,15 +17,15 @@
 Recursively check account, container, content and chunk integrity.
 """
 
+
 from __future__ import print_function
+from oio.common.green import Event, GreenPool
+
 import os
 import csv
 import sys
 import cStringIO
 import argparse
-
-from eventlet.event import Event
-from eventlet.greenpool import GreenPool
 
 from oio.common import exceptions as exc
 from oio.common.storage_method import STORAGE_METHODS

--- a/oio/event/agent.py
+++ b/oio/event/agent.py
@@ -15,13 +15,14 @@
 
 
 from __future__ import print_function
+from oio.common.green import eventlet
+
 import sys
 import random
 import errno
 import signal
 import time
 import os
-import eventlet
 from oio.common.utils import CPU_COUNT, drop_privileges
 from oio.common.easy_value import int_value
 from oio.common.configuration import read_conf

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -14,11 +14,11 @@
 # License along with this library.
 
 
+from oio.common.green import socket, Empty, LifoQueue
+
 import os
 import sys
 import yaml
-from eventlet.green import socket
-from eventlet.queue import Empty, LifoQueue
 from urlparse import urlparse
 from cStringIO import StringIO as BytesIO
 

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -14,15 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from oio.common.green import eventlet, Timeout, greenthread
+
 import time
 import signal
 import os
 import sys
-
 import greenlet
-import eventlet
-from eventlet import Timeout, greenthread
-from oio.common.exceptions import OioNetworkException, ClientException
 
 from oio.conscience.client import ConscienceClient
 from oio.rdir.client import RdirClient
@@ -32,7 +30,8 @@ from oio.common.easy_value import int_value
 from oio.common.json import json
 from oio.event.evob import is_success, is_error
 from oio.event.loader import loadhandlers
-from oio.common.exceptions import ExplicitBury
+from oio.common.exceptions import ExplicitBury, OioNetworkException, \
+    ClientException
 
 
 SLEEP_TIME = 1
@@ -139,7 +138,6 @@ class EventWorker(Worker):
         self.app_env = dict()
 
     def init(self):
-        eventlet.monkey_patch(os=False)
         self.tube = self.conf.get("tube", DEFAULT_TUBE)
         self.cs = ConscienceClient(self.conf, logger=self.logger)
         self.rdir = RdirClient(self.conf, logger=self.logger)

--- a/oio/rebuilder/rebuilder.py
+++ b/oio/rebuilder/rebuilder.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from oio.common.green import ratelimit, eventlet, ContextPool
+
 import time
 
 from oio.common.easy_value import int_value
-from oio.common.green import ratelimit, eventlet, ContextPool
 from oio.common.logger import get_logger
 
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -12,7 +12,7 @@
 # License along with this library.
 
 
-from eventlet import Timeout, sleep
+from oio.common.green import Timeout, sleep
 
 from contextlib import contextmanager
 from oio.common.http import HeadersDict

--- a/tests/unit/api/__init__.py
+++ b/tests/unit/api/__init__.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import sleep
+
 from io import BytesIO
-from eventlet import sleep
 from oio.common.http import HeadersDict
 from oio.common.http_urllib3 import urllib3
 from oio.api.object_storage import ObjectStorageApi

--- a/tests/unit/api/test_ec.py
+++ b/tests/unit/api/test_ec.py
@@ -13,13 +13,15 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import Timeout
+
 import unittest
 import random
 from io import BytesIO
 from collections import defaultdict
 import hashlib
 from copy import deepcopy
-from eventlet import Timeout
 from mock import patch
 from oio.common.storage_method import STORAGE_METHODS
 from oio.api.ec import EcMetachunkWriter, ECChunkDownloadHandler, \

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -13,11 +13,13 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+
+from oio.common.green import Timeout
+
 import unittest
 from collections import defaultdict
 from io import BytesIO
 import hashlib
-from eventlet import Timeout
 from mock import patch
 
 from oio.common import exceptions as exc


### PR DESCRIPTION
##### SUMMARY

Apply `monkey_patch` every time we use `eventlet`.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.2.4.dev11
```

##### ADDITIONAL INFORMATION

See #1593 

Before:
```
$ time openio object list --auto -f value --full | wc -l
10001

real	0m49,446s
user	0m8,302s
sys	0m0,900s
$ time openio object list --auto -f value --full | wc -l
10001

real	0m53,206s
user	0m8,492s
sys	0m0,938s
$ time openio object list --auto -f value --full | wc -l
10001

real	0m53,347s
user	0m8,511s
sys	0m1,064s
```

After:
```
$ time openio object list --auto -f value --full | wc -l
10001

real	0m13,778s
user	0m8,987s
sys	0m0,613s
$ time openio object list --auto -f value --full | wc -l
10001

real	0m15,618s
user	0m9,876s
sys	0m0,766s
$ time openio object list --auto -f value --full | wc -l
10001

real	0m15,246s
user	0m10,517s
sys	0m1,002s
```