### PR TITLE
blob-rebuilder: use random delays to avoid request bursts

### DIFF
--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -58,6 +58,8 @@ tube for broken chunks events.
                         help="Number of workers (1)")
     parser.add_argument('--chunks-per-second', type=int,
                         help="Max chunks per second per worker (30)")
+    parser.add_argument("--random-wait", type=int,
+                        help="Random wait (in μs)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
     parser.add_argument('--allow-same-rawx', action='store_true',
@@ -122,6 +124,8 @@ def main():
         conf['workers'] = args.workers
     if args.chunks_per_second is not None:
         conf['items_per_second'] = args.chunks_per_second
+    if args.random_wait:
+        conf['random_wait'] = args.random_wait
 
     success = False
     try:

--- a/oio/rebuilder/rebuilder.py
+++ b/oio/rebuilder/rebuilder.py
@@ -16,6 +16,7 @@
 
 from oio.common.green import ratelimit, eventlet, ContextPool
 
+import random
 import time
 
 from oio.common.easy_value import int_value
@@ -123,6 +124,7 @@ class RebuilderWorker(object):
             conf.get('report_interval'), 3600)
         self.max_items_per_second = int_value(
             conf.get('items_per_second'), 30)
+        self.random_wait = conf.get('random_wait')
 
     def rebuilder_pass(self, num, queue, **kwargs):
         start_time = report_time = time.time()
@@ -149,6 +151,8 @@ class RebuilderWorker(object):
 
             self.items_run_time = ratelimit(self.items_run_time,
                                             self.max_items_per_second)
+            if self.random_wait:
+                eventlet.sleep(random.randint(0, self.random_wait) / 1.0e6)
 
     def _rebuild_one(self, item, **kwargs):
         """


### PR DESCRIPTION
##### SUMMARY


Default ratelimit tries to consume all events at start of
every second: when launching a lot of threads/instance, it
creates burst effects on cluster.

This commit introduce an option to add random wait after each chunk
rebuild, that take an argument to perform a [0, arg[ ms wait.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
oio-blob-rebuilder

##### SDS VERSION
```
4.2.x
```