### PR TITLE
oio-blob-rebuilder: Minor fixes

### DIFF
--- a/oio/rebuilder/blob_rebuilder.py
+++ b/oio/rebuilder/blob_rebuilder.py
@@ -255,6 +255,7 @@ class DistributedBlobRebuilder(BlobRebuilder):
                     senders[beanstalkd_addr].event_done()
                     self.update_processed(
                         chunk, bytes_processed, error=error, **kwargs)
+                self.log_report('RUN', **kwargs)
             except OioTimeout:
                 self.logger.error("No response since %d secondes",
                                   DISTRIBUTED_REBUILDER_TIMEOUT)


### PR DESCRIPTION
##### SUMMARY

- Log during distributed rebuilding.
- Accept the 'beanstalk://' prefix to the beanstalk URL.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `oio-blob-rebuilder`

##### SDS VERSION

```
openio 4.3.1.dev24
```