### PR TITLE
Redistribute degraded chunks in an optimized way

### DIFF
--- a/bin/oio-blob-improver
+++ b/bin/oio-blob-improver
@@ -27,17 +27,10 @@ from oio.rebuilder.blob_improver import DEFAULT_IMPROVER_TUBE, \
 def make_arg_parser():
     log_parser = make_logger_args_parser()
     descr = """Listen to perfectible chunk events,
-               and try to place them more adequately."""
+               and try to place them more adequately.
+               Events that could not be handled will be rescheduled later."""
     parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
     parser.add_argument('namespace', help="Namespace")
-    parser.add_argument('--dry-run', action='store_true',
-                        help="Display actions but do nothing")
-    parser.add_argument('--report-interval', type=int,
-                        help="Report interval in seconds (3600)")
-    parser.add_argument('--workers', type=int,
-                        help="Number of workers (1)")
-    parser.add_argument('--chunks-per-second', type=int,
-                        help="Max chunks per second per worker (30)")
     parser.add_argument('--beanstalkd',
                         metavar='IP:PORT',
                         help="Address of the beanstalkd service to listen to")
@@ -45,6 +38,22 @@ def make_arg_parser():
         '--beanstalkd-tube', metavar='LISTENER_TUBE',
         help='Listen to this beanstalkd tube (default: "%s").'
              % DEFAULT_IMPROVER_TUBE)
+    parser.add_argument('--chunks-per-second', type=int,
+                        help="Max chunks per second per worker (30)")
+    parser.add_argument('--dry-run', action='store_true',
+                        help="Display actions but do nothing")
+    parser.add_argument('--max-move-attempts', type=int, default=3,
+                        help=('Maximum number of attempts at finding a spare '
+                              'chunk and moving a perfectible chunk. '
+                              'Defaults to 3.'))
+    parser.add_argument('--report-interval', type=int,
+                        help="Report interval in seconds (3600)")
+    parser.add_argument('--retry-delay', type=int,
+                        help=('Delay to wait before rescheduling a job that '
+                              'could not be handled. Defaults to 3600s.'),
+                        default=3600)
+    parser.add_argument('--workers', type=int,
+                        help="Number of workers (1)")
     return parser
 
 
@@ -72,12 +81,15 @@ def main():
         conf['workers'] = args.workers
     if args.chunks_per_second is not None:
         conf['items_per_second'] = args.chunks_per_second
+    if args.retry_delay:
+        conf['retry_delay'] = args.retry_delay
 
     success = False
     try:
         blob_improver = BlobImprover(
             conf, logger, beanstalkd_addr=args.beanstalkd)
-        success = blob_improver.rebuilder_pass(dry_run=args.dry_run)
+        success = blob_improver.rebuilder_pass(
+            dry_run=args.dry_run, move_attempts=args.max_move_attempts)
     except KeyboardInterrupt:
         logger.info('Exiting')
     except Exception as exc:

--- a/bin/oio-blob-improver
+++ b/bin/oio-blob-improver
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+# oio-blob-improver.py
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import sys
+
+from oio.cli import make_logger_args_parser, get_logger_from_args
+from oio.rebuilder.blob_improver import DEFAULT_IMPROVER_TUBE, \
+    BlobImprover
+
+
+def make_arg_parser():
+    log_parser = make_logger_args_parser()
+    descr = """Listen to perfectible chunk events,
+               and try to place them more adequately."""
+    parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
+    parser.add_argument('namespace', help="Namespace")
+    parser.add_argument('--dry-run', action='store_true',
+                        help="Display actions but do nothing")
+    parser.add_argument('--report-interval', type=int,
+                        help="Report interval in seconds (3600)")
+    parser.add_argument('--workers', type=int,
+                        help="Number of workers (1)")
+    parser.add_argument('--chunks-per-second', type=int,
+                        help="Max chunks per second per worker (30)")
+    parser.add_argument('--beanstalkd',
+                        metavar='IP:PORT',
+                        help="Address of the beanstalkd service to listen to")
+    parser.add_argument(
+        '--beanstalkd-tube', metavar='LISTENER_TUBE',
+        help='Listen to this beanstalkd tube (default: "%s").'
+             % DEFAULT_IMPROVER_TUBE)
+    return parser
+
+
+def main():
+    args = make_arg_parser().parse_args()
+
+    if not args.beanstalkd:
+        raise ValueError('Missing beanstalkd address')
+
+    conf = {}
+    conf['dry_run'] = args.dry_run
+    conf['namespace'] = args.namespace
+    tube = args.beanstalkd_tube or DEFAULT_IMPROVER_TUBE
+
+    conf['syslog_prefix'] = 'OIO,%s,blob-improver,%s' % (
+        args.namespace, 'tube:' + tube)
+
+    logger = get_logger_from_args(args, default_conf=conf)
+
+    if args.beanstalkd_tube is not None:
+        conf['beanstalkd_tube'] = args.beanstalkd_tube
+    if args.report_interval is not None:
+        conf['report_interval'] = args.report_interval
+    if args.workers is not None:
+        conf['workers'] = args.workers
+    if args.chunks_per_second is not None:
+        conf['items_per_second'] = args.chunks_per_second
+
+    success = False
+    try:
+        blob_improver = BlobImprover(
+            conf, logger, beanstalkd_addr=args.beanstalkd)
+        success = blob_improver.rebuilder_pass(dry_run=args.dry_run)
+    except KeyboardInterrupt:
+        logger.info('Exiting')
+    except Exception as exc:
+        logger.exception('ERROR in improver: %s', exc)
+    if not success:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/oio-blob-improver
+++ b/bin/oio-blob-improver
@@ -52,6 +52,9 @@ def make_arg_parser():
                         help=('Delay to wait before rescheduling a job that '
                               'could not be handled. Defaults to 3600s.'),
                         default=3600)
+    parser.add_argument('--stop-after-events', type=int, default=0,
+                        help=('Stop the process after this number of events '
+                              'have been processed. Useful for testing.'))
     parser.add_argument('--workers', type=int,
                         help="Number of workers (1)")
     return parser
@@ -89,7 +92,8 @@ def main():
         blob_improver = BlobImprover(
             conf, logger, beanstalkd_addr=args.beanstalkd)
         success = blob_improver.rebuilder_pass(
-            dry_run=args.dry_run, move_attempts=args.max_move_attempts)
+            dry_run=args.dry_run, move_attempts=args.max_move_attempts,
+            max_events=args.stop_after_events)
     except KeyboardInterrupt:
         logger.info('Exiting')
     except Exception as exc:

--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -19,23 +19,13 @@
 import argparse
 import sys
 
+from oio.cli import make_logger_args_parser, get_logger_from_args
 from oio.rebuilder.blob_rebuilder import DEFAULT_REBUILDER_TUBE, \
     BlobRebuilder, DistributedBlobRebuilder
-from oio.common.logger import get_logger
 
 
 def make_arg_parser():
-    log_parser = argparse.ArgumentParser(add_help=False)
-    levels = ['DEBUG', 'INFO', 'WARN', 'ERROR']
-    log_parser.add_argument('--log-level', choices=levels,
-                            help="Log level")
-    log_parser.add_argument('--log-syslog-prefix',
-                            help="Syslog prefix")
-    log_parser.add_argument('--log-facility',
-                            help="Log facility")
-    log_parser.add_argument('--log-address',
-                            help="Log address")
-
+    log_parser = make_logger_args_parser()
     descr = """
 Rebuild chunks that were on the specified volume, or chunks listed in
 the input file. If no input file is provided, the list of chunks is
