### PR TITLE
Allow to change the policy of an object

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -987,6 +987,44 @@ meta2_backend_put_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 	return err;
 }
 
+GError*
+meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
+		struct oio_url_s *url, GSList *in,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		m2_onbean_cb cb_added, gpointer u0_added)
+{
+	GError *err = NULL;
+	struct sqlx_sqlite3_s *sq3 = NULL;
+	struct sqlx_repctx_s *repctx = NULL;
+
+	EXTRA_ASSERT(m2b != NULL);
+	EXTRA_ASSERT(url != NULL);
+	if (!in)
+		return NEWERROR(CODE_BAD_REQUEST, "No bean");
+
+	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
+	if (!err) {
+		struct m2db_put_args_s args;
+		memset(&args, 0, sizeof(args));
+		args.sq3 = sq3;
+		args.url = url;
+		args.ns_max_versions = meta2_max_versions;
+		args.worm_mode = oio_ns_mode_worm && !oio_ext_is_admin();
+
+		if (!(err = _transaction_begin(sq3, url, &repctx))) {
+			if (!(err = m2db_change_alias_policy(
+					&args, in, cb_deleted, u0_deleted, cb_added, u0_added)))
+				m2db_increment_version(sq3);
+			err = sqlx_transaction_end(repctx, err);
+			if (!err)
+				m2b_add_modified_container(m2b, sq3);
+		}
+		m2b_close(sq3);
+	}
+
+	return err;
+}
+
 GError *
 meta2_backend_update_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
 		GSList *in, m2_onbean_cb cb_deleted, gpointer u0_deleted,

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -129,6 +129,11 @@ GError* meta2_backend_put_alias(struct meta2_backend_s *m2b,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 
+GError* meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
+		struct oio_url_s *url, GSList *in,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		m2_onbean_cb cb_added, gpointer u0_added);
+
 GError* meta2_backend_append_to_alias(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, GSList *beans,
 		m2_onbean_cb cb, gpointer u0);

--- a/meta2v2/meta2_filters_action_content.c
+++ b/meta2v2/meta2_filters_action_content.c
@@ -260,19 +260,25 @@ meta2_filter_action_put_content(struct gridd_filter_ctx_s *ctx,
 
 	GSList *added = NULL, *deleted = NULL;
 
-	GRID_DEBUG("Putting %d beans in [%s]%s%s", g_slist_length(beans),
+	GRID_DEBUG("Putting %d beans in [%s]%s%s%s", g_slist_length(beans),
 			oio_url_get(url, OIOURL_WHOLE),
 			meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_OVERWRITE)?
 			" (overwrite)":"",
 			meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_UPDATE)?
-			" (update)":"");
+			" (update)":"",
+			meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_CHANGE_POLICY)?
+			" (policy change)":"");
 
