### PR TITLE
Resolve CID on reference show and return account and container names

### DIFF
--- a/meta1v2/meta1_backend_services.c
+++ b/meta1v2/meta1_backend_services.c
@@ -1035,15 +1035,15 @@ __services_list_append_account_and_container(gchar ***interm_result,
 		goto end;
 	}
 
-	gchar *packed_acc = g_strdup_printf(SQLX_ADMIN_ACCOUNT ":%s", acc);
-	*interm_result = oio_strv_append(*interm_result, packed_acc);
-
 	const char *cont = oio_url_get(url, OIOURL_USER);
 	if (cont == NULL) {
 		err = NEWERROR(CODE_INTERNAL_ERROR, "[%s] Unable to add reference name"
 				" to services list.", __FUNCTION__);
 		goto end;
 	}
+
+	gchar *packed_acc = g_strdup_printf(SQLX_ADMIN_ACCOUNT ":%s", acc);
+	*interm_result = oio_strv_append(*interm_result, packed_acc);
 
 	gchar *packed_cont = g_strdup_printf(SQLX_ADMIN_USERNAME":%s", cont);
 	*interm_result = oio_strv_append(*interm_result, packed_cont);

--- a/meta1v2/meta1_remote.c
+++ b/meta1v2/meta1_remote.c
@@ -20,6 +20,8 @@ License along with this library.
 #include <metautils/lib/metautils.h>
 #include <metautils/lib/common_variables.h>
 
+#include <sqliterepo/sqlite_utils.h>
+
 #include "./internals.h"
 #include "./meta1_remote.h"
 
@@ -107,10 +109,49 @@ meta1v2_remote_list_reference_services(const char *to, struct oio_url_s *url,
 		const char *srvtype, gchar ***result, gint64 deadline)
 {
 	EXTRA_ASSERT(url != NULL);
+	GError *err = NULL;
 	MESSAGE req = metautils_message_create_named(NAME_MSGNAME_M1V2_SRVLIST, deadline);
 	metautils_message_add_url_no_type (req, url);
 	metautils_message_add_field_str (req, NAME_MSGKEY_TYPENAME, srvtype);
-	return STRV_request(to, message_marshall_gba_and_clean(req), result, deadline);
+
+	gchar **_tmp_result = NULL;
+	GPtrArray *srv_arry = g_ptr_array_new();
+
+	err = STRV_request(to, message_marshall_gba_and_clean(req), &_tmp_result,
+			deadline);
+
+	const char acc_prefix[] = SQLX_ADMIN_PREFIX_SYS "account:";
+	const int acc_prefix_len = (int)(sizeof(acc_prefix)/sizeof(*acc_prefix));
+	const char ref_prefix[] = SQLX_ADMIN_PREFIX_SYS "reference:";
+	const int ref_prefix_len = (int)(sizeof(ref_prefix)/sizeof(*ref_prefix));
+
+	// Fill oio_url_s from the response and returned the usual results
+	if(!err) {
+		gchar **srvc=_tmp_result;
+		while (*srvc != NULL) {
+			if (g_str_has_prefix(*srvc, acc_prefix)) {
+				if(oio_url_get(url, OIOURL_ACCOUNT) == NULL)
+					oio_url_set(url, OIOURL_ACCOUNT,
+							(*srvc)+acc_prefix_len-1);
+				gchar *old = *(srvc++);
+				g_free(old);
+			} else if (g_str_has_prefix(*srvc, ref_prefix)) {
+				if(oio_url_get(url, OIOURL_USER) == NULL)
+					oio_url_set(url, OIOURL_USER,
+							(*srvc)+ref_prefix_len-1);
+				gchar *old = *(srvc++);
+				g_free(old);
+			} else {
+				g_ptr_array_add(srv_arry, *srvc);
+				srvc++;
+			}
+		}
+
+		g_ptr_array_add(srv_arry, NULL);
+
+		*result = (gchar **) g_ptr_array_free(srv_arry, FALSE);
+	}
+	return err;
 }
 
 GError *