@@ -60,9 +50,7 @@ tube for broken chunks events.
     parser.add_argument('--chunks-per-second', type=int,
                         help="Max chunks per second per worker (30)")
     parser.add_argument("--random-wait", type=int,
-                        help="Random wait (in μs)")
-    parser.add_argument('-q', '--quiet', action='store_true',
-                        help="Don't print log on console")
+                        help="Random wait (in microseconds)")
     parser.add_argument('--allow-same-rawx', action='store_true',
                         help="Allow rebuilding a chunk on the original rawx")
     dft_help = "Try to delete faulty chunks after they have been rebuilt " \
@@ -75,17 +63,17 @@ tube for broken chunks events.
                  "'container_id|content_id|short_chunk_id_or_position'."
     parser.add_argument('--input-file', nargs='?',
                         help=ifile_help)
-    beanstalkd_help = "Listen to broken chunks events from a beanstalkd tube " \
-                      "instead of querying rdir. If --distributed is in use, " \
-                      "listen to rebuilt chunk events from a beanstalkd tube."
+    beanstalkd_help = """Listen to broken chunks events from a beanstalkd tube
+                      instead of querying rdir. If --distributed is in use,
+                      listen to rebuilt chunk events from a beanstalkd tube."""
     parser.add_argument('--beanstalkd',
                         metavar='IP:PORT',
                         help=beanstalkd_help)
     parser.add_argument(
         '--beanstalkd-tube',
         metavar='LISTENER_TUBE',
-        help='The beanstalkd tube to use to listen (default: "%s")' \
-            % DEFAULT_REBUILDER_TUBE)
+        help='The beanstalkd tube to use to listen (default: "%s")'
+             % DEFAULT_REBUILDER_TUBE)
     distributed_help = "Send broken chunks to beanstalkd tubes " \
                        "instead of rebuilding them locally " \
                        "(the following options are ignored: " \
@@ -97,8 +85,8 @@ tube for broken chunks events.
     parser.add_argument(
         '--distributed-tube',
         metavar='SENDER_TUBE',
-        help='The beanstalkd tube to use to send the broken chunks (default: "%s")' \
-            % DEFAULT_REBUILDER_TUBE)
+        help=('The beanstalkd tube to use to send the broken chunks '
+              '(default: "%s")' % DEFAULT_REBUILDER_TUBE))
 
     return parser
 
@@ -114,22 +102,13 @@ def main():
     conf['dry_run'] = args.dry_run
     conf['namespace'] = args.namespace
 
-    if args.log_level is not None:
-        conf['log_level'] = args.log_level
-    if args.log_facility is not None:
-        conf['log_facility'] = args.log_facility
-    if args.log_address is not None:
-        conf['log_address'] = args.log_address
-    if args.log_syslog_prefix is not None:
-        conf['syslog_prefix'] = args.log_syslog_prefix
-    else:
-        conf['syslog_prefix'] = 'OIO,%s,blob-rebuilder,%s' % \
-            (args.namespace,
-             args.volume or
-             args.input_file or
-             ('tube:' + (args.beanstalkd_tube or DEFAULT_REBUILDER_TUBE)))
+    conf['syslog_prefix'] = 'OIO,%s,blob-rebuilder,%s' % \
+        (args.namespace,
+         args.volume or
+         args.input_file or
+         ('tube:' + (args.beanstalkd_tube or DEFAULT_REBUILDER_TUBE)))
 
-    logger = get_logger(conf, 'log', not args.quiet)
+    logger = get_logger_from_args(args, default_conf=conf)
 
     if args.beanstalkd_tube is not None:
         conf['beanstalkd_tube'] = args.beanstalkd_tube

--- a/core/url.c
+++ b/core/url.c
@@ -636,6 +636,11 @@ oio_url_to_json (GString *out, struct oio_url_s *u)
 		if (len != out->len) g_string_append_c (out, ',');
 		oio_str_gstring_append_json_pair (out, "id", u->hexid);
 	}
+	if (oio_str_is_set(u->version)) {
+		if (len != out->len)
+			g_string_append_c(out, ',');
+		oio_str_gstring_append_json_pair(out, "version", u->version);
+	}
 }
 
 gboolean

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -51,7 +51,7 @@ struct list_params_s
 	guint8 flag_local     :1;
 };
 
