### PR TITLE
Fix webhook and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
   - TEST_SUITE=worm
   - TEST_SUITE=build,unit,copyright,variables
   - TEST_SUITE=rebuilder,mover,with-service-id
+  - TEST_SUITE=webhook
+
 script:
   - sudo bash -c "echo '/tmp/core.%p.%E' > /proc/sys/kernel/core_pattern"
   - ulimit -c unlimited -S

--- a/etc/bootstrap-option-webhook.yml
+++ b/etc/bootstrap-option-webhook.yml
@@ -1,0 +1,2 @@
+webhook_enabled: true
+webhook_endpoint: http://localhost:9081

--- a/etc/event-handlers.conf-sample
+++ b/etc/event-handlers.conf-sample
@@ -2,6 +2,7 @@
 [handler:storage.content.new]
 # pipeline = replication
 pipeline =
+# pipeline = webhook
 
 [handler:storage.content.update]
 # pipeline = replication
@@ -10,6 +11,7 @@ pipeline =
 [handler:storage.content.append]
 # pipeline = replication
 pipeline =
+# pipeline = webhook
 
 [handler:storage.content.broken]
 pipeline = content_rebuild
@@ -21,6 +23,7 @@ pipeline = content_cleaner
 [handler:storage.content.drained]
 # pipeline = content_cleaner replication
 pipeline = content_cleaner
+# pipeline = webhook content_cleaner
 
 [handler:storage.content.perfectible]
 pipeline = content_improve

--- a/oio/event/consumer.py
+++ b/oio/event/consumer.py
@@ -121,6 +121,7 @@ class EventTypes(object):
     CONTENT_BROKEN = 'storage.content.broken'
     CONTENT_NEW = 'storage.content.new'
     CONTENT_DELETED = 'storage.content.deleted'
+    CONTENT_APPEND = 'storage.content.append'
 
 
 def _stop(client, server):

--- a/oio/event/filters/webhook.py
+++ b/oio/event/filters/webhook.py
@@ -69,7 +69,8 @@ class WebhookFilter(Filter):
                 'version': alias['version'],
                 'metadata': properties,
             })
-        else:
+        elif event.event_type not in (EventTypes.CONTENT_DELETED,
+                                      EventTypes.CONTENT_APPEND):
             all_properties = self.container_client.content_get_properties(
                 account=url['account'], reference=url['user'],
                 content=url['content'])

