### PR TITLE
Cast boolean value to string representation before passing it on to redis

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -323,8 +323,8 @@ class AccountBackend(RedisConn):
                 ("containers:%s" % (account_id)),
                 ("account:%s" % (account_id))]
         args = [name, mtime, dtime, object_count, bytes_used,
-                autocreate_account, Timestamp(time()).normal, EXPIRE_TIME,
-                autocreate_container]
+                str(autocreate_account), Timestamp(time()).normal, EXPIRE_TIME,
+                str(autocreate_container)]
         try:
             self.script_update_container(keys=keys, args=args, client=conn)
         except redis.exceptions.ResponseError as exc:


### PR DESCRIPTION
##### SUMMARY
Version 3.0.0 or the redis python sdk breaks code that depends on it.
##### ISSUE TYPE
Version 3.0.0 introduces breaking changes, namely anything passed to a command must be an integer, a bytes or a string. 
Previously, the API coerced True and False values into 'True' and 'False', and None into 'None'.

More changes may be required : [breaking changes list](https://github.com/andymccurdy/redis-py#upgrading-from-redis-py-2x-to-30)
##### COMPONENT NAME
`sdk`, more specifically, `oio/account/backend.py:AccountBackend`
##### SDS VERSION
```
openio 4.3.1.dev47
```

##### ADDITIONAL INFORMATION
```
None
```