-	if (NULL != meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_OVERWRITE)) {
+	if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_OVERWRITE)) {
 		e = meta2_backend_force_alias(m2b, url, beans, _bean_list_cb, &deleted,
 				_bean_list_cb, &added);
 	} else if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_UPDATE)) {
 		reply->subject("(update)");
 		e = meta2_backend_update_content(m2b, url, beans,
+				_bean_list_cb, &deleted, _bean_list_cb, &added);
+	} else if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_CHANGE_POLICY)) {
+		reply->subject("(policy change)");
+		e = meta2_backend_change_alias_policy(m2b, url, beans,
 				_bean_list_cb, &deleted, _bean_list_cb, &added);
 	} else {
 		e = meta2_backend_put_alias(m2b, url, beans, _bean_list_cb, &deleted,

--- a/meta2v2/meta2_filters_extract.c
+++ b/meta2v2/meta2_filters_extract.c
@@ -249,6 +249,7 @@ meta2_filter_extract_header_optional_overwrite(struct gridd_filter_ctx_s *ctx,
 	TRACE_FILTER();
 	EXTRACT_OPT(NAME_MSGKEY_OVERWRITE);
 	EXTRACT_OPT(NAME_MSGKEY_UPDATE);
+	EXTRACT_OPT(NAME_MSGKEY_CHANGE_POLICY);
 	return FILTER_OK;
 }
 

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -202,6 +202,11 @@ GError* m2db_put_alias(struct m2db_put_args_s *args, GSList *beans,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 
+GError* m2db_change_alias_policy(struct m2db_put_args_s *args,
+		GSList *new_beans,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		m2_onbean_cb cb_added, gpointer u0_added);
+
 GError* m2db_force_alias(struct m2db_put_args_s *args, GSList *in,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -51,6 +51,7 @@ License along with this library.
 #define NAME_MSGKEY_AUTOCREATE         "AUTOCREATE"
 #define NAME_MSGKEY_BASENAME           "BNAME"
 #define NAME_MSGKEY_BASETYPE           "BTYPE"
+#define NAME_MSGKEY_CHANGE_POLICY      "CHANGE_POLICY"
 #define NAME_MSGKEY_CHUNKED            "CHUNKED"
 #define NAME_MSGKEY_CONTAINERID        "CID"
 #define NAME_MSGKEY_CONTENTLENGTH      "CL"

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -662,12 +662,26 @@ class ObjectStorageApi(object):
     @handle_object_not_found
     @ensure_headers
     @ensure_request_id
-    def object_change_policy(self, account, container, obj, version, policy,
-                             **kwargs):
-        _, stream = self.object_fetch(
-            account, container, obj, version=version, **kwargs)
+    def object_change_policy(self, account, container, obj, policy, **kwargs):
+        """
+        Change the storage policy of an object
+
+        :param account: name of the account where to change
+            the policy of the object
+        :type account: `str`
+        :param container: name of the container where to change
+            the policy of the object
+        :type container: `str`
+        :param obj: name of the object to change the policy
+        :type obj: `str`
+        :param policy: name of the new storage policy
+        :type policy: `str`
+        """
+        meta, stream = self.object_fetch(
+            account, container, obj, **kwargs)
+        kwargs['version'] = meta['version']
         return self.object_create(
-            account, container, obj_name=obj, version=version,
+            account, container, obj_name=meta['name'],
             data=stream, policy=policy, change_policy=True, **kwargs)
 
     @ensure_headers
@@ -678,11 +692,12 @@ class ObjectStorageApi(object):
         Trigger a notification about an object
         (as if it just had been created).
 
-        :param account: name of the account where to create the object
+        :param account: name of the account where to touch the object
         :type account: `str`
-        :param container: name of the container where to create the object
+        :param container: name of the container where to touch the object
         :type container: `str`
         :param obj: name of the object to touch
+        :type obj: `str`
         """
         self.container.content_touch(account, container, obj,
                                      version=version, **kwargs)

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -676,11 +676,13 @@ class ObjectStorageApi(object):
         :type obj: `str`
         :param policy: name of the new storage policy
         :type policy: `str`
+
+        :returns: `list` of chunks, size, hash and metadata of object
         """
         meta, stream = self.object_fetch(
             account, container, obj, **kwargs)
         kwargs['version'] = meta['version']
-        return self.object_create(
+        return self.object_create_ext(
             account, container, obj_name=meta['name'],
             data=stream, policy=policy, change_policy=True, **kwargs)
 

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -659,6 +659,17 @@ class ObjectStorageApi(object):
                     properties=properties, policy=policy,
                     key_file=key_file, append=append, **kwargs)
 
+    @handle_object_not_found
+    @ensure_headers
+    @ensure_request_id
+    def object_change_policy(self, account, container, obj, version, policy,
+                             **kwargs):
+        _, stream = self.object_fetch(
+            account, container, obj, version=version, **kwargs)
+        return self.object_create(
+            account, container, obj_name=obj, version=version,
+            data=stream, policy=policy, change_policy=True, **kwargs)
+
     @ensure_headers
     @ensure_request_id
     def object_touch(self, account, container, obj,
@@ -1145,8 +1156,9 @@ class ObjectStorageApi(object):
             policy=policy, key_file=key_file,
             **kwargs)
 
-        # XXX content_id is necessary to update an existing object
+        # XXX content_id and version are necessary to update an existing object
         kwargs['content_id'] = obj_meta['id']
+        kwargs['version'] = obj_meta['version']
 
         try:
             ul_chunks, ul_bytes, obj_checksum = self._object_upload(
@@ -1176,8 +1188,7 @@ class ObjectStorageApi(object):
             self.container.content_create(
                 account, container, obj_name, size=ul_bytes,
                 checksum=obj_checksum, data=data,
-                stgpol=obj_meta['policy'],
-                version=obj_meta['version'], mime_type=obj_meta['mime_type'],
+                stgpol=obj_meta['policy'], mime_type=obj_meta['mime_type'],
                 chunk_method=obj_meta['chunk_method'],
                 **kwargs)
         except (exc.Conflict, exc.DeadlineReached) as ex:

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -360,7 +360,7 @@ class ShowObject(ObjectCommandMixin, show.ShowOne):
                 'object': obj}
         conv = {'id': 'id', 'version': 'version', 'mime-type': 'mime_type',
                 'size': 'length', 'hash': 'hash', 'ctime': 'ctime',
-                'policy': 'policy'}
+                'mtime': 'mtime', 'policy': 'policy'}
         for key0, key1 in conv.items():
             info[key0] = data.get(key1, 'n/a')
         for k, v in data['properties'].iteritems():
@@ -693,7 +693,7 @@ class ListObject(ContainerCommandMixin, lister.Lister):
                         result = (obj['name'], obj['size'],
                                   obj['hash'], obj['version'],
                                   obj['deleted'], obj['mime_type'],
-                                  Timestamp(obj['ctime']).isoformat,
+                                  Timestamp(obj['mtime']).isoformat,
                                   obj['policy'],
                                   _format_props(obj.get('properties', {})))
                         yield result

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -397,7 +397,8 @@ class ContainerClient(ProxyClient):
                        size=None, checksum=None, data=None, cid=None,
                        content_id=None, stgpol=None, version=None,
                        mime_type=None, chunk_method=None, headers=None,
-                       append=False, force=False, **kwargs):
+                       append=False, change_policy=False, force=False,
+                       **kwargs):
         """
         Create a new object. This method does not upload any data, it just
         registers object metadata in the database.
@@ -422,11 +423,15 @@ class ContainerClient(ProxyClient):
         :param headers: extra headers to send to the proxy
         :param append: append to an existing object instead of creating it
         :type append: `bool`
+        :param change_policy: change policy of an existing object
+        :type change_policy: `bool`
         """
         uri = self._make_uri('content/create')
         params = self._make_params(account, reference, path, cid=cid)
         if append:
             params['append'] = '1'
+        if change_policy:
+            params['change_policy'] = '1'
         # TODO(FVE): implement 'force' parameter
         if not isinstance(data, dict):
             warnings.simplefilter('once')
@@ -562,7 +567,7 @@ class ContainerClient(ProxyClient):
 
     def content_prepare(self, account=None, reference=None, path=None,
                         size=None, cid=None, stgpol=None, content_id=None,
-                        **kwargs):
+                        version=None, **kwargs):
         """
         Prepare an upload: get URLs of chunks on available rawx.
 
@@ -570,7 +575,7 @@ class ContainerClient(ProxyClient):
         """
         uri = self._make_uri('content/prepare')
         params = self._make_params(account, reference, path, cid=cid,
-                                   content=content_id)
+                                   content=content_id, version=version)
         data = {'size': size}
         if stgpol:
             data['policy'] = stgpol

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from oio.common.exceptions import OioException
 from oio.common.logger import get_logger