--- a/tests/functional/event/test_webhook.py
+++ b/tests/functional/event/test_webhook.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import time
+
+from oio.common.http_urllib3 import get_pool_manager
+from oio.common.json import json
+from oio.api.object_storage import ObjectStorageApi
+
+from tests.utils import BaseTestCase
+
+
+class TestMeta2EventsEmission(BaseTestCase):
+    def setUp(self):
+        super(TestMeta2EventsEmission, self).setUp()
+        if not self.conf.get('webhook', ''):
+            self.skipTest('webhook is required')
+
+        self.acct = 'AccountWebhook%f' % time.time()
+        self.cnt_name = 'TestWebhookEvents%f' % time.time()
+        self.obj_name = 'obj%f' % time.time()
+        self.storage_api = ObjectStorageApi(self.ns)
+        self.pool = get_pool_manager()
+        self._clean()
+
+    def _get(self, success=True, timeout=2, event_id=None):
+        path = '%s/%s/%s' % (self.acct, self.cnt_name, self.obj_name)
+        start = time.time()
+        while time.time() - start < timeout:
+            res = self.pool.request('GET', 'http://127.0.0.1:9081/' + path)
+            if success and res.status == 200:
+                obj = json.loads(res.data)
+                if not event_id or event_id < obj['eventId']:
+                    return res, obj
+            if not success and res.status == 404:
+                return res, None
+
+            time.sleep(0.1)
+        # fixme
+        assert("Timeout waiting webhook event")
+
+    def _clean(self):
+        self.pool.request('POST', 'http://127.0.0.1:9081/PURGE')
+
+    def _add(self, data, properties=None):
+        self.storage_api.object_create(self.acct, self.cnt_name,
+                                       data=data, obj_name=self.obj_name,
+                                       properties=properties)
+        ret, data = self._get()
+        self.assertEqual(ret.status, 200)
+        return ret, data
+
+    def _remove(self):
+        self.storage_api.object_delete(self.acct, self.cnt_name, self.obj_name)
+        ret, data = self._get(success=False)
+        self.assertEqual(ret.status, 404)
+        return ret, data
+
+    def test_content_add(self):
+        content = "XXX"
+        ret, data = self._add(content)
+        self.assertEqual(data['data']['account'], self.acct)
+        self.assertEqual(data['data']['container'], self.cnt_name)
+        self.assertEqual(data['data']['name'], self.obj_name)
+        self.assertEqual(data['data']['size'], len(content))
+
+    def test_content_add_with_metadata(self):
+        properties = {'key1': 'val1'}
+        ret, data = self._add(data="XXX", properties=properties)
+        self.assertEqual(data['data']['account'], self.acct)
+        self.assertEqual(data['data']['container'], self.cnt_name)
+        self.assertEqual(data['data']['name'], self.obj_name)
+        self.assertEqual(data['data']['metadata'], properties)
+
+    def test_content_update_metadata(self):
+        properties = {'key1': 'val1'}
+        ret, data = self._add(data="XXX", properties=properties)
+        self.assertEqual(data['data']['metadata'], properties)
+
+        properties = {'key1': 'NEWVAL'}
+        self.storage_api.object_set_properties(
+            self.acct, self.cnt_name,
+            self.obj_name, properties)
+
+        event_id = data['eventId']
+        res, data = self._get(event_id=event_id)
+        self.assertEqual(res.status, 200)
+        self.assertGreater(data['eventId'], event_id)
+        self.assertEqual(data['data']['metadata'], properties)
+
+    def test_content_remove(self):
+        self._add("XX")
+        self._remove()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -50,4 +50,5 @@ install(PROGRAMS
 			oio-test-config.py
 			oio-reset.sh
 			oio-dump-buried-events.py
+            oio-webhook-test.py
         DESTINATION bin)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -786,7 +786,7 @@ pipeline = ${WEBHOOK}
 
 [handler:storage.content.append]
 # pipeline = replication
-pipeline = noop
+pipeline = ${WEBHOOK} noop
 
 [handler:storage.content.broken]
 pipeline = content_rebuild
@@ -1611,6 +1611,7 @@ def generate(options):
     final_conf['config'] = options['config']
     final_conf['with_service_id'] = options['with_service_id']
     final_conf['random_service_id'] = bool(options['random_service_id'])
