### PR TITLE
Remove index entry when moving a meta2 database with oio-meta2-mover

### DIFF
--- a/bin/oio-meta2-mover
+++ b/bin/oio-meta2-mover
@@ -54,7 +54,8 @@ if __name__ == '__main__':
         mapping = Meta1RefMapping(args.namespace)
         moved = mapping.move(args.src_service, args.dest_service, args.base,
                              'meta2')
-        moved_ok = mapping.apply(moved)
+        kwargs = {'src_service': args.src_service}
+        moved_ok = mapping.apply(moved, **kwargs)
     except Exception as exc:
         print("ERROR: " + str(exc))
     if not moved_ok:

--- a/oio/directory/meta.py
+++ b/oio/directory/meta.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from oio.directory.admin import AdminClient
+from oio.rdir.client import RdirClient
 from oio.conscience.client import ConscienceClient
 from oio.common.exceptions import OioException, ServiceBusy
 from oio.common.logger import get_logger
@@ -24,10 +25,11 @@ class MetaMapping(object):
 
     def __init__(self, conf, service_types,
                  admin_client=None, conscience_client=None, logger=None,
-                 **kwargs):
+                 rdir_client=None, **kwargs):
         self.conf = conf
         self._admin = admin_client
         self._conscience = conscience_client
+        self._rdir = rdir_client
         self.logger = logger or get_logger(self.conf)
         self.raw_services_by_base = dict()
         self.services_by_base = dict()
@@ -47,6 +49,12 @@ class MetaMapping(object):
         if not self._conscience:
             self._conscience = ConscienceClient(self.conf)
         return self._conscience
+
+    @property
+    def rdir(self):
+        if not self._rdir:
+            self._rdir = RdirClient(self.conf)
+        return self._rdir
 
     def reset(self):
         """

--- a/oio/directory/meta1.py
+++ b/oio/directory/meta1.py
@@ -53,6 +53,19 @@ class Meta1RefMapping(MetaMapping):
                     service_type=service_type, cid=cid,  replace=True,
                     services=dict(host=','.join(peers), type=service_type,
                                   args=args, seq=seq))
+                """
+                FIXME(ABO): This part can be removed when, either:
+                - meta1 sends the removed services bundled with the
+                  account.services events.
+                - meta2 sends a storage.container.deleted event when the
+                  sqliterepo layer is the one that notifies the deletion of
+                  the databases.
+                """
+                if service_type == 'meta2' and kwargs.get('src_service'):
+                    self.rdir.meta2_index_delete(
+                        volume_id=kwargs.get('src_service'),
+                        container_id=cid
+                    )
             except OioException as exc:
                 self.logger.warn(
                     "Failed to link services for base %s (seq=%d): %s",

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -485,8 +485,8 @@ class RdirClient(HttpApi):
             resp['name']
         )
 
-    def meta2_index_delete(self, volume_id, container_id=None, container_path=None,
-                           **kwargs):
+    def meta2_index_delete(self, volume_id, container_path=None,
+                           container_id=None, **kwargs):
         """
         Remove a meta2 record from the volume's index. Either the container ID
         or the container path have to be given.
@@ -500,7 +500,7 @@ class RdirClient(HttpApi):
         elif container_path and not container_id:
             _tmp = container_path.rsplit("/")
             container_id = cid_from_name(_tmp[1], _tmp[3])
-        else:
+        elif not container_path and not container_id:
             raise ValueError("At least the container ID or the container path "
                              "should be given.")
 


### PR DESCRIPTION
##### SUMMARY
When moving a meta2 database using the oio-meta2-mover, we have to remove the database from the previous meta2 peer's index.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`oio-meta2-mover`

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.3.1.dev54
```


##### ADDITIONAL INFORMATION
```
Nil.
```
