### PR TITLE
sqliterepo: Fix a file descriptor leak

### DIFF
--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1446,7 +1446,7 @@ sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 	EXTRA_ASSERT(sq3 != NULL);
 	EXTRA_ASSERT(read_file_cb != NULL);
 
-	do {
+	for (;;) {
 		/* First try to dump on local volume, on error try /tmp */
 		g_snprintf(path, sizeof(path), "%s/tmp/dump.sqlite3.XXXXXX",
 				try_slash_tmp? "" : sq3->repo->basedir);
@@ -1481,7 +1481,7 @@ sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 		} else {
 			break;
 		}
-	} while (1);
+	}
 
 	if (!err) {
 		err = read_file_cb(fd, cb_arg);

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1433,15 +1433,6 @@ _read_file(int fd, GByteArray *gba)
 }
 
 GError*
-sqlx_repository_backup_base(struct sqlx_sqlite3_s *src_sq3,
-		struct sqlx_sqlite3_s *dst_sq3)
-{
-	EXTRA_ASSERT(src_sq3 != NULL);
-	EXTRA_ASSERT(dst_sq3 != NULL);
-	return _backup_main(src_sq3->db, dst_sq3->db);
-}
-
-GError*
 sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 		dump_base_fd_cb read_file_cb, gpointer cb_arg)
 {

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1438,7 +1438,7 @@ sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 {
 	gchar path[LIMIT_LENGTH_VOLUMENAME+32] = {0};
 	gboolean try_slash_tmp = FALSE;
-	int rc, fd;
+	int rc, fd = -1;
 	sqlite3 *dst = NULL;
 	GError *err = NULL;
 
@@ -1447,6 +1447,8 @@ sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 	EXTRA_ASSERT(read_file_cb != NULL);
 
 	for (;;) {
+		EXTRA_ASSERT(fd < 0);
+
 		/* First try to dump on local volume, on error try /tmp */
 		g_snprintf(path, sizeof(path), "%s/tmp/dump.sqlite3.XXXXXX",
 				try_slash_tmp? "" : sq3->repo->basedir);
@@ -1477,6 +1479,7 @@ sqlx_repository_dump_base_fd(struct sqlx_sqlite3_s *sq3,
 			GRID_WARN("Failed to dump base into %s (%s), will try with /tmp",
 					path, err->message);
 			g_clear_error(&err);
+			metautils_pclose(&fd);
 			try_slash_tmp = TRUE;
 		} else {
 			break;

--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -300,11 +300,6 @@ typedef GError*(*dump_base_chunked_cb)(GByteArray *gba, gint64 remaining_bytes,
 GError* sqlx_repository_dump_base_chunked(struct sqlx_sqlite3_s *sq3,
 		gint chunk_size, dump_base_chunked_cb callback, gpointer callback_arg);
 
-/** Perform a SQLite backup on the sqlite handles underlying two sqliterepo
- * bases. */
-GError* sqlx_repository_backup_base(struct sqlx_sqlite3_s *src_sq3,
-		struct sqlx_sqlite3_s *dst_sq3);
-
 GError* sqlx_repository_restore_base(struct sqlx_sqlite3_s *sq3,
 		guint8 *raw, gsize rawsize);
 


### PR DESCRIPTION
##### SUMMARY
Prior to this fix, when a dump fails in the repository and there is a retry in /tmp, the FDof the attempt file in the repository is not closed, thus keeping the file present on the filesystem until the process is stopped.

In addition, an unused function has been removed.

##### ISSUE TYPE
Bugfix!

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.2.7.dev1`