+    final_conf['webhook'] = WEBHOOK_ENDPOINT
     with open('{CFGDIR}/test.yml'.format(**ENV), 'w+') as f:
         f.write(yaml.dump(final_conf))
     return final_conf

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -778,11 +778,11 @@ queue_url=${QUEUE_URL}
 template_event_agent_handlers = """
 [handler:storage.content.new]
 # pipeline = replication
-pipeline = noop
+pipeline = ${WEBHOOK}
 
 [handler:storage.content.update]
 # pipeline = replication webhook
-pipeline = noop
+pipeline = ${WEBHOOK}
 
 [handler:storage.content.append]
 # pipeline = replication
@@ -793,7 +793,7 @@ pipeline = content_rebuild
 
 [handler:storage.content.deleted]
 # pipeline = content_cleaner replication
-pipeline = content_cleaner
+pipeline = ${WEBHOOK} content_cleaner
 
 [handler:storage.content.drained]
 # pipeline = content_cleaner replication
@@ -844,6 +844,7 @@ use = egg:oio#volume_index
 
 [filter:webhook]
 use = egg:oio#webhook
+endpoint = ${WEBHOOK_ENDPOINT}
 
 [filter:replication]
 use = egg:oio#notify
@@ -1140,6 +1141,8 @@ def generate(options):
     want_service_id = '' if options.get('with_service_id') else '#'
 
     DATADIR = options.get('DATADIR', SDSDIR + '/data')
+    WEBHOOK = 'webhook' if options.get('webhook_enabled', False) else ''
+    WEBHOOK_ENDPOINT = options.get('webhook_endpoint', '')
 
     key_file = options.get(KEY_FILE, CFGDIR + '/' + 'application_keys.cfg')
     ENV = dict(ZK_CNXSTRING=options.get('ZK'),
@@ -1178,7 +1181,9 @@ def generate(options):
                KEY_FILE=key_file,
                HTTPD_BINARY=HTTPD_BINARY,
                META_HEADER=META_HEADER,
-               WANT_SERVICE_ID=want_service_id)
+               WANT_SERVICE_ID=want_service_id,
+               WEBHOOK=WEBHOOK,
+               WEBHOOK_ENDPOINT=WEBHOOK_ENDPOINT)
 
     def merge_env(add):
         env = dict(ENV)

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -342,6 +342,12 @@ if is_running_test_suite "multi-beanstalk" ; then
 		-f "${SRCDIR}/etc/bootstrap-option-3beanstalkd.yml"
 fi
 
+if is_running_test_suite "webhook" ; then
+	echo -e "\n### with webhooks"
+	func_tests -f "${SRCDIR}/etc/bootstrap-preset-SINGLE.yml" \
+        -f "${SRCDIR}/etc/bootstrap-option-webhook.yml"
+fi
+
 func_tests_rebuilder_mover () {
 	randomize_env
 	args=

--- a/tools/oio-webhook-test.py
+++ b/tools/oio-webhook-test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+# oio-webhook-test.py
+# Copyright (C) 2015-2019 OpenIO SAS, original work as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import BaseHTTPServer
+import SocketServer
+import argparse
+import json
+import socket
+
+PORT = 9081
+DATA = {}
+
+
+class MyTCPServer(SocketServer.TCPServer):
+    def server_bind(self):
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.socket.bind(self.server_address)
+
+
+class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+
+    def do_POST(self):
+        global DATA
+
+        if self.path == '/PURGE':
+            DATA = {}
+            self.send_response(200)
+            return
+
+        content_len = int(self.headers.getheader('content-length', 0))
+        body = json.loads(self.rfile.read(content_len))
+
+        name = '/'.join([body['data']['account'], body['data']['container'],
+                         body['data']['name']])
+        if body['eventType'] in ('storage.content.new',
+                                 'storage.content.update'):
+            DATA[name] = body
+        elif body['eventType'] == 'storage.content.deleted':
+            if name in DATA:
+                del DATA[name]
+        else:
+            self.send_response(400)
+            return
+
+        self.send_response(200)
+
+    def do_GET(self):
+        path = self.path.strip('/')
+
+        if not path:
+            data = json.dumps(DATA.keys())
+        else:
+            data = DATA.get(self.path.strip('/'), None)
+
+        if data:
+            body = json.dumps(data)
+            self.send_response(200)
+            self.send_header('Content-Length', len(body))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+
+
+def options():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--port", type=int, default=PORT,
+        help="Port to listen")
+    return parser.parse_args()
+
+
+def main():
+    opts = options()
+    httpd = MyTCPServer(("", opts.port), MyHandler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
##### SUMMARY

Webhook was too aggressive on few events, with this PR, webhook will skip retrieving properties on `storage.content.deleted` event.

It also skip `storage.content.append` event due to invalid `content` received and no version available in event data, it is not possible to retrieve properties nor size. 

Fixes OS-235

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- event-handler

##### SDS VERSION
```
4.3.x
```

##### ADDITIONAL INFORMATION
