### PR TITLE
Implement tests for account, reference, container and object properties

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -197,10 +197,18 @@ class ObjectStorageApi(object):
         return self.account.account_list(**kwargs)
 
     @handle_account_not_found
-    def account_update(self, account, metadata, to_delete=None, **kwargs):
-        warnings.warn("You'd better use account_set_properties()",
-                      DeprecationWarning, stacklevel=2)
-        self.account.account_update(account, metadata, to_delete, **kwargs)
+    @ensure_headers
+    @ensure_request_id
+    def account_get_properties(self, account, **kwargs):
+        """
+        Get information about an account, including account properties.
+        """
+        res = self.account.account_show(account, **kwargs)
+        # Deal with the previous protocol which
+        # returned 'metadata' instead of 'properties'.
+        props = res.pop('metadata', dict())
+        res.setdefault('properties', dict()).update(props)
+        return res
 
     @handle_account_not_found
     @ensure_headers

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -549,7 +549,7 @@ class ContainerClient(ProxyClient):
             # TODO(FVE): this special behavior can be removed when
             # the 'content/locate' protocol is changed to include
             # object properties in the response body instead of headers.
-            if properties and 'got more than 100 headers' in str(exc):
+            if properties and 'got more than ' in str(exc):
                 params['properties'] = False
                 _resp, chunks = self._direct_request(
                     'GET', uri, params=params, **kwargs)