-gchar* m2v2_build_chunk_url (const char *srv, const char *id);
+gchar* m2v2_build_chunk_url(const char *srv, const char *id);
 
 
 struct m2v2_position_s {
@@ -71,9 +71,9 @@ struct m2v2_sorted_content_s {
 struct checked_content_s;
 
 
-struct m2v2_position_s m2v2_position_decode (const char *str);
+struct m2v2_position_s m2v2_position_decode(const char *str);
 
-void m2v2_position_encode (GString *out, struct m2v2_position_s *p);
+void m2v2_position_encode(GString *out, struct m2v2_position_s *p);
 
 /* Sort the beans of a content. Use m2v2_sorted_content_free to free
  * the result. The beans must be freed separately. */
@@ -178,7 +178,7 @@ GError* m2db_check_content(struct m2v2_sorted_content_s *sorted_content,
 
 void m2db_check_content_quality(
 		struct m2v2_sorted_content_s *sorted_content, GSList *chunk_meta,
-        GSList **to_be_improved);
+		GSList **to_be_improved);
 
 GError* m2db_update_content(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 		GSList *beans, m2_onbean_cb cb_deleted, gpointer u0_deleted,
@@ -248,5 +248,16 @@ GError* m2db_flush_container(struct sqlx_sqlite3_s *sq3, m2_onbean_cb cb,
 
 GError* m2db_deduplicate_contents(struct sqlx_sqlite3_s *sq3,
 		struct oio_url_s *url);
+
+/* --- Low level ----------------------------------------------------------- */
+
+/** Generate a chunk "bean", filled with only an address and ctime. */
+struct bean_CHUNKS_s *generate_chunk_bean(struct oio_lb_selected_item_s *sel,
+		const struct storage_policy_s *policy);
+
+/** Generate a property "bean", with details about the quality of a chunk. */
+struct bean_PROPERTIES_s *generate_chunk_quality_bean(
+		struct oio_lb_selected_item_s *sel,
+		const gchar *chunkid, struct oio_url_s *url);
 
 #endif /*OIO_SDS__meta2v2__meta2_utils_h*/

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -260,4 +260,7 @@ struct bean_PROPERTIES_s *generate_chunk_quality_bean(
 		struct oio_lb_selected_item_s *sel,
 		const gchar *chunkid, struct oio_url_s *url);
 
+/** Get the version of the first alias bean from the list. */
+gint64 find_alias_version(GSList *bean);
+
 #endif /*OIO_SDS__meta2v2__meta2_utils_h*/

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -27,10 +27,6 @@ from oio.common.constants import ADMIN_HEADER, \
 _POOL_MANAGER_OPTIONS_KEYS = ["pool_connections", "pool_maxsize",
                               "max_retries", "backoff_factor"]
 
-URLLIB3_REQUESTS_KWARGS = ('fields', 'headers', 'body', 'retries', 'redirect',
-                           'assert_same_host', 'timeout', 'pool_timeout',
-                           'release_conn', 'chunked')
-
 
 class HttpApi(object):
     """
@@ -101,9 +97,7 @@ class HttpApi(object):
         :raise oio.common.exceptions.ClientException: in case of HTTP status
         code >= 400
         """
-        # Filter arguments that are not recognized by urllib3
-        out_kwargs = {k: v for k, v in kwargs.items()
-                      if k in URLLIB3_REQUESTS_KWARGS}
+        out_kwargs = dict(kwargs)
 
         # Ensure headers are all strings
         if headers:

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -131,6 +131,10 @@ class HttpApi(object):
                 to = float(to)
             out_headers[TIMEOUT_HEADER] = int(to * 1000000.0)
 
+        # Look for a request ID
+        if 'req_id' in kwargs:
+            out_headers['X-oio-req-id'] = str(kwargs['req_id'])
+
         # Convert json and add Content-Type
         if json:
             out_headers["Content-Type"] = "application/json"

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -136,6 +136,7 @@ class BlobClient(object):
         return resps
 
     @update_rawx_perfdata
+    @ensure_headers
     @ensure_request_id
     def chunk_get(self, url, **kwargs):
         url = self.resolve_url(url)

--- a/oio/cli/__init__.py
+++ b/oio/cli/__init__.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+from oio.common.logger import get_logger
+
+LOG_LEVELS = ['DEBUG', 'INFO', 'WARN', 'ERROR']
+
+
+def make_logger_args_parser():
+    """Create an ArgumentParser for logger configuration."""
+    log_parser = argparse.ArgumentParser(add_help=False)
+    log_parser.add_argument('--log-level', choices=LOG_LEVELS,
+                            help="Log level")
+    log_parser.add_argument('--log-syslog-prefix', help="Syslog prefix")
+    log_parser.add_argument('--log-facility', help="Log facility")
+    log_parser.add_argument('--log-address', help="Log address")
+    log_parser.add_argument('-q', '--quiet', action='store_true',
+                            help="Don't print logs on console")
+
+    return log_parser
+
+
+def get_logger_from_args(args, default_conf=None):
+    """Build a Logger instance from parsed args."""
+    conf = default_conf or dict()
+    if args.log_level is not None:
+        conf['log_level'] = args.log_level
+    if args.log_facility is not None:
+        conf['log_facility'] = args.log_facility
+    if args.log_address is not None:
+        conf['log_address'] = args.log_address
+    if args.log_syslog_prefix is not None:
+        conf['syslog_prefix'] = args.log_syslog_prefix
+
+    return get_logger(conf, 'log', not args.quiet)

--- a/oio/common/decorators.py
+++ b/oio/common/decorators.py
@@ -31,8 +31,11 @@ def ensure_request_id(func):
     @wraps(func)
     def ensure_request_id_wrapper(*args, **kwargs):
         headers = kwargs.get('headers', dict())
-        if 'X-oio-req-id' not in headers and 'req_id' not in kwargs:
-            headers['X-oio-req-id'] = request_id()
+        if 'X-oio-req-id' not in headers:
+            if 'req_id' in kwargs:
+                headers['X-oio-req-id'] = kwargs.pop('req_id')
+            else:
+                headers['X-oio-req-id'] = request_id()
             kwargs['headers'] = headers
         return func(*args, **kwargs)
     return ensure_request_id_wrapper

--- a/oio/common/decorators.py
+++ b/oio/common/decorators.py
@@ -30,9 +30,10 @@ def ensure_headers(func):
 def ensure_request_id(func):
     @wraps(func)
     def ensure_request_id_wrapper(*args, **kwargs):
-        headers = kwargs['headers']
-        if 'X-oio-req-id' not in headers:
+        headers = kwargs.get('headers', dict())
+        if 'X-oio-req-id' not in headers and 'req_id' not in kwargs:
             headers['X-oio-req-id'] = request_id()
+            kwargs['headers'] = headers
         return func(*args, **kwargs)
     return ensure_request_id_wrapper
 

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -57,6 +57,10 @@ class Meta2Exception(OioException):
 
 
 class SpareChunkException(Meta2Exception):
+    """
+    Exception raised when no spare chunk has been found,
+    or some may have been found but they don't match all criteria.
+    """
     pass
 
 

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -68,10 +68,6 @@ class ContentException(OioException):
     pass
 
 
-class InconsistentContent(ContentException):
-    pass
-
-
 class ContentNotFound(ContentException):
     pass
 
@@ -93,6 +89,14 @@ class CommandError(Exception):
 
 
 class ExplicitBury(OioException):
+    pass
+
+
+class RetryLater(OioException):
+    """
+    Exception raised by workers that want a task to be
+    rescheduled later.
+    """
     pass
 
 

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -181,15 +181,16 @@ def fix_ranges(ranges, length):
     return result
 
 
-def request_id(prefix=None):
+def request_id(prefix=''):
     """
     Build a 128-bit request id string.
 
     :param prefix: optional prefix to the request id.
     """
-    pref_bits = min(112, len(prefix) * 8 if prefix else 0)
-    return "%04X%028X" % (os.getpid(),
-                          getrandbits(112 - pref_bits))
+    pref_bits = min(112, len(prefix) * 4)
+    rand_bits = 112 - pref_bits
+    return "%s%04X%0*X" % (prefix, os.getpid(),
+                           rand_bits/4, getrandbits(rand_bits))
 
 
 class GeneratorIO(RawIOBase):

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -26,6 +26,15 @@ CONTENT_HEADER_PREFIX = 'x-oio-content-meta-'
 SYSMETA_KEYS = ("chunk-method", "ctime", "mtime", "deleted", "hash",
                 "hash-method", "id", "length", "mime-type", "name", "policy",
                 "size", "version")
+CHUNK_SYSMETA_PREFIX = '__OIO_CHUNK__'
+
+
+def extract_chunk_qualities(properties):
+    """Extract chunk quality information from a dictionary of properties."""
+    qualities = {k[len(CHUNK_SYSMETA_PREFIX):]: json.loads(v)
+                 for k, v in properties.items()
+                 if k.startswith(CHUNK_SYSMETA_PREFIX)}
+    return qualities
 
 
 def extract_content_headers_meta(headers):
@@ -586,6 +595,7 @@ class ContainerClient(ProxyClient):
             chunks = body['chunks']
             obj_meta = extract_content_headers_meta(resp.headers)
             obj_meta['properties'] = dict()
+            # pylint: disable=no-member
             obj_meta['properties'].update(body.get('properties', {}))
         except exceptions.NotFound:
             # Proxy does not support v2 request (oio < 4.3)

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -29,8 +29,18 @@ SYSMETA_KEYS = ("chunk-method", "ctime", "mtime", "deleted", "hash",
 CHUNK_SYSMETA_PREFIX = '__OIO_CHUNK__'
 
 
-def extract_chunk_qualities(properties):
-    """Extract chunk quality information from a dictionary of properties."""
+def extract_chunk_qualities(properties, raw=False):
+    """
+    Extract chunk quality information from a dictionary (or a list)
+    of properties.
+
+    :param properties: properties object.
+    :param raw: False if `properties` is a dictionary, True if
+        `properties` is a list of "raw" properties.
+    """
+    if raw:
+        properties = {x['key']: x['value']
+                      for x in properties}
     qualities = {k[len(CHUNK_SYSMETA_PREFIX):]: json.loads(v)
                  for k, v in properties.items()
                  if k.startswith(CHUNK_SYSMETA_PREFIX)}

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -49,7 +49,7 @@ class ECContent(Content):
         broken_list = list()
         if not allow_same_rawx and chunk_id is not None:
             broken_list.append(current_chunk)
-        spare_url = self._get_spare_chunk(chunks.all(), broken_list)
+        spare_url, _quals = self._get_spare_chunk(chunks.all(), broken_list)
         new_chunk = Chunk({'pos': current_chunk.pos, 'url': spare_url[0]})
 
         # Regenerate the lost chunk's data, from existing chunks

--- a/oio/content/factory.py
+++ b/oio/content/factory.py
@@ -34,12 +34,12 @@ class ContentFactory(object):
         self.blob_client = BlobClient(conf, **kwargs)
 
     def _get(self, container_id, meta, chunks,
-             account=None, container_name=None):
+             account=None, container_name=None, **kwargs):
         chunk_method = meta['chunk_method']
         storage_method = STORAGE_METHODS.load(chunk_method)
         if not account or not container_name:
             container_info = self.container_client.container_get_properties(
-                cid=container_id)['system']
+                cid=container_id, **kwargs)['system']
             if not account:
                 account = container_info['sys.account']
             if not container_name:
@@ -52,28 +52,31 @@ class ContentFactory(object):
                    logger=self.logger)
 
     def get(self, container_id, content_id, account=None,
-            container_name=None):
+            container_name=None, **kwargs):
         try:
             meta, chunks = self.container_client.content_locate(
-                cid=container_id, content=content_id)
+                cid=container_id, content=content_id, **kwargs)
         except NotFound:
             raise ContentNotFound("Content %s/%s not found" % (container_id,
                                   content_id))
 
         return self._get(container_id, meta, chunks,
-                         account=account, container_name=container_name)
+                         account=account, container_name=container_name,
+                         **kwargs)
 
     def get_by_path_and_version(self, container_id, path, version,
-                                account=None, container_name=None):
+                                account=None, container_name=None,
+                                **kwargs):
         try:
             meta, chunks = self.container_client.content_locate(
-                cid=container_id, path=path, version=version)
+                cid=container_id, path=path, version=version, **kwargs)
         except NotFound:
             raise ContentNotFound("Content %s/%s/%s not found" % (container_id,
                                   path, str(version)))
 
         return self._get(container_id, meta, chunks,
-                         account=account, container_name=container_name)
+                         account=account, container_name=container_name,
+                         **kwargs)
 
     def new(self, container_id, path, size, policy, account=None,
             container_name=None, **kwargs):

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -71,7 +71,9 @@ class PlainContent(Content):
         broken_list = list()
         if not allow_same_rawx and chunk_id is not None:
             broken_list.append(current_chunk)