-from oio.common.utils import cid_from_name, depaginate
+from oio.common.utils import depaginate
 from oio.common.easy_value import true_value
 
 
@@ -821,10 +821,11 @@ class Transition(LifecycleAction):
 
     def apply(self, obj_meta, **kwargs):
         if self.match(obj_meta, **kwargs):
-            cid = cid_from_name(self.lifecycle.account,
-                                self.lifecycle.container)
-            # TODO: avoid loading content description a second time
-            self.factory.change_policy(cid, obj_meta['id'], self.policy)
+            if obj_meta['policy'] == self.policy:
+                return "Policy already changed to %s" % self.policy
+            self.lifecycle.api.object_change_policy(
+                self.lifecycle.account, self.lifecycle.container,
+                obj_meta['name'], self.policy, version=obj_meta['version'])
             return "Policy changed to %s" % self.policy
         return "Kept"
 

--- a/oio/container/lifecycle.py
+++ b/oio/container/lifecycle.py
@@ -603,7 +603,7 @@ class DaysActionFilter(LifecycleActionFilter):
 
     def match(self, obj_meta, now=None, **kwargs):
         now = now or time.time()
-        return float(obj_meta['ctime']) + self.days * 86400 < now
+        return float(obj_meta['mtime']) + self.days * 86400 < now
 
 
 class NoncurrentDaysActionFilter(DaysActionFilter):
