### PR TITLE
meta2: fix order of events

### DIFF
--- a/meta2v2/meta2_filters_action_content.c
+++ b/meta2v2/meta2_filters_action_content.c
@@ -286,10 +286,10 @@ meta2_filter_action_put_content(struct gridd_filter_ctx_s *ctx,
 		meta2_filter_ctx_set_error(ctx, e);
 		rc = FILTER_KO;
 	} else {
-		_m2b_notify_beans(m2b, url, added, "content.new", FALSE);
 		for (GSList *l=deleted; l; l=l->next) {
 			_m2b_notify_beans(m2b, url, l->data, "content.deleted", TRUE);
 		}
+		_m2b_notify_beans(m2b, url, added, "content.new", FALSE);
 		_on_bean_ctx_send_list(obc);
 		rc = FILTER_OK;
 	}


### PR DESCRIPTION
##### SUMMARY

Fix invalid events order when replacing an object
Thanks to contributors that exhibit this issue !

Fixes OS-253

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meta2

##### SDS VERSION
```
4.2.x
```
