### PR TITLE
Strengthen 'directory decommission' operations

### DIFF
--- a/oio/cli/common/clientmanager.py
+++ b/oio/cli/common/clientmanager.py
@@ -91,7 +91,8 @@ class ClientManager(object):
     @property
     def meta1_digits(self):
         if not self._meta1_digits:
-            m1d = self.sds_conf.get("meta1_digits", None)
+            m1d = (self.sds_conf.get("ns.meta1_digits") or
+                   self.sds_conf.get("meta1_digits"))
             if m1d:
                 self._meta1_digits = int(m1d)
         return self._meta1_digits

--- a/oio/directory/admin.py
+++ b/oio/directory/admin.py
@@ -172,7 +172,7 @@ class AdminClient(ProxyClient):
         """
         Force the new peer set in the replicas of the old peer set.
         """
-        data = {'system': {'sys.peers': ','.join(peers)}}
+        data = {'system': {'sys.peers': ','.join(sorted(peers))}}
         self._request('POST', "/set_properties",
                       params=params, json=data, **kwargs)
 

--- a/oio/directory/meta.py
+++ b/oio/directory/meta.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import defaultdict
+
 from oio.directory.admin import AdminClient
 from oio.conscience.client import ConscienceClient
 from oio.common.exceptions import OioException, ServiceBusy
@@ -29,7 +31,7 @@ class MetaMapping(object):
         self._admin = admin_client
         self._conscience = conscience_client
         self.logger = logger or get_logger(self.conf)
-        self.raw_services_by_base = dict()
+        self.raw_services_by_base = defaultdict(list)
         self.services_by_base = dict()
         self.services_by_service_type = dict()
         for svc_type in service_types:

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -726,7 +726,7 @@ conscience=${CS_ALL_PUB}
 ecd=${IP}:${PORT_ECD}
 ${NOBS}event-agent=${BEANSTALKD_CNXSTRING}
 
-meta1_digits=${M1_DIGITS}
+ns.meta1_digits=${M1_DIGITS}
 
 admin=${IP}:${PORT_ADMIN}
 


### PR DESCRIPTION
##### SUMMARY
Fix loading of `meta1_digits` parameter and strengthen the `MetaMapping` code. Try to prevent dubious cases seen when running "directory decommission" operations, when the "old" peer set did not contain any of the previous peers, and thus the "new" peer set was empty.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API
- CLI

##### SDS VERSION
```
openio 4.2.5.dev7
```