--- a/tests/functional/api/test_objectstorage_properties.py
+++ b/tests/functional/api/test_objectstorage_properties.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import logging
+from oio import ObjectStorageApi
+from tests.utils import random_str, BaseTestCase
+
+
+class ObjectStoragePropertiesTest(BaseTestCase):
+    """
+    Test various scenarios with properties,
+    especially with many or big properties.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(ObjectStoragePropertiesTest, cls).setUpClass()
+        cls.logger = logging.getLogger('test')
+        cls.api = ObjectStorageApi(cls._cls_ns, cls.logger)
+        cls.obj_cname = "obj_props_" + random_str(8)
+
+    def _test_set_container_property_with_size(self, size):
+        cname = random_str(16)
+        res = self.api.container_create(self.account, cname)
+        self.assertEqual(res, True)
+
+        properties = {str(size): random_str(size)}
+        self.api.container_set_properties(self.account, cname, properties)
+        data = self.api.container_get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], properties)
+        self.api.container_del_properties(
+            self.account, cname, properties.keys())
+        data = self.api.container_get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.container_delete(self.account, cname)
+
+    def test_container_set_properties_65535(self):
+        self._test_set_container_property_with_size(65535)
+
+    def test_container_set_properties_65536(self):
+        self._test_set_container_property_with_size(65536)
+
+    def test_container_set_properties_1Mi(self):
+        self._test_set_container_property_with_size(1024*1024)
+
+    def _test_set_container_property_with_key_size(self, size):
+        cname = random_str(16)
+        res = self.api.container_create(self.account, cname)
+        self.assertEqual(res, True)
+
+        properties = {random_str(size): str(size)}
+        self.api.container_set_properties(self.account, cname, properties)
+        data = self.api.container_get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], properties)
+        self.api.container_del_properties(
+            self.account, cname, properties.keys())
+        data = self.api.container_get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.container_delete(self.account, cname)
+
+    def test_container_set_properties_key_65535(self):
+        self._test_set_container_property_with_key_size(65535)
+
+    def test_container_set_properties_key_65536(self):
+        self._test_set_container_property_with_key_size(65536)
+
+    def test_container_set_properties_key_1Mi(self):
+        self._test_set_container_property_with_key_size(1024*1024)
+
+    def _test_set_object_property_with_size(self, size):
+        oname = random_str(16)
+        self.api.container_create(self.account, self.obj_cname)
+        self.api.object_create(self.account, self.obj_cname,
+                               obj_name=oname, data=oname)
+
+        # Set a property with the specified size
+        properties = {str(size): random_str(size)}
+        self.api.object_set_properties(
+            self.account, self.obj_cname, oname, properties)
+        # Read all properties and compare them
+        data = self.api.object_get_properties(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], properties)
+        # Read all properties with another method, more prone to failures
+        data, _chunks = self.api.object_locate(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], properties)
+        # Delete all known properties
+        self.api.object_del_properties(
+            self.account, self.obj_cname, oname, properties.keys())
+        # Ensure all properties have been deleted
+        data = self.api.object_get_properties(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], {})
+
+        self.api.object_delete(self.account, self.obj_cname, oname)
+
+    def test_object_set_properties_65535(self):
+        self._test_set_object_property_with_size(65535)
+
+    def test_object_set_properties_65536(self):
+        self._test_set_object_property_with_size(65536)
+
+    def test_object_set_properties_1Mi(self):
+        self._test_set_object_property_with_size(1024*1024)
+
+    def _test_set_object_property_with_key_size(self, size):
+        oname = random_str(16)
+        self.api.container_create(self.account, self.obj_cname)
+        self.api.object_create(self.account, self.obj_cname,
+                               obj_name=oname, data=oname)
+
+        # Set a property with the specified size
+        properties = {random_str(size): str(size)}
+        self.api.object_set_properties(
+            self.account, self.obj_cname, oname, properties)
+        # Read all properties and compare them
+        data = self.api.object_get_properties(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], properties)
+        # Read all properties with another method, more prone to failures
+        data, _chunks = self.api.object_locate(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], properties)
+        # Delete all known properties
+        self.api.object_del_properties(
+            self.account, self.obj_cname, oname, properties.keys())
+        # Ensure all properties have been deleted
+        data = self.api.object_get_properties(
+            self.account, self.obj_cname, oname)
+        self.assertDictEqual(data['properties'], {})
+
+        self.api.object_delete(self.account, self.obj_cname, oname)
+
+    def test_object_set_properties_key_65535(self):
+        self._test_set_object_property_with_size(65535)
+
+    def test_object_set_properties_key_65536(self):
+        self._test_set_object_property_with_size(65536)
+
+    def test_object_set_properties_key_1Mi(self):
+        self._test_set_object_property_with_size(1024*1024)

--- a/tests/functional/api/test_objectstorage_properties.py
+++ b/tests/functional/api/test_objectstorage_properties.py
@@ -34,14 +34,140 @@ class ObjectStoragePropertiesTest(BaseTestCase):
         cls.api = ObjectStorageApi(cls._cls_ns, cls.logger)
         cls.obj_cname = "obj_props_" + random_str(8)
 
+    def _sized_prop(self, ksize=None, vsize=None):
+        if ksize:
+            pkey = random_str(ksize)
+        else:
+            pkey = "key"
+        if vsize:
+            pval = random_str(vsize)
+        else:
+            pval = "value"
+        return pkey, pval
+
+    def _many_props(self, count=PROPERTIES_COUNT):
+        return {'long_enough_property_key_%04d' % i:
+                'long_enough_property_value_%d' % i
+                for i in range(count)}
+
+    # --- Account properties ------------------------------------------
+
+    def _test_set_account_property_with_size(self, ksize=None, vsize=None):
+        aname = 'test_account_' + random_str(8)
+        res = self.api.account_create(aname)
+        self.assertEqual(res, True)
+
+        properties = dict((self._sized_prop(ksize, vsize), ))
+        self.api.account_set_properties(aname, properties)
+        data = self.api.account_get_properties(aname)
+        self.assertDictEqual(data['properties'], properties)
+        self.api.account_del_properties(aname, properties.keys())
+        data = self.api.account_get_properties(aname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.account_delete(aname)
+
+    def test_account_set_properties_65535(self):
+        self._test_set_account_property_with_size(vsize=65535)
+
+    def test_account_set_properties_65536(self):
+        self._test_set_account_property_with_size(vsize=65536)
+
+    def test_account_set_properties_1Mi(self):
+        self._test_set_account_property_with_size(vsize=1024*1024)
+
+    def test_account_set_properties_key_65535(self):
+        self._test_set_account_property_with_size(ksize=65535)
+
+    def test_account_set_properties_key_65536(self):
+        self._test_set_account_property_with_size(ksize=65536)
+
+    def test_account_set_properties_key_1Mi(self):
+        self._test_set_account_property_with_size(ksize=1024*1024)
+
+    def test_account_set_many_properties(self):
+        aname = 'test_account_many_properties_' + random_str(8)
+        properties = self._many_props()
+        res = self.api.account_create(aname)
+        self.assertEqual(res, True)
+
+        self.api.account_set_properties(aname, properties)
+        data = self.api.account_get_properties(aname)
+        self.assertDictEqual(data['properties'], properties)
+
+        self.api.account_del_properties(aname, properties.keys())
+        data = self.api.account_get_properties(aname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.account_delete(aname)
+
+    # --- Reference properties ----------------------------------------
+
+    def _test_set_reference_property_with_size(self, ksize=None, vsize=None):
+        cname = 'test_ref_' + random_str(8)
+        res = self.api.directory.create(self.account, cname)
+        self.assertEqual(res, True)
+
+        properties = dict((self._sized_prop(ksize, vsize), ))
+        # Not accessible directly, must use low-level directory client.
+        self.api.directory.set_properties(self.account, cname, properties)
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], properties)
+        self.api.directory.del_properties(
+            self.account, cname, properties.keys())
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.directory.delete(self.account, cname)
+
+    def test_reference_set_properties_65535(self):
+        self._test_set_reference_property_with_size(vsize=65535)
+
+    def test_reference_set_properties_65536(self):
+        self._test_set_reference_property_with_size(vsize=65536)
+
+    def test_reference_set_properties_1Mi(self):
+        self._test_set_reference_property_with_size(vsize=1024*1024)
+
+    def test_reference_set_properties_key_65535(self):
+        self._test_set_reference_property_with_size(ksize=65535)
+
+    def test_reference_set_properties_key_65536(self):
+        self._test_set_reference_property_with_size(ksize=65536)
+
+    def test_reference_set_properties_key_1Mi(self):
+        self._test_set_reference_property_with_size(ksize=1024*1024)
+
+    def test_reference_set_many_properties(self):
+        cname = 'test_ref_many_properties_' + random_str(8)
+        properties = self._many_props()
+        res = self.api.directory.create(self.account, cname,
+                                        properties=properties)
+        self.assertEqual(res, True)
+
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], properties)
+
+        self.api.directory.del_properties(
+            self.account, cname, properties.keys())
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], {})
+
+        self.api.directory.set_properties(self.account, cname, properties)
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], properties)
+
+        self.api.directory.del_properties(
+            self.account, cname, properties.keys())
+        data = self.api.directory.get_properties(self.account, cname)
+        self.assertDictEqual(data['properties'], {})
+        self.api.directory.delete(self.account, cname)
+
     # --- Container properties ----------------------------------------
 
-    def _test_set_container_property_with_size(self, size):
-        cname = random_str(16)
+    def _test_set_container_property_with_size(self, ksize=None, vsize=None):
+        cname = 'test_container_' + random_str(8)
         res = self.api.container_create(self.account, cname)
         self.assertEqual(res, True)
 
-        properties = {str(size): random_str(size)}
+        properties = dict((self._sized_prop(ksize, vsize), ))
         self.api.container_set_properties(self.account, cname, properties)
         data = self.api.container_get_properties(self.account, cname)
         self.assertDictEqual(data['properties'], properties)
@@ -52,43 +178,26 @@ class ObjectStoragePropertiesTest(BaseTestCase):
         self.api.container_delete(self.account, cname)
 
     def test_container_set_properties_65535(self):
-        self._test_set_container_property_with_size(65535)
+        self._test_set_container_property_with_size(vsize=65535)
 
     def test_container_set_properties_65536(self):
-        self._test_set_container_property_with_size(65536)
+        self._test_set_container_property_with_size(vsize=65536)
 
     def test_container_set_properties_1Mi(self):
-        self._test_set_container_property_with_size(1024*1024)
-
-    def _test_set_container_property_with_key_size(self, size):
-        cname = random_str(16)
-        res = self.api.container_create(self.account, cname)
-        self.assertEqual(res, True)
-
-        properties = {random_str(size): str(size)}
-        self.api.container_set_properties(self.account, cname, properties)
-        data = self.api.container_get_properties(self.account, cname)
-        self.assertDictEqual(data['properties'], properties)
-        self.api.container_del_properties(
-            self.account, cname, properties.keys())
-        data = self.api.container_get_properties(self.account, cname)
-        self.assertDictEqual(data['properties'], {})
-        self.api.container_delete(self.account, cname)
+        self._test_set_container_property_with_size(vsize=1024*1024)
 
     def test_container_set_properties_key_65535(self):
-        self._test_set_container_property_with_key_size(65535)
+        self._test_set_container_property_with_size(ksize=65535)
 
     def test_container_set_properties_key_65536(self):
-        self._test_set_container_property_with_key_size(65536)
+        self._test_set_container_property_with_size(ksize=65536)
 
     def test_container_set_properties_key_1Mi(self):
-        self._test_set_container_property_with_key_size(1024*1024)
+        self._test_set_container_property_with_size(ksize=1024*1024)
 
     def test_container_set_many_properties(self):
-        cname = "many_properties" + random_str(8)
-        properties = {'long_enough_property_key_%04d' % i:
-                      'long_enough_property_value_%d' % i
-                      for i in range(PROPERTIES_COUNT)}
+        cname = 'test_container_many_properties_' + random_str(8)
+        properties = self._many_props()
         res = self.api.container_create(self.account, cname,
                                         properties=properties)
         self.assertEqual(res, True)
@@ -113,14 +222,14 @@ class ObjectStoragePropertiesTest(BaseTestCase):
 
     # --- Object properties -------------------------------------------
 
-    def _test_set_object_property_with_size(self, size):
+    def _test_set_object_property_with_size(self, ksize=None, vsize=None):
         oname = random_str(16)
         self.api.container_create(self.account, self.obj_cname)
         self.api.object_create(self.account, self.obj_cname,
                                obj_name=oname, data=oname)
 
         # Set a property with the specified size
-        properties = {str(size): random_str(size)}
+        properties = dict((self._sized_prop(ksize, vsize), ))
         self.api.object_set_properties(
             self.account, self.obj_cname, oname, properties)
         # Read all properties and compare them
@@ -142,56 +251,26 @@ class ObjectStoragePropertiesTest(BaseTestCase):
         self.api.object_delete(self.account, self.obj_cname, oname)
 
     def test_object_set_properties_65535(self):
-        self._test_set_object_property_with_size(65535)
+        self._test_set_object_property_with_size(vsize=65535)
 
     def test_object_set_properties_65536(self):
-        self._test_set_object_property_with_size(65536)
+        self._test_set_object_property_with_size(vsize=65536)
 
     def test_object_set_properties_1Mi(self):
-        self._test_set_object_property_with_size(1024*1024)
-
-    def _test_set_object_property_with_key_size(self, size):
-        oname = random_str(16)
-        self.api.container_create(self.account, self.obj_cname)
-        self.api.object_create(self.account, self.obj_cname,
-                               obj_name=oname, data=oname)
-
-        # Set a property with the specified size
-        properties = {random_str(size): str(size)}
-        self.api.object_set_properties(
-            self.account, self.obj_cname, oname, properties)
-        # Read all properties and compare them
-        data = self.api.object_get_properties(
-            self.account, self.obj_cname, oname)
-        self.assertDictEqual(data['properties'], properties)
-        # Read all properties with another method, more prone to failures
-        data, _chunks = self.api.object_locate(
-            self.account, self.obj_cname, oname)
-        self.assertDictEqual(data['properties'], properties)
-        # Delete all known properties
-        self.api.object_del_properties(
-            self.account, self.obj_cname, oname, properties.keys())
-        # Ensure all properties have been deleted
-        data = self.api.object_get_properties(
-            self.account, self.obj_cname, oname)
-        self.assertDictEqual(data['properties'], {})
-
-        self.api.object_delete(self.account, self.obj_cname, oname)
+        self._test_set_object_property_with_size(vsize=1024*1024)
 
     def test_object_set_properties_key_65535(self):
-        self._test_set_object_property_with_size(65535)
+        self._test_set_object_property_with_size(ksize=65535)
 
     def test_object_set_properties_key_65536(self):
-        self._test_set_object_property_with_size(65536)
+        self._test_set_object_property_with_size(ksize=65536)
 
     def test_object_set_properties_key_1Mi(self):
-        self._test_set_object_property_with_size(1024*1024)
+        self._test_set_object_property_with_size(ksize=1024*1024)
 
     def test_object_set_many_properties(self):
         oname = "many_properties" + random_str(8)
-        properties = {'long_enough_property_key_%04d' % i:
-                      'long_enough_property_value_%d' % i
-                      for i in range(PROPERTIES_COUNT)}
+        properties = self._many_props()
         self.api.object_create(self.account, self.obj_cname,
                                obj_name=oname, data=oname,
                                properties=properties)


### PR DESCRIPTION
##### SUMMARY
To be able to answer questions about the size of properties one can set on the different items, implement the following tests:
- [x] ensure we can store at least 1MiB bytes in a single account property.
- [x] ensure we can store at least 1MiB bytes in a single reference property.
- [x] ensure we can store at least 1MiB in a single container property.
- [x] ensure we can store at least 1MiB in a single object property.
- [x] ensure we can store at least 1000 account properties.
- [x] ensure we can store at least 1000 reference properties.
- [x] ensure we can store at least 1000 container properties.
- [x] ensure we can store at least 1000 object properties.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.3.1.dev51
```