@@ -636,7 +636,7 @@ class DateActionFilter(LifecycleActionFilter):
 
     def match(self, obj_meta, now=None, **kwargs):
         now = now or time.time()
-        return now > self.date and float(obj_meta['ctime']) < self.date
+        return now > self.date and float(obj_meta['mtime']) < self.date
 
 
 class NoncurrentCountActionFilter(LifecycleActionFilter):

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -15,7 +15,6 @@
 
 from oio.common.exceptions import ContentNotFound
 from oio.common.exceptions import NotFound
-from oio.common.utils import GeneratorIO
 from oio.common.logger import get_logger
 from oio.container.client import ContainerClient
 from oio.blob.client import BlobClient
@@ -120,16 +119,3 @@ class ContentFactory(object):
         return cls(self.conf, origin.container_id,
                    metadata, chunks, storage_method,
                    origin.account, origin.container_name)
-
-    def change_policy(self, container_id, content_id, new_policy):
-        old_content = self.get(container_id, content_id)
-        if old_content.policy == new_policy:
-            return old_content
-
-        new_content = self.copy(old_content, policy=new_policy)
-
-        stream = old_content.fetch()
-        new_content.create(GeneratorIO(stream))
-        # the old content is automatically deleted because the new content has
-        # the same name (but not the same id)
-        return new_content

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -2403,6 +2403,7 @@ static GError *_m2_json_put (struct req_args_s *args,
 
 	const gboolean append = _request_get_flag (args, "append");
 	const gboolean force = _request_get_flag (args, "force");
+	const gboolean change_policy = _request_get_flag (args, "change_policy");
 	GSList *ibeans = NULL, *obeans = NULL;
 	GError *err;
 
@@ -2423,6 +2424,7 @@ static GError *_m2_json_put (struct req_args_s *args,
 	PACKER_VOID(_pack) {
 		if (force) return m2v2_remote_pack_OVERWRITE (args->url, ibeans, DL());
 		if (append) return m2v2_remote_pack_APPEND (args->url, ibeans, DL());
+		if (change_policy) return m2v2_remote_pack_CHANGE_POLICY (args->url, ibeans, DL());
 		return m2v2_remote_pack_PUT (args->url, ibeans, DL());
 	}
 	err = _resolve_meta2(args, _prefer_master(), _pack, &obeans, NULL);

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -288,6 +288,15 @@ m2v2_remote_pack_UPDATE(struct oio_url_s *url, GSList *beans, gint64 dl)
 }
 
 GByteArray*
+m2v2_remote_pack_CHANGE_POLICY(struct oio_url_s *url, GSList *beans, gint64 dl)
+{
+	GByteArray *body = bean_sequence_marshall(beans);
+	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_PUT, url, body, dl);
+	metautils_message_add_field_str(msg, NAME_MSGKEY_CHANGE_POLICY, "1");
+	return message_marshall_gba_and_clean(msg);
+}
+
+GByteArray*
 m2v2_remote_pack_APPEND(struct oio_url_s *url, GSList *beans, gint64 dl)
 {
 	GByteArray *body = bean_sequence_marshall(beans);

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -127,6 +127,11 @@ GByteArray* m2v2_remote_pack_UPDATE(
 		GSList *beans,
 		gint64 deadline);
 
+GByteArray* m2v2_remote_pack_CHANGE_POLICY(
+		struct oio_url_s *url,
+		GSList *beans,
+		gint64 deadline);
+
 GByteArray* m2v2_remote_pack_APPEND(
 		struct oio_url_s *url,
 		GSList *beans,

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -1249,7 +1249,7 @@ class TestObjectChangePolicy(ObjectStorageApiTestBase):
                      if cont_info[0] == name]
 
         self.api.object_change_policy(
-            self.account, name, name, obj1['version'], new_policy)
+            self.account, name, name, new_policy, version=obj1['version'])
         obj2, chunks2 = self.api.object_locate(
             self.account, name, name, version=obj1['version'])
         cnt_props2 = self.api.container_get_properties(self.account, name)