-        spare_url = self._get_spare_chunk(duplicate_chunks, broken_list)[0]
+        spare_urls, _quals = self._get_spare_chunk(
+            duplicate_chunks, broken_list)
+        spare_url = spare_urls[0]
 
         # Actually create the spare chunk, by duplicating a good one
         uploaded = False

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -703,7 +703,7 @@ class BeanstalkdSender(TubedBeanstalkd):
         self.nb_jobs = 0
         self.nb_jobs_lock = threading.Lock()
 
-    def send_job(self, job, **kwargs):
+    def send_job(self, job, priority=DEFAULT_PRIORITY, delay=0, **kwargs):
         """
         Send a job, if the queue has not reached its size limit.
 
@@ -722,7 +722,8 @@ class BeanstalkdSender(TubedBeanstalkd):
                 self._connect(**kwargs)
 
             with self.nb_jobs_lock:
-                job_id = self.beanstalkd.put(job)
+                job_id = self.beanstalkd.put(
+                    job, priority=priority, delay=delay)
                 self.nb_jobs += 1
                 if self.nb_jobs >= self.high_limit:
                     self.accepts_jobs = False

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -14,9 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from oio.common.green import eventlet, Timeout, greenthread
+from oio.common.green import eventlet, Timeout, greenthread, time
 
-import time
 import signal
 import os
 import sys

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -108,18 +108,6 @@ class Worker(object):
             self.logger.warn("parent changed, shutting down")
             return False
         return True
-
-
-class EventTypes(object):
-    ACCOUNT_SERVICES = 'account.services'
-    CHUNK_NEW = 'storage.chunk.new'
-    CHUNK_DELETED = 'storage.chunk.deleted'
-    CONTAINER_NEW = 'storage.container.new'
-    CONTAINER_DELETED = 'storage.container.deleted'
-    CONTAINER_STATE = 'storage.container.state'
-    CONTENT_BROKEN = 'storage.content.broken'
-    CONTENT_NEW = 'storage.content.new'
-    CONTENT_DELETED = 'storage.content.deleted'
 
 
 def _stop(client, server):

--- a/oio/event/evob.py
+++ b/oio/event/evob.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -72,6 +72,21 @@ class EventException(Response, Exception):
     def __init__(self, *args, **kwargs):
         Response.__init__(self, *args, **kwargs)
         Exception.__init__(self, self.status)
+
+
+class EventTypes(object):
+    """Enum class for event type names."""
+
+    ACCOUNT_SERVICES = 'account.services'
+    CHUNK_DELETED = 'storage.chunk.deleted'
+    CHUNK_NEW = 'storage.chunk.new'
+    CONTAINER_DELETED = 'storage.container.deleted'
+    CONTAINER_NEW = 'storage.container.new'
+    CONTAINER_STATE = 'storage.container.state'
+    CONTENT_BROKEN = 'storage.content.broken'
+    CONTENT_DELETED = 'storage.content.deleted'
+    CONTENT_NEW = 'storage.content.new'
+    CONTENT_PERFECTIBLE = 'storage.content.perfectible'
 
 
 class StatusMap(object):

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -16,8 +16,7 @@
 
 from oio.common.exceptions import ClientException, OioTimeout
 from oio.account.client import AccountClient
-from oio.event.evob import Event, EventError
-from oio.event.consumer import EventTypes
+from oio.event.evob import Event, EventError, EventTypes
 from oio.event.filters.base import Filter
 
 

--- a/oio/event/filters/content_cleaner.py
+++ b/oio/event/filters/content_cleaner.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,8 +15,7 @@
 
 
 from oio.blob.client import BlobClient
-from oio.event.evob import Event
-from oio.event.consumer import EventTypes
+from oio.event.evob import Event, EventTypes
 from oio.event.filters.base import Filter
 from oio.common.exceptions import OioException
 from oio.api.backblaze import BackblazeDeleteHandler

--- a/oio/event/filters/volume_index.py
+++ b/oio/event/filters/volume_index.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,8 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from oio.event.evob import Event, EventError
-from oio.event.consumer import EventTypes
+from oio.event.evob import Event, EventError, EventTypes
 from oio.event.filters.base import Filter
 from oio.common.exceptions import OioException, VolumeException
 

--- a/oio/event/filters/webhook.py
+++ b/oio/event/filters/webhook.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -18,8 +18,7 @@ from oio.common import exceptions
 from oio.common.http_urllib3 import urllib3, get_pool_manager, \
     oio_exception_from_httperror
 from oio.common.json import json
-from oio.event.evob import Event, EventError
-from oio.event.consumer import EventTypes
+from oio.event.evob import Event, EventError, EventTypes
 from oio.event.filters.base import Filter
 from oio.container.client import ContainerClient
 

--- a/oio/rebuilder/blob_improver.py
+++ b/oio/rebuilder/blob_improver.py
@@ -1,0 +1,182 @@
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+
+from oio.rebuilder.rebuilder import Rebuilder, RebuilderWorker
+from oio.common import exceptions
+from oio.common.fullpath import encode_fullpath
+from oio.common.json import json
+from oio.content.factory import ContentFactory
+from oio.event.beanstalk import BeanstalkdListener
+
+# TODO(FVE): move to a relevant module
+CONTENT_PERFECTIBLE = 'storage.content.perfectible'
+DEFAULT_IMPROVER_TUBE = 'oio-improve'
+
+
+class BlobImprover(Rebuilder):
+    """
+    Move chunks of objects declared as "perfectible",
+    if possible to improve them (increased distance between chunks or
+    better hosting service).
+    """
+
+    supported_events = (CONTENT_PERFECTIBLE, )
+
+    def __init__(self, conf, logger, beanstalkd_addr, **kwargs):
+        super(BlobImprover, self).__init__(conf, logger, volume=None, **kwargs)
+        self.content_factory = ContentFactory(self.conf, logger=self.logger)
+        beanstalkd_tube = self.conf.get('beanstalkd_tube',
+                                        DEFAULT_IMPROVER_TUBE)
+        self.listener = BeanstalkdListener(beanstalkd_addr, beanstalkd_tube,
+                                           self.logger, **kwargs)
+
+    def _event_from_job(self, job_id, data, **kwargs):
+        # pylint: disable=no-member
+        event = json.loads(data)
+        type_ = event.get('event')
+        if type_ not in self.__class__.supported_events:
+            msg = 'Discarding event %s (type=%s)' % (
+                event.get('job_id'), type_)
+            self.logger.info(msg)
+            raise exceptions.ExplicitBury(msg)
+        yield event
+
+    def _create_worker(self, **kwargs):
+        return BlobImproverWorker(self, **kwargs)
+
+    def _fill_queue(self, queue, **kwargs):
+        events = self.listener.fetch_jobs(self._event_from_job, **kwargs)
+        for event in events:
+            queue.put(event)
+
+    def _item_to_string(self, item, **kwargs):
+        url = item['url']
+        fullpath = encode_fullpath(
+            url['account'], url['user'], url['path'],
+            url.get('version'), url['content'])
+        # TODO(FVE): maybe tell some numbers about chunks
+        if item.get('event') == CONTENT_PERFECTIBLE:
+            return 'perfectible object %s' % (fullpath, )
+        else:
+            return 'object %s' % (fullpath, )
+
+    def _get_report(self, status, end_time, counters, **kwargs):
+        items_processed, errors, total_items_processed, total_errors = counters
+        time_since_last_report = (end_time - self.last_report) or 0.00001
+        total_time = (end_time - self.start_time) or 0.00001
+        return ('%(status)s volume=%(volume)s '
+                'last_report=%(last_report)s %(time_since_last_report).2fs '
+                'chunks=%(chunks)d %(chunks_rate).2f/s '
+                'errors=%(errors)d %(errors_rate).2f%% '
+                'start_time=%(start_time)s %(total_time).2fs '
+                'total_chunks=%(total_chunks)d '
+                '%(total_chunks_rate).2f/s '
+                'total_errors=%(total_errors)d %(total_errors_rate).2f%%' % {
+                    'status': status,
+                    'volume': self.volume,
+                    'last_report': datetime.fromtimestamp(
+                        int(self.last_report)).isoformat(),
+                    'time_since_last_report': time_since_last_report,
+                    'chunks': items_processed,
+                    'chunks_rate':
+                        items_processed / time_since_last_report,
+                    'errors': errors,
+                    'errors_rate':
+                        100 * errors / float(items_processed or 1),
+                    'start_time': datetime.fromtimestamp(
+                        int(self.start_time)).isoformat(),
+                    'total_time': total_time,
+                    'total_chunks': total_items_processed,
+                    'total_chunks_rate':
+                        total_items_processed / total_time,
+                    'total_errors': total_errors,
+                    'total_errors_rate': 100 * total_errors /
+                        float(total_items_processed or 1)
+                })
+
+
+class BlobImproverWorker(RebuilderWorker):
+
+    def __init__(self, rebuilder, **kwargs):
+        super(BlobImproverWorker, self).__init__(rebuilder, **kwargs)
+
+    @property
+    def content_factory(self):
+        return self.rebuilder.content_factory
+
+    def move_perfectible_from_event(self, event, dry_run=False, **kwargs):
+        """
+        Move one or more "perfectible" chunks described in a
+        "storage.content.perfectible" event.
+        """
+        url = event['url']
+        # There are chances that the set of chunks of the object has
+        # changed between the time the event has been emitted and now.
+        # It seems a good idea to reload the object metadata and compare.
+        content = self.content_factory.get(url['id'], url['content'],
+                                           account=url.get('account'),
+                                           container_name=url.get('user'))
+        fullpath = encode_fullpath(url['account'], url['user'], url['path'],
+                                   url.get('version'), url['content'])
+        for chunk in event['data']['chunks']:
+            found = content.chunks.filter(url=chunk['id']).one()
+            if not found:
+                raise exceptions.PreconditionFailed(
+                    "Chunk %s not found in %s" % (chunk['id'], fullpath))
+            # Chunk quality information is not saved along with object
+            # metadata, thus we must fill it now.
+            found.quality = chunk['quality']
+
+        moveable = dict()
+        for chunk in content.chunks:
+            imperfections = chunk.imperfections
+            n_imp = len(imperfections)
+            if n_imp > 0:
+                moveable.setdefault(n_imp, list()).append(chunk)
+
+        moves = list()
+        errors = list()
+        for n_imperfections, chunks in moveable.items():
+            self.logger.debug("Chunks with %d imperfections: %s",
+                              n_imperfections, chunks)
+            for chunk in chunks:
+                try:
+                    src = str(chunk.url)
+                    self.logger.debug("Working on %s: %s",
+                                      src, chunk.imperfections)
+                    dst = content.move_chunk(chunk, check_quality=True,
+                                             dry_run=dry_run, **kwargs)
+                    self.logger.debug("%s replaced by %s", src, dst['url'])
+                    moves.append((src, dst))
+                except exceptions.OioException as err:
+                    self.logger.warn("Could not improve %s: %s", chunk, err)
+                    errors.append(err)
+        return moves, errors
+
+    def _rebuild_one(self, item, **kwargs):
+        moves, errors = self.move_perfectible_from_event(item, **kwargs)
+        if errors:
+            if not moves:
+                raise exceptions.FaultyChunk(
+                    'Could not improve any chunk: %s', errors)
+            else:
+                self.logger.info(
+                    'Some chunks of %s have not been improved: %s',
+                    self.rebuilder._item_to_string(item), errors)
+        else:
+            for move in moves:
+                self.logger.debug('%s moved to %s', move[0], move[1])

--- a/oio/rebuilder/rebuilder.py
+++ b/oio/rebuilder/rebuilder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,10 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from oio.common.green import ratelimit, eventlet, threading, ContextPool
-
 import random
-import time
+from oio.common.green import ratelimit, eventlet, threading, ContextPool, time
 
 from oio.common.easy_value import int_value
 from oio.common.logger import get_logger
@@ -25,7 +23,7 @@ from oio.common.logger import get_logger
 
 class Rebuilder(object):
     """
