### PR TITLE
Don't link a deleted alias to a content

### DIFF
--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -1028,9 +1028,13 @@ m2db_delete_alias(struct sqlx_sqlite3_s *sq3, gint64 max_versions,
 	} else {
 		gint64 now = oio_ext_real_time () / G_TIME_SPAN_SECOND;
 		/* Create a new version marked as deleted */
-		struct bean_ALIASES_s *new_alias = _bean_dup(alias);
+		struct bean_ALIASES_s *new_alias = _bean_create(&descr_struct_ALIASES);
 		ALIASES_set_deleted(new_alias, TRUE);
+		ALIASES_set_alias(new_alias, ALIASES_get_alias(alias));
 		ALIASES_set_version(new_alias, 1 + ALIASES_get_version(alias));
+		GByteArray *content = g_byte_array_new_take((guint8 *) "DELETED", 7);
+		ALIASES_set_content(new_alias, content);
+		g_byte_array_free(content, FALSE);
 		ALIASES_set_ctime(new_alias, now);
 		ALIASES_set_mtime(new_alias, now);
 		err = _db_save_bean(sq3->db, new_alias);

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -793,14 +793,11 @@ class ObjectStorageApi(object):
             **kwargs)
 
         for obj in resp_body['objects']:
-            mtype = obj.get('mime-type')
-            if mtype is not None:
-                obj['mime_type'] = mtype
+            try:
+                obj['mime_type'] = obj['mime-type']
                 del obj['mime-type']
-            version = obj.get('ver')
-            if version is not None:
-                obj['version'] = version
-                del obj['ver']
+            except KeyError:
+                obj['mime_type'] = None
 
         resp_body['truncated'] = true_value(
             hdrs.get(HEADER_PREFIX + 'list-truncated'))

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -877,8 +877,9 @@ test_content_put_get_delete(void)
 				_bean_buffer_cb, tmp);
 		if (VERSIONS_ENABLED(maxver)) {
 			g_assert_no_error(err);
-			// nb_versions * (1 alias + 1 content header + chunks_count * (1 chunk))
-			expected = 2 * (2 + chunks_count);
+			// 1 alias + 1 content header + chunks_count * (1 chunk)
+			// + 1 deleted alias
+			expected = (1 + 1 + chunks_count) + (1);
 			GRID_DEBUG("TEST Got %u beans for all versions, expected %u"
 					" (chunks count: %"G_GINT64_FORMAT")",
 					tmp->len, expected, chunks_count);
@@ -1051,7 +1052,9 @@ test_content_append(void)
 		GRID_DEBUG("TEST Found %u beans (ALLVERSION)", tmp->len);
 		if (VERSIONS_ENABLED(maxver)) {
 			g_assert_no_error(err);
-			expected = 2*(1+1+(2*chunks_count));
+			// 1 alias + 1 content header + chunks_count * (2 chunks)
+			// + 1 deleted alias
+			expected = (1 + 1 + 2 * chunks_count) + (1);
 		} else {
 			g_assert_error(err, GQ(), CODE_CONTENT_NOTFOUND);
 			g_clear_error (&err);


### PR DESCRIPTION
##### SUMMARY

Don't link a deleted alias to a content.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `meta2`

##### SDS VERSION

```
openio 4.2.4.dev13
```

##### ADDITIONAL INFORMATION

If the deleted alias is linked to a content, when we delete the object permanently the chunks are not deleted. You must also delete the deleted alias.