@@ -1357,7 +1357,7 @@ class TestObjectChangePolicy(ObjectStorageApiTestBase):
         obj = self.api.object_get_properties(self.account, name, name)
         self.assertRaises(
             exc.ClientException, self.api.object_change_policy,
-            self.account, name, name, obj['version'], 'UNKNOWN')
+            self.account, name, name, 'UNKNOWN', version=obj['version'])
 
     def test_change_policy_with_delete_marker(self):
         name = random_str(32)
@@ -1370,7 +1370,7 @@ class TestObjectChangePolicy(ObjectStorageApiTestBase):
         obj = self.api.object_get_properties(self.account, name, name)
         self.assertRaises(
             exc.NoSuchObject, self.api.object_change_policy,
-            self.account, name, name, obj['version'], 'SINGLE')
+            self.account, name, name, 'SINGLE', version=obj['version'])
         self.assertRaises(
             exc.ClientException, self.api.object_create,
             self.account, name, obj_name=name, version=obj['version'],

--- a/tests/functional/audit/test_audit_storage.py
+++ b/tests/functional/audit/test_audit_storage.py
@@ -16,6 +16,7 @@
 import hashlib
 
 import os
+import time
 
 from oio.common.utils import cid_from_name
 from oio.common.xattr import xattr
@@ -121,7 +122,7 @@ class TestBlobAuditorFunctional(BaseTestCase):
             "size": self.chunk.metachunk_size}
         self.container_client.content_create(
             self.account, self.ref, self.content.path,
-            content_id=self.content.id,
+            version=int(time.time()*1000000), content_id=self.content.id,
             size=self.content.size, checksum=self.content.hash,
             data={'chunks': [chunk_proxy]}, stgpol="SINGLE")
 

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -29,7 +29,7 @@ CONTAINER_FIELDS = ['account', 'base_name', 'bytes_usage', 'quota',
                     'container', 'ctime', 'storage_policy', 'objects',
                     'max_versions', 'status']
 OBJ_FIELDS = ['account', 'container', 'ctime', 'hash', 'id', 'mime-type',
-              'object', 'policy', 'size', 'version']
+              'mtime', 'object', 'policy', 'size', 'version']
 
 
 class ObjectTest(CliTestCase):

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -209,7 +209,7 @@ class TestMeta2Containers(BaseTestCase):
             p = "X-oio-content-meta-"
             headers = {p+"policy": "NONE",
                        p+"id": h,
-                       p+"version": "0",
+                       p+"version": "1",
                        p+"hash": "0"*32,
                        p+"length": "0",
                        p+"mime-type": "application/octet-stream",
@@ -420,6 +420,7 @@ class TestMeta2Containers(BaseTestCase):
         headers = {'x-oio-action-mode': 'autocreate',
                    'x-oio-content-meta-size': '1024',
                    'x-oio-content-meta-policy': stgpol,
+                   'x-oio-content-meta-version': int(time.time()*1000000),
                    'x-oio-content-meta-id': random_id(32)}
         resp = self.request('POST', self.url_content('create'), params=params,
                             headers=headers, data=json.dumps(chunks))
@@ -620,6 +621,7 @@ class TestMeta2Contents(BaseTestCase):
         headers = {'x-oio-action-mode': 'autocreate',
                    'x-oio-content-meta-size': '1024',
                    'x-oio-content-meta-policy': stgpol,
+                   'x-oio-content-meta-version': int(time.time()*1000000),
                    'x-oio-content-meta-id': random_id(32)}
         resp = self.request('POST', self.url_content('create'), params=params,
                             headers=headers, data=json.dumps(chunks))
@@ -792,6 +794,7 @@ class TestMeta2Contents(BaseTestCase):
         headers = {'x-oio-action-mode': 'autocreate',
                    'x-oio-content-meta-size': '1024',
                    'x-oio-content-meta-policy': stgpol,
+                   'x-oio-content-meta-version': int(time.time()*1000000),
                    'x-oio-content-meta-id': random_id(32)}
         resp = self.request('POST', self.url_content('create'),
                             params=params, headers=headers,

--- a/tests/functional/container/test_lifecycle.py
+++ b/tests/functional/container/test_lifecycle.py
@@ -975,13 +975,13 @@ class TestContainerLifecycle(BaseTestCase):
             """})
         fake_listing = {
             'objects': [
-                {'name': 'a', 'version': 1540933092888883, 'ctime': '12',
+                {'name': 'a', 'version': 1540933092888883, 'mtime': '12',
                  'deleted': False},
-                {'name': 'b', 'version': 1540933092888883, 'ctime': '12',
+                {'name': 'b', 'version': 1540933092888883, 'mtime': '12',
                  'deleted': False},
-                {'name': 'c', 'version': 1540933092888883, 'ctime': '12',
+                {'name': 'c', 'version': 1540933092888883, 'mtime': '12',
                  'deleted': False},
-                {'name': 'd', 'version': 1540933092888883, 'ctime': '12',
+                {'name': 'd', 'version': 1540933092888883, 'mtime': '12',
                  'deleted': False}],
             'truncated': False
         }

--- a/tests/functional/crawler/test_storage_tierer.py
+++ b/tests/functional/crawler/test_storage_tierer.py
@@ -14,16 +14,13 @@
 # License along with this library.
 
 import time
-from io import BytesIO
 
 from mock import MagicMock as Mock
 import mock
 
-from oio.common.utils import cid_from_name
+from oio import ObjectStorageApi
 from oio.container.client import ContainerClient
-from oio.content.factory import ContentFactory
 from oio.crawler.storage_tierer import StorageTiererWorker
-from oio.api.object_storage import ObjectStorageApi
 from tests.functional.content.test_content import random_data
 from tests.utils import BaseTestCase
 
@@ -33,69 +30,62 @@ class TestStorageTierer(BaseTestCase):
         super(TestStorageTierer, self).setUp()
         self.namespace = self.conf['namespace']
         self.test_account = "test_storage_tiering_%f" % time.time()
+        self.api = ObjectStorageApi(self.namespace)
         self.gridconf = {"namespace": self.namespace,
                          "container_fetch_limit": 2,
                          "content_fetch_limit": 2,
                          "account": self.test_account,
                          "outdated_threshold": 0,
                          "new_policy": "EC"}
-        self.content_factory = ContentFactory(self.gridconf)
-        self.container_client = ContainerClient(self.gridconf)
+        self.api.container = ContainerClient(self.gridconf)
         self._populate()
 
     def _populate(self):
-        self.container_0_name = "container_empty"
-        self.container_0_id = cid_from_name(
-            self.test_account, self.container_0_name)
-        self.container_client.container_create(
-            account=self.test_account, reference=self.container_0_name)
+        self.container_0_name = 'container_empty'
+        self.container_0 = self._new_container(self.container_0_name)
 
-        self.container_1_name = "container_with_1_content"
-        self.container_1_id = cid_from_name(
-            self.test_account, self.container_1_name)
-        self.container_client.container_create(
-            account=self.test_account, reference=self.container_1_name)
-        self.container_1_content_0_name = "container_1_content_0"
-        self.container_1_content_0 = self._new_content(
-            self.container_1_id, self.container_1_content_0_name, "SINGLE",
-            self.test_account, self.container_1_name)
+        self.container_1_name = 'container_with_1_content'
+        self.container_1 = self._new_container(self.container_1_name)
+        self.container_1_content_0_name = 'container_1_content_0'
+        self.container_1_content_0 = self._new_object(
+            self.container_1_name, self.container_1_content_0_name, 'SINGLE')
 
-        self.container_2_name = "container_with_2_contents"
-        self.container_2_id = cid_from_name(
-            self.test_account, self.container_2_name)
-        self.container_client.container_create(
-            account=self.test_account, reference=self.container_2_name)
-        self.container_2_content_0_name = "container_2_content_0"
-        self.container_2_content_0 = self._new_content(
-            self.container_2_id, self.container_2_content_0_name, "SINGLE",
-            self.test_account, self.container_2_name)
-        self.container_2_content_1_name = "container_2_content_1"
-        self.container_2_content_1 = self._new_content(
-            self.container_2_id, self.container_2_content_1_name, "TWOCOPIES",
-            self.test_account, self.container_2_name)
+        self.container_2_name = 'container_with_2_contents'
+        self.container_2 = self._new_container(self.container_1_name)
+        self.container_2_content_0_name = 'container_2_content_0'
+        self.container_2_content_0 = self._new_object(
+            self.container_2_name, self.container_2_content_0_name, 'SINGLE')
+        self.container_2_content_1_name = 'container_2_content_1'
+        self.container_2_content_1 = self._new_object(
+            self.container_2_name, self.container_2_content_1_name,
+            'TWOCOPIES')
 
-    def _new_content(self, container_id, content_name, stgpol, account,
-                     reference):
+    def _new_container(self, container):
+        self.api.container_create(self.test_account, container)
+        cnt = self.api.container_get_properties(self.test_account, container)
+        return cnt
+
+    def _new_object(self, container, obj_name, stgpol):
         data = random_data(10)
-        content = self.content_factory.new(container_id, content_name,
-                                           len(data), stgpol, account=account,
-                                           container_name=reference)
-
-        content.create(BytesIO(data))
-        return content
+        self.api.object_create(
+            self.test_account, container, obj_name=obj_name,
+            policy=stgpol, data=data)
+        obj = self.api.object_get_properties(
+            self.test_account, container, obj_name)
+        return obj
 
     def tearDown(self):
         super(TestStorageTierer, self).tearDown()
 
     def test_iter_container_list(self):
         worker = StorageTiererWorker(self.gridconf, Mock())
-        api = ObjectStorageApi(self.namespace)
-        actual = [x[0] for x in api.container_list(self.test_account)]
+        actual = [x[0] for x in self.api.container_list(self.test_account)]
         if len(actual) < 3:
             print "Slow event propagation!"
             # account events have not yet propagated
             time.sleep(3.0)
-            actual = [x[0] for x in api.container_list(self.test_account)[0]]
+            actual = [x[0] for x in self.api.container_list(
+                      self.test_account)[0]]
         gen = worker._list_containers()
         self.assertListEqual(list(gen), actual)
 
@@ -103,12 +93,18 @@ class TestStorageTierer(BaseTestCase):
         self.gridconf["outdated_threshold"] = 0
         worker = StorageTiererWorker(self.gridconf, Mock())
         gen = worker._list_contents()
-        self.assertEqual(gen.next(), (
-            self.container_1_id, self.container_1_content_0.content_id))
-        self.assertEqual(gen.next(), (
-            self.container_2_id, self.container_2_content_0.content_id))
-        self.assertEqual(gen.next(), (
-            self.container_2_id, self.container_2_content_1.content_id))
+        self.assertEqual((
+            self.test_account, self.container_1_name,
+            self.container_1_content_0_name,
+            int(self.container_1_content_0['version'])), gen.next())
+        self.assertEqual((
+            self.test_account, self.container_2_name,
+            self.container_2_content_0_name,
+            int(self.container_2_content_0['version'])), gen.next())
+        self.assertEqual((
+            self.test_account, self.container_2_name,
+            self.container_2_content_1_name,
+            int(self.container_2_content_1['version'])), gen.next())
         self.assertRaises(StopIteration, gen.next)
 
     def test_iter_content_list_outdated_threshold_9999999999(self):
@@ -121,26 +117,33 @@ class TestStorageTierer(BaseTestCase):
         # add a new content created after the three previous contents
         now = int(time.time())
         time.sleep(2)
-        self._new_content(self.container_2_id, "titi", "TWOCOPIES",
-                          self.test_account, self.container_2_name)
+        self._new_object(self.container_2_name, 'titi', 'TWOCOPIES')
 
         self.gridconf["outdated_threshold"] = 2
         worker = StorageTiererWorker(self.gridconf, Mock())
         with mock.patch('oio.crawler.storage_tierer.time.time',
-                        mock.MagicMock(return_value=now+1)):
+                        mock.MagicMock(return_value=now)):
             gen = worker._list_contents()
-        self.assertEqual(gen.next(), (
-            self.container_1_id, self.container_1_content_0.content_id))
-        self.assertEqual(gen.next(), (
-            self.container_2_id, self.container_2_content_0.content_id))
-        self.assertEqual(gen.next(), (
-            self.container_2_id, self.container_2_content_1.content_id))
+        self.assertEqual((
+            self.test_account, self.container_1_name,
+            self.container_1_content_0_name,
+            int(self.container_1_content_0['version'])), gen.next())
+        self.assertEqual((
+            self.test_account, self.container_2_name,
+            self.container_2_content_0_name,
+            int(self.container_2_content_0['version'])), gen.next())
+        self.assertEqual((
+            self.test_account, self.container_2_name,
+            self.container_2_content_1_name,
+            int(self.container_2_content_1['version'])), gen.next())
         self.assertRaises(StopIteration, gen.next)
 
     def test_iter_content_list_skip_good_policy(self):
         self.gridconf["new_policy"] = "SINGLE"
         worker = StorageTiererWorker(self.gridconf, Mock())
         gen = worker._list_contents()
-        self.assertEqual(gen.next(), (
-            self.container_2_id, self.container_2_content_1.content_id))
+        self.assertEqual((
+            self.test_account, self.container_2_name,
+            self.container_2_content_1_name,
+            int(self.container_2_content_1['version'])), gen.next())
         self.assertRaises(StopIteration, gen.next)

--- a/tests/unit/container/test_lifecycle.py
+++ b/tests/unit/container/test_lifecycle.py
@@ -35,6 +35,7 @@ class TestContainerLifecycle(unittest.TestCase):
     obj_meta = {
         'hash': '262C4009B642DE2F7A95EFD4FCD0A465',
         'ctime': '554119200',
+        'mtime': '554119200',
         'deleted': 'False',
         'id': 'DA5BEBD37F5705004FFD42A9B275AB84',
         'length': '44065',
@@ -1511,7 +1512,7 @@ class TestContainerLifecycle(unittest.TestCase):
         obj_meta = self.obj_meta.copy()
         self.assertTrue(days.match(obj_meta))
 
-        obj_meta['ctime'] = time.time()
+        obj_meta['mtime'] = time.time()
         self.assertFalse(days.match(obj_meta))
 
     def test_DateActionFilter_match(self):


### PR DESCRIPTION
##### SUMMARY

Allow to change the policy of an object:
- must have the same hash and the same size
- keep the same `version`
- keep the same `ctime` and `mtime`

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `meta2`
- `proxy`
- Python API
- CLI
- `lifecycle`

##### SDS VERSION

```
openio 4.3.1.dev30
```