-    Base class for rebuilders.
+    Base class for rebuilders or movers.
     Subclass and implement
       `_create_worker()`
       `_fill_queue()`
@@ -73,6 +71,9 @@ class Rebuilder(object):
         return self.total_errors == 0
 
     def _create_worker(self, **kwargs):
+        """
+        Spawn a worker, subclass of `RebuilderWorker`.
+        """
         raise NotImplementedError()
 
     def _fill_queue(self, queue, **kwargs):
@@ -83,6 +84,9 @@ class Rebuilder(object):
         raise NotImplementedError()
 
     def _item_to_string(self, item, **kwargs):
+        """
+        Pretty-print an item that is being worked on.
+        """
         raise NotImplementedError()
 
     def _update_processed_without_lock(self, info, error=None, **kwargs):
@@ -130,7 +134,7 @@ class Rebuilder(object):
 
 class RebuilderWorker(object):
     """
-    Base class for rebuilder workers.
+    Base class for rebuilder or mover workers.
     Subclass and implement `_rebuild_one()`.
     """
 

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -2908,12 +2908,10 @@ enum http_rc_e action_content_touch (struct req_args_s *args) {
 // POST /v3.0/{NS}/content/spare?acct={account_name}&ref={container_name}&path={file_path}
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
-// .. code-block:: text
+// Get spare chunk addresses, in order to replace broken or missing chunks.
+// Doesn't work with "single" storage policy.
 //
-//    {"notin": <list of actual chunk>, "broken": <list of broken chunk>}
-//
-//
-// Get other chunks if chunks are broken. Don't work with single storage policy
+// Sample request:
 //
 // .. code-block:: http
 //
@@ -2925,6 +2923,16 @@ enum http_rc_e action_content_touch (struct req_args_s *args) {
 //    x-oio-content-meta-id: 2996752DFD7205006B73F17AD315AA2B
 //    Content-Length: 182
 //    Content-Type: application/x-www-form-urlencoded
+//
+// .. code-block:: text
+//
+//    {
+//      "notin": <list of current chunks>,
+//      "broken": <list of broken chunks>
+//    }
+//
+//
+// Sample response:
 //
 // .. code-block:: http
 //

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ scripts =
     bin/oio-blob-registrator
     bin/oio-blob-auditor
     bin/oio-blob-mover
+    bin/oio-blob-improver
     bin/oio-blob-indexer
     bin/oio-blob-rebuilder
     bin/oio-blob-converter

--- a/tests/functional/content/test_content_perfectible.py
+++ b/tests/functional/content/test_content_perfectible.py
@@ -28,7 +28,7 @@ from oio.common.json import json
 from oio.event.beanstalk import ResponseError
 from oio.event.client import EventClient
 from oio.event.evob import Event
-from oio.rebuilder.blob_rebuilder import DEFAULT_IMPROVER_TUBE
+from oio.rebuilder.blob_improver import DEFAULT_IMPROVER_TUBE
 
 
 REASONABLE_EVENT_DELAY = 3.0

--- a/tests/functional/event/filters/test_filters.py
+++ b/tests/functional/event/filters/test_filters.py
@@ -112,9 +112,8 @@ class TestContentRebuildFilter(BaseTestCase):
         _, after = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
-        self.assertIs(chunk_created, self._is_chunks_created(chunks,
-                                                             after,
-                                                             missing_pos))
+        self.assertIs(chunk_created,
+                      self._is_chunks_created(chunks, after, missing_pos))
 
     def test_nothing_missing(self):
         content_name = "test_nothing_missing"
@@ -146,6 +145,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         for chunk in chunks:
@@ -167,6 +167,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         for chunk in chunks:
@@ -187,6 +188,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         for i in range(0, 2):
             chunks_to_remove.append(chunks.pop(0))
@@ -208,6 +210,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         for chunk in chunks:
@@ -228,6 +231,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         for i in range(0, 3):
             chunks_to_remove.append(chunks.pop(0))
@@ -250,6 +254,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(9))
         chunks_to_remove.append(chunks.pop(6))
@@ -276,6 +281,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         for chunk in chunks:
@@ -298,6 +304,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         for i in range(0, 3):
             chunks_to_remove.append(chunks.pop(0))
@@ -321,6 +328,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         chunks_to_remove.append(chunks.pop(3))
@@ -345,6 +353,7 @@ class TestContentRebuildFilter(BaseTestCase):
         meta, chunks = self.object_storage_api.object_locate(
                         container=self.container, obj=content_name,
                         account=self.account)
+        chunks = list(chunks)
         chunks_to_remove = []
         chunks_to_remove.append(chunks.pop(0))
         chunks_to_remove.append(chunks.pop(0))

--- a/tests/functional/event/test_events_emission.py
+++ b/tests/functional/event/test_events_emission.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,7 +19,8 @@ import json
 import time
 from oio.api.object_storage import ObjectStorageApi
 from oio.event.beanstalk import Beanstalk, ResponseError
-from oio.event.consumer import DEFAULT_TUBE, EventTypes
+from oio.event.consumer import DEFAULT_TUBE
+from oio.event.evob import EventTypes
 from oio.common.utils import cid_from_name
 from oio.container.client import ContainerClient
 from tests.utils import BaseTestCase

--- a/tests/unit/content/test_content_functions.py
+++ b/tests/unit/content/test_content_functions.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2018 OpenIO SAS, as part of
+# OpenIO Software Defined Storage
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import unittest
+
+from oio.common import exceptions
+from oio.content.content import compare_chunk_quality, \
+    ensure_better_chunk_qualities, Chunk
+
+
+CRAPPY = {u'expected_dist': 2, u'warn_dist': 1, u'final_dist': 1,
+          u'expected_slot': u'rawx-odd', u'final_slot': u'rawx'}
+PERFECT = {u'expected_dist': 2, u'warn_dist': 1, u'final_dist': 2,
+           u'expected_slot': u'rawx-odd', u'final_slot': u'rawx-odd'}
+SMALL_DIST = {u'expected_dist': 2, u'warn_dist': 1, u'final_dist': 1,
+              u'expected_slot': u'rawx-odd', u'final_slot': u'rawx-odd'}
+WRONG_SLOT = {u'expected_dist': 2, u'warn_dist': 1, u'final_dist': 2,
+              u'expected_slot': u'rawx-odd', u'final_slot': u'rawx'}
+
+
+class TestContentFunctions(unittest.TestCase):
+
+    def test_compare_chunk_quality_better(self):
+        self.assertGreater(compare_chunk_quality(CRAPPY, PERFECT), 0)
+        self.assertGreater(compare_chunk_quality(CRAPPY, SMALL_DIST), 0)
+        self.assertGreater(compare_chunk_quality(CRAPPY, WRONG_SLOT), 0)
+        self.assertGreater(compare_chunk_quality(SMALL_DIST, PERFECT), 0)
+        self.assertGreater(compare_chunk_quality(WRONG_SLOT, PERFECT), 0)
+
+    def test_compare_chunk_quality_same(self):
+        self.assertEqual(0, compare_chunk_quality(CRAPPY, CRAPPY))
+        self.assertEqual(0, compare_chunk_quality(PERFECT, PERFECT))
+        self.assertEqual(0, compare_chunk_quality(SMALL_DIST, SMALL_DIST))
+        self.assertEqual(0, compare_chunk_quality(WRONG_SLOT, WRONG_SLOT))
+
+    def test_compare_chunk_quality_worse(self):
+        self.assertLess(compare_chunk_quality(PERFECT, CRAPPY), 0)
+        self.assertLess(compare_chunk_quality(SMALL_DIST, CRAPPY), 0)
+        self.assertLess(compare_chunk_quality(WRONG_SLOT, CRAPPY), 0)
+        self.assertLess(compare_chunk_quality(PERFECT, SMALL_DIST), 0)
+        self.assertLess(compare_chunk_quality(PERFECT, WRONG_SLOT), 0)
+
+    def test_ensure_better_quality(self):
+        chunk0_data = {
+            "url": "http://127.0.0.1:6010/AABBCC",
+            "pos": "0", "size": 0,
+            "hash": "00000000000000000000000000000000",
+            'quality': CRAPPY
+        }
+        chunk1_data = {
+            "url": "http://127.0.0.2:6010/AABBDD",
+            "pos": "0", "size": 0,
+            "hash": "00000000000000000000000000000000",
+            'quality': SMALL_DIST
+        }
+        chunk2_data = {
+            "url": "http://127.0.0.3:6010/AABBEE",
+            "pos": "0", "size": 0,
+            "hash": "00000000000000000000000000000000",
+            'quality': PERFECT
+        }
+        chunk0 = Chunk(chunk0_data)
+        chunk1 = Chunk(chunk1_data)
+        chunk2 = Chunk(chunk2_data)
+
+        # OK, better quality
+        ensure_better_chunk_qualities([chunk0], {chunk1.url: chunk1.quality})
+        ensure_better_chunk_qualities([chunk0], {chunk2.url: chunk2.quality})
+        ensure_better_chunk_qualities([chunk1], {chunk2.url: chunk2.quality})
+
+        # Not OK, improvement is 1, threshold is 2
+        self.assertRaises(exceptions.SpareChunkException,
+                          ensure_better_chunk_qualities,
+                          [chunk0], {chunk1.url: chunk1.quality},
+                          threshold=2)
+        self.assertRaises(exceptions.SpareChunkException,
+                          ensure_better_chunk_qualities,
+                          [chunk1], {chunk2.url: chunk2.quality},
+                          threshold=2)
+
+        # OK, far better quality
+        ensure_better_chunk_qualities([chunk0], {chunk2.url: chunk2.quality},
+                                      threshold=2)
+
+    def test_ensure_better_quality_same(self):
+        chunk_data = {
+            "url": "http://127.0.0.1:6010/AABBCC",
+            "pos": "0", "size": 0,
+            "hash": "00000000000000000000000000000000",
+            'quality': CRAPPY
+        }
+        chunk = Chunk(chunk_data)
+
+        self.assertRaises(exceptions.SpareChunkException,
+                          ensure_better_chunk_qualities,
+                          [chunk], {chunk.url: chunk.quality})
+        # threshold=0 -> accept no improvement
+        ensure_better_chunk_qualities([chunk], {chunk.url: chunk.quality},
+                                      threshold=0)

--- a/tools/oio-rdir-harass.py
+++ b/tools/oio-rdir-harass.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # oio-rdir-harass.py
-# Copyright (C) 2016-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2017,2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -19,7 +19,7 @@
 import sys
 import time
 import random
-from oio.event.consumer import EventTypes
+from oio.event.evob import EventTypes
 from oio.conscience.client import ConscienceClient
 from oio.rdir.client import RdirClient
 


### PR DESCRIPTION
##### SUMMARY

- [x] Modify meta2's `get_conditioned_spare_chunks()` function to also return the quality of generated chunk addresses.
- [x] Modify Python API's `Content._get_spare_chunk()` method to compare this quality to the expected one, and retry the request a limited number of times in case of failure.
- [x] Move the "perfectible" chunk to its new place.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- meta2
- oio-proxy
- Python API
- oio-blob-rebuilder

##### SDS VERSION
```
openio 4.3.1.dev80
```


##### ADDITIONAL INFORMATION
Jira: R1810-28