### PR TITLE
Python API: document and use ServiceUnavailable exception

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -189,7 +189,9 @@ class ECChunkDownloadHandler(object):
             stream.start()
             return stream
         else:
-            raise exceptions.OioException("Not enough valid sources to read")
+            raise exceptions.ServiceUnavailable(
+                'Not enough valid sources to read (%d/%d)' % (
+                    len(readers), self.storage_method.ec_nb_data))
 
 
 class ECStream(object):

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -77,6 +77,10 @@ class UnrecoverableContent(ContentException):
 
 
 class ServiceUnavailable(OioException):
+    """
+    Exception raised when some services are temporarily
+    not available. This does not mean data is lost.
+    """
     pass
 
 

--- a/oio/common/storage_functions.py
+++ b/oio/common/storage_functions.py
@@ -210,7 +210,7 @@ def fetch_stream(chunks, ranges, storage_method, headers=None,
                     "Cannot download position %d: %s" %
                     (pos, err))
             except Exception as err:
-                raise exc.OioException(
+                raise exc.ServiceUnavailable(
                     "Error while downloading position %d: %s" %
                     (pos, err))
             for part in it:


### PR DESCRIPTION
##### SUMMARY
When appropriate, raise `ServiceUnavailable` exceptions instead of the more generic `OioException`. This will help client programs trap these exceptions and display appropriate error messages.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.2.7.dev16
```
