### PR TITLE
CLI: allow to override autocontainer parameters

### DIFF
--- a/oio/cli/common/clientmanager.py
+++ b/oio/cli/common/clientmanager.py
@@ -27,6 +27,7 @@ class ClientManager(object):
         self._sds_conf = None
         self._namespace = None
         self._admin_mode = None
+        self._flatns_bits = None
         self._flatns_manager = None
         self._meta1_digits = None
         self._nsinfo = None
@@ -60,6 +61,9 @@ class ClientManager(object):
             self._admin_mode = self._options.get('admin_mode')
         return self._admin_mode
 
+    def flatns_set_bits(self, bits):
+        self._flatns_bits = bits
+
     @property
     def flatns_manager(self):
         if self._flatns_manager:
@@ -68,7 +72,7 @@ class ClientManager(object):
         options = self.nsinfo['options']
         bitlength, offset, size = None, 0, None
         try:
-            bitlength = int(options['flat_bitlength'])
+            bitlength = int(self._flatns_bits or options['flat_bitlength'])
         except Exception:
             from oio.common.exceptions import ConfigurationException
             raise ConfigurationException(

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -46,6 +46,11 @@ class ContainerCommandMixin(object):
             action="store_true",
         )
         parser.add_argument(
+            '--flat-bits',
+            type=int,
+            help="Number of bits for flat-NS computation",
+        )
+        parser.add_argument(
             '--cid',
             dest='is_cid',
             default=False,
@@ -62,6 +67,9 @@ class ContainerCommandMixin(object):
         if parsed_args.is_cid:
             parsed_args.cid = parsed_args.container
             parsed_args.container = None
+
+        if parsed_args.flat_bits:
+            self.app.client_manager.flatns_set_bits(parsed_args.flat_bits)
 
 
 class ObjectCommandMixin(ContainerCommandMixin):

--- a/tests/functional/cli/__init__.py
+++ b/tests/functional/cli/__init__.py
@@ -11,6 +11,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+import os
 import shlex
 import subprocess
 from tests.utils import BaseTestCase
@@ -33,7 +34,7 @@ class CommandFailed(Exception):
                                  self.stderr))
 
 
-def execute(cmd, stdin=None):
+def execute(cmd, stdin=None, env=None):
     """Executes command."""
     cmdlist = shlex.split(cmd)
     result = ''
@@ -41,7 +42,11 @@ def execute(cmd, stdin=None):
     stdout = subprocess.PIPE
     stderr = subprocess.PIPE
     in_ = subprocess.PIPE if stdin else None
-    proc = subprocess.Popen(cmdlist, stdin=in_, stdout=stdout, stderr=stderr)
+    _env = os.environ.copy()
+    if env:
+        _env.update(env)
+    proc = subprocess.Popen(cmdlist, stdin=in_, stdout=stdout, stderr=stderr,
+                            env=_env)
     result, result_err = proc.communicate(stdin)
     result = result.decode('utf-8')
     if proc.returncode != 0:
@@ -51,14 +56,14 @@ def execute(cmd, stdin=None):
 
 class CliTestCase(BaseTestCase):
     @classmethod
-    def openio(cls, cmd):
+    def openio(cls, cmd, env=None):
         """Executes openio CLI command."""
-        return execute('openio ' + cmd)
+        return execute('openio ' + cmd, env=env)
 
     @classmethod
-    def openio_batch(cls, commands):
+    def openio_batch(cls, commands, env=None):
         """Execute several commands in the same openio CLI process."""
-        return execute('openio', stdin='\n'.join(commands))
+        return execute('openio', stdin='\n'.join(commands), env=env)
 
     @classmethod
     def get_opts(cls, fields, format='value'):


### PR DESCRIPTION
##### SUMMARY

A namespace can now be used with several flatns configurations on separate account.
This commit allow CLI to interact with account that doesn't use default configuration.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
CLI

##### SDS VERSION
```
4.2.4dev15
```


##### ADDITIONAL INFORMATION
```
$ openio object create --auto --flat-bitlength 8 /etc/hosts
+-------+------+----------------------------------+--------+
| Name  | Size | Hash                             | Status |
+-------+------+----------------------------------+--------+
| hosts |  719 | 8408B8BFE97F012FB75067551367AACB | Ok     |
+-------+------+----------------------------------+--------+
$ openio object list --auto --flat-bitlength 8
+------------+------+----------------------------------+------------------+
| Name       | Size | Hash                             |          Version |
+------------+------+----------------------------------+------------------+
| hosts      |  719 | 8408B8BFE97F012FB75067551367AACB | 1542646758582101 |
+------------+------+----------------------------------+------------------+
$ openio container list
+------+-------+-------+
| Name | Bytes | Count |
+------+-------+-------+
| 4F   |   719 |     1 |
+------+-------+-------+
```