--- a/meta1v2/meta1_remote.c
+++ b/meta1v2/meta1_remote.c
@@ -121,7 +121,7 @@ meta1v2_remote_list_reference_services(const char *to, struct oio_url_s *url,
 
 	// Fill oio_url_s from the response and return the usual results
 	if (!err) {
-		GPtrArray *srv_arry = g_ptr_array_new();
+		GPtrArray *srv_array = g_ptr_array_new();
 		for (gchar **srvc = _tmp_result; *srvc; srvc++) {
 			if (g_str_has_prefix(*srvc, SQLX_ADMIN_ACCOUNT)) {
 				if (!oio_url_has(url, OIOURL_ACCOUNT)) {
@@ -136,14 +136,14 @@ meta1v2_remote_list_reference_services(const char *to, struct oio_url_s *url,
 				}
 				g_free(*srvc);
 			} else {
-				g_ptr_array_add(srv_arry, *srvc);
+				g_ptr_array_add(srv_array, *srvc);
 			}
 			*srvc = NULL;  // Either freed or sent to the other array
 		}
-		g_ptr_array_add(srv_arry, NULL);
+		g_ptr_array_add(srv_array, NULL);
 		g_free(_tmp_result);
 
-		*result = (gchar **) g_ptr_array_free(srv_arry, FALSE);
+		*result = (gchar **) g_ptr_array_free(srv_array, FALSE);
 	}
 	return err;
 }

--- a/proxy/dir_actions.c
+++ b/proxy/dir_actions.c
@@ -554,6 +554,14 @@ enum http_rc_e action_ref_show (struct req_args_s *args) {
 		oio_str_gstring_append_json_pair(out, "cid",
 				oio_url_get(args->url, OIOURL_HEXID));
 
+		g_string_append_c(out, ',');
+		oio_str_gstring_append_json_pair(out, "account",
+				oio_url_get(args->url, OIOURL_ACCOUNT));
+
+		g_string_append_c(out, ',');
+		oio_str_gstring_append_json_pair(out, "name",
+				oio_url_get(args->url, OIOURL_USER));
+
 		g_string_append_static (out, "}");
 		return _reply_success_json (args, out);
 	}

--- a/tests/functional/api/test_directory.py
+++ b/tests/functional/api/test_directory.py
@@ -17,6 +17,7 @@ import random
 import time
 from mock import MagicMock as Mock, ANY, call
 from oio.directory.client import DirectoryClient
+from oio.common.utils import cid_from_name
 from oio.common import exceptions as exc
 from oio.conscience.client import ConscienceClient
 from oio.rdir.client import RdirDispatcher, RdirClient, RDIR_ACCT, _make_id
@@ -60,10 +61,25 @@ class TestDirectoryAPI(BaseTestCase):
         res = self.api.list(self.account, name)
         self.assertIsNot(res['dir'], None)
         self.assertIsNot(res['srv'], None)
+        self.assertEqual(res['name'], name)
+        self.assertEqual(res['account'], self.account)
 
         self._delete(name)
         # get on deleted reference
         self.assertRaises(exc.NotFound, self.api.list, self.account, name)
+
+    def test_show_by_cid(self):
+        name = random_str(32)
+
+        self._create(name)
+
+        res = self.api.list(cid=cid_from_name(self.account, name))
+        self.assertIsNotNone(res['dir'])
+        self.assertIsNotNone(res['srv'])
+        self.assertEqual(res['name'], name)
+        self.assertEqual(res['account'], self.account)
+
+        self._delete(name)
 
     def test_create(self):
         name = random_str(32)
@@ -270,6 +286,8 @@ class TestDirectoryAPI(BaseTestCase):
         res = self.api.list(self.account, name, service_type=echo)
         self.assertIsNot(res['dir'], None)
         self.assertIsNot(res['srv'], None)
+        self.assertEqual(res['name'], name)
+        self.assertEqual(res['account'], self.account)
 
         self._delete(name)
         # get on deleted reference

--- a/tests/unit/test_meta1_backend.c
+++ b/tests/unit/test_meta1_backend.c
@@ -233,7 +233,10 @@ _count_services(struct meta1_backend_s *m1, struct oio_url_s *url, const char *s
 			oio_ext_monotonic_time() + 30 * G_TIME_SPAN_SECOND);
 	g_assert_no_error(err);
 	g_assert_nonnull(out);
-	guint count = g_strv_length(out);
+	// (ABO) The -2 is there because we started to include the ref account and
+	// name in the services list. Hence to keep compatibility with most of the
+	// tests, this seemed the most simple way.
+	guint count = g_strv_length(out)-2;
 	g_strfreev(out);
 	out = NULL;
 	return count;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The endpoint `/v3.0/reference/show` now returns the account and container names associated with the resolved reference, which would enable resolving the account / container associated with a certain CID.

The changes made are as follows:
- `oio-meta1-server`: The SRV_LIST reply now includes two additional prefixed strings that contain the container and account name.
- `meta1_remote`: The `meta1v2_remote_list_reference_services` functions intercepts the reply, extracts the account and container and fills the `oio_url_s` object accordingly, while returning the usual service list.
- `oio-proxy`: Returns two new fields `account` and `name` representing respectively the account name and the container name.

Before:
```
{
    "cid": "D7D9B4A795FBFE86481F432B50BB04E4F9F826D0296A35E30062115651CF5D41",
    "dir": [
       ...
    ],
    "srv": [
       ...
    ]
}
```

After:
```
{
    "cid": "D7D9B4A795FBFE86481F432B50BB04E4F9F826D0296A35E30062115651CF5D41",
    "account": "testacc",
     "dir": [
       ...
    ],
    "name": "testcontainer",
    "srv": [
        ...
    ]
}
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`oio-meta1-server`, `meta1remote`, `oio-proxy`

##### SDS VERSION
```
openio 4.3.0.0b2.dev4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
None
```
