### PR TITLE
sqliterepo: Clean stale DB dumps

### DIFF
--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -154,6 +154,10 @@ GError * sqlx_repository_init(const gchar *vol,
 		const struct sqlx_repo_config_s *cfg,
 		sqlx_repository_t **result);
 
+/* The cleanup is not performed during the sqlx_repository_init() because we
+ * prefer ensuring we are the only process with an access granted. */
+void sqlx_repository_initial_cleanup(sqlx_repository_t *repo);
+
 /** Cleans all the structures associated with the given repository.
  * For security purposes, it internally calls sqlx_repository_stop(). */
 void sqlx_repository_clean(sqlx_repository_t *repo);

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -789,6 +789,8 @@ sqlx_service_action(void)
 		sqlx_peering_direct__set_udp(SRV.peering, fd_udp);
 	}
 
+	sqlx_repository_initial_cleanup(SRV.repository);
+
 	/* SERVER/GRIDD main run loop */
 	if (NULL != (err = network_server_run(SRV.server, _reconfigure_on_SIGHUP)))
 		return _action_report_error(err, "GRIDD run failure");


### PR DESCRIPTION
##### SUMMARY
Clean stale DB dumps at the startup of any sqliterepo-based service, when it owns the lock on the base directory.

##### ISSUE TYPE
Bugfix

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.2.6`