### PR TITLE
Test sqliterepo replication

### DIFF
--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS core library
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -215,6 +215,7 @@ int oio_str_caseprefixed(const char *str, const char *prefix);
 gboolean oio_str_is_number (const char *s, gint64 *pi64);
 
 int oio_str_cmp3 (const void *a, const void *b, void *ignored);
+int oio_str_casecmp3(const void *a, const void *b, void *ignored);
 
 /* Light wrappers around json-c, to return GLib errors */
 GError* JSON_parse_buffer (const guint8 *b, gsize l, struct json_object **o);

--- a/core/str.c
+++ b/core/str.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS core library
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -480,6 +480,10 @@ int oio_str_cmp3 (const void *a, const void *b, void *i UNUSED) {
 	return g_strcmp0 (a,b);
 }
 
+int oio_str_casecmp3(const void *a, const void *b, void *i UNUSED)
+{
+	return g_ascii_strcasecmp(a, b);
+}
 
 GError* JSON_parse_buffer (const guint8 *b, gsize l, struct json_object **o) {
 	EXTRA_ASSERT(o != NULL);

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -622,7 +622,7 @@ class MetachunkPreparer(object):
         while True:
             mc_pos += 1
             meta, next_body = self.container_client.content_prepare(
-                    self.account, self.container, self.obj_name, 1,
+                    self.account, self.container, self.obj_name, size=1,
                     stgpol=self.policy, **self.extra_kwargs)
             self.obj_meta['properties'].update(meta.get('properties', {}))
             self._fix_mc_pos(next_body, mc_pos)

--- a/oio/directory/admin.py
+++ b/oio/directory/admin.py
@@ -46,6 +46,7 @@ class AdminClient(ProxyClient):
     def __init__(self, conf, **kwargs):
         super(AdminClient, self).__init__(
             conf, request_prefix="/admin", **kwargs)
+        kwargs.pop('pool_manager', None)
         self.forwarder = ProxyClient(
             conf, request_prefix="/forward", pool_manager=self.pool_manager,
             no_ns_in_url=True, **kwargs)
@@ -222,3 +223,12 @@ class AdminClient(ProxyClient):
     def service_flush_cache(self, svc_id, **kwargs):
         """Flush the resolver cache of an sqlx-bases service."""
         self._forward_service_action(svc_id, '/flush', **kwargs)
+
+    def service_set_live_config(self, svc_id, config, **kwargs):
+        """
+        Set some configuration parameters on the specified service.
+        Works on all services using ASN.1 protocol.
+        Notice that some parameters may not be taken into account,
+        and no parameter will survice a service restart.
+        """
+        self._forward_service_action(svc_id, '/config', json=config, **kwargs)

--- a/proxy/common.c
+++ b/proxy/common.c
@@ -570,7 +570,10 @@ void client_init (struct client_ctx_s *ctx, struct req_args_s *args,
 	ctx->seq = seq;
 	sqlx_inline_name_fill_type_asis (&ctx->name, args->url,
 			*srvtype == '#' ? srvtype+1 : srvtype, ctx->seq);
-	ctx->which = CLIENT_PREFER_NONE;
+	if (SERVICE_ID())
+		ctx->which = CLIENT_SPECIFIED;
+	else
+		ctx->which = CLIENT_PREFER_NONE;
 }
 
 void client_clean (struct client_ctx_s *ctx) {

--- a/proxy/cs_actions.c
+++ b/proxy/cs_actions.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS proxy
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -139,51 +139,14 @@ conscience_remote_remove_services(gchar **allcs, const char *type, GSList *ls, g
 }
 
 GError *
-conscience_resolve_service_id(gchar **cs UNUSED, const char *type, const char *service_id, gchar **out) {
-	*out = NULL;
-
-	gchar *key = oio_make_service_key(ns_name, type, service_id);
-	struct oio_lb_item_s *item = oio_lb_world__get_item(lb_world, key);
-	g_free(key);
-	if (item) {
-		*out = g_strdup(item->addr);
+conscience_resolve_service_id(gchar **cs UNUSED, const char *type UNUSED,
+		const char *service_id, gchar **out)
+{
+	*out = oio_lb_resolve_service_id(service_id);
+	if (*out)
 		return NULL;
-	}
 
 	return NEWERROR(CODE_UNAVAILABLE, "Service ID [%s] not found", service_id);
-#if 0
-	GError *err = NULL;
-	GSList *sl = NULL;
-
-	/* FIXME: implement only direct request at this time */
-	err = conscience_remote_get_services (cs, type, FALSE, &sl, oio_ext_get_deadline());
-	if (err) {
-		g_slist_free_full (sl, (GDestroyNotify) service_info_clean);
-		return err;
-	}
-
-	/* FIXME: we should build a HASH table from Service ID to ADDR to find them quickly */
-	for (GSList *l = sl; l; l = l->next) {
-		const struct service_info_s *si = l->data;
-
-		if (si->tags && si->tags->len) {
-			for(guint i = 0; i < si->tags->len; ++i) {
-				struct service_tag_s *tag = si->tags->pdata[i];
-				if (g_strcmp0(tag->name, "tag.service_id") == 0 && g_strcmp0(tag->value.s, service_id) == 0) {
-					gchar straddr[STRLEN_ADDRINFO];
-					grid_addrinfo_to_string(&(si->addr), straddr, sizeof(straddr));
-					*out = g_strdup(straddr);
-
-					g_slist_free_full (sl, (GDestroyNotify) service_info_clean);
-					return NULL;
-				}
-			}
-		}
-	}
-
-	g_slist_free_full (sl, (GDestroyNotify) service_info_clean);
-	return NEWERROR(CODE_UNAVAILABLE, "Service ID [%s] not found", service_id);
-#endif
 }
 
 /* -------------------------------------------------------------------------- */

--- a/proxy/sqlx_actions.c
+++ b/proxy/sqlx_actions.c
@@ -94,7 +94,10 @@ _sqlx_action_noreturn (struct req_args_s *args, enum proxy_preference_e how,
 			ctx.name.base[i] = '0';
 	}
 
-	ctx.which = how;
+	if (SERVICE_ID())
+		ctx.which = CLIENT_SPECIFIED;
+	else
+		ctx.which = how;
 	enum http_rc_e rc = _sqlx_action_noreturn_TAIL (args, &ctx, pack);
 	client_clean(&ctx);
 	return rc;
@@ -335,11 +338,7 @@ enum http_rc_e
 action_admin_leave (struct req_args_s *args)
 {
 	PACKER_VOID(_pack) { return sqlx_pack_EXITELECTION (_u, DL()); }
-	const char *service_id = SERVICE_ID();
-	if (service_id)
-		return _sqlx_action_noreturn (args, CLIENT_SPECIFIED, _pack);
-	else
-		return _sqlx_action_noreturn (args, CLIENT_RUN_ALL, _pack);
+	return _sqlx_action_noreturn (args, CLIENT_RUN_ALL, _pack);
 }
 
 enum http_rc_e

--- a/sqliterepo/cache.c
+++ b/sqliterepo/cache.c
@@ -875,6 +875,7 @@ sqlx_cache_count(sqlx_cache_t *cache)
 	memset(&count, 0, sizeof(count));
 	if (cache) {
 		count.max = cache->bases_max_hard;
+		count.soft_max = cache->bases_max_soft;
 		count.cold = _count_beacon(cache, &cache->beacon_idle);
 		count.hot = _count_beacon(cache, &cache->beacon_idle_hot);
 		count.used = _count_beacon(cache, &cache->beacon_used);

--- a/sqliterepo/cache.h
+++ b/sqliterepo/cache.h
@@ -64,6 +64,7 @@ guint sqlx_cache_expire(sqlx_cache_t *cache, guint max, gint64 duration);
 struct cache_counts_s
 {
 	guint max;
+	guint soft_max;
 	guint cold;
 	guint hot;
 	guint used;

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -2361,6 +2361,8 @@ _info_cache(struct sqlx_repository_s *repo, GString *gstr)
 	g_string_append_static(gstr, "\"cache\":{");
 	oio_str_gstring_append_json_pair_int(gstr, "max", count.max);
 	g_string_append_c(gstr, ',');
+	oio_str_gstring_append_json_pair_int(gstr, "soft_max", count.soft_max);
+	g_string_append_c(gstr, ',');
 	oio_str_gstring_append_json_pair_int(gstr, "hot", count.hot);
 	g_string_append_c(gstr, ',');
 	oio_str_gstring_append_json_pair_int(gstr, "cold", count.cold);

--- a/sqliterepo/sqlite_utils.h
+++ b/sqliterepo/sqlite_utils.h
@@ -59,6 +59,7 @@ License along with this library.
 #define SQLX_ADMIN_USERNAME SQLX_ADMIN_PREFIX_SYS "user.name"
 #endif
 
+// Deprecated since oio-sds 4.4.0
 #ifndef SQLX_ADMIN_USERTYPE
 #define SQLX_ADMIN_USERTYPE SQLX_ADMIN_PREFIX_SYS "user.type"
 #endif

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -306,31 +306,9 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         data = self._get_properties(name)
         self.assertEqual(data['properties'], metadata)
 
-    def _wait_account_meta2(self, timeout=20.0, score_threshold=35):
-        # give account and meta2 time to catch their breath
-        wait = False
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            try:
-                for service in self.conscience.all_services("account"):
-                    if int(service['score']) < score_threshold:
-                        wait = True
-                        break
-                if not wait:
-                    for service in self.conscience.all_services("meta2"):
-                        if int(service['score']) < score_threshold:
-                            wait = True
-                            break
-                    if not wait:
-                        return
-            except exc.OioException as err:
-                logging.warn('Could not check service score: %s', err)
-            wait = False
-            time.sleep(1)
-
     def _flush_and_check(self, cname, fast=False):
         self.api.container_flush(self.account, cname, limit=50)
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         properties = self.api.container_get_properties(self.account, cname)
         self.assertEqual(properties['system']['sys.m2.objects'], '0')
         self.assertEqual(properties['system']['sys.m2.usage'], '0')
@@ -766,7 +744,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
     def test_container_refresh_user_not_found(self):
         self._wait_account_meta2()
         name = random_str(32)
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         self.api.account.container_update(name, name, {"mtime": time.time()})
         self.api.container_refresh(name, name)
         containers = self.api.container_list(name)
@@ -777,7 +755,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self._wait_account_meta2()
         # account_refresh on unknown account
         account = random_str(32)
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         self.assertRaises(
             exc.NoSuchAccount, self.api.account_refresh, account)
 

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -688,7 +688,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.blob_client.chunk_delete_many.assert_called_once()
 
     def test_container_refresh(self):
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         # FIXME(FVE): for this test to pass properly, we should implement
         # some kind of back notification mechanism, e.g. a tube where all
         # events are sent after being handled by event-agent.
@@ -742,7 +742,6 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(account)
 
     def test_container_refresh_user_not_found(self):
-        self._wait_account_meta2()
         name = random_str(32)
         self.wait_for_score(('account', 'meta2'))
         self.api.account.container_update(name, name, {"mtime": time.time()})
@@ -752,7 +751,6 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(name)
 
     def test_account_refresh(self):
-        self._wait_account_meta2()
         # account_refresh on unknown account
         account = random_str(32)
         self.wait_for_score(('account', 'meta2'))
@@ -790,7 +788,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
             exc.NoSuchAccount, self.api.account_refresh, account)
 
     def test_account_refresh_all(self):
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         # clear accounts
         accounts = self.api.account_list()
         for account in accounts:
@@ -822,7 +820,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(account2)
 
     def test_account_flush(self):
-        self._wait_account_meta2()
+        self.wait_for_score(('account', 'meta2'))
         # account_flush on unknown account
         account = random_str(32)
         self.assertRaises(

--- a/tests/functional/blob/test_auditor.py
+++ b/tests/functional/blob/test_auditor.py
@@ -36,7 +36,7 @@ class TestBlobAuditor(BaseTestCase):
 
         self.api.container_create(self.account, self.container)
         _, chunks = self.api.container.content_prepare(
-            self.account, self.container, self.path, 1)
+            self.account, self.container, self.path, size=1)
         services = self.conscience.all_services('rawx')
         self.rawx_volumes = dict()
         for rawx in services:

--- a/tests/functional/blob/test_converter.py
+++ b/tests/functional/blob/test_converter.py
@@ -42,7 +42,7 @@ class TestBlobConverter(BaseTestCase):
 
         self.api.container_create(self.account, self.container)
         _, chunks = self.api.container.content_prepare(
-            self.account, self.container, self.path, 1)
+            self.account, self.container, self.path, size=1)
         services = self.conscience.all_services('rawx')
         self.rawx_volumes = dict()
         for rawx in services:

--- a/tests/functional/blob/test_mover.py
+++ b/tests/functional/blob/test_mover.py
@@ -37,7 +37,7 @@ class TestBlobMover(BaseTestCase):
 
         self.api.container_create(self.account, self.container)
         _, chunks = self.api.container.content_prepare(
-            self.account, self.container, self.path, 1)
+            self.account, self.container, self.path, size=1)
         services = self.conscience.all_services('rawx')
         if len(chunks) >= len([s for s in services if s['score'] > 0]):
             self.skipTest("need at least %d rawx to run" % (len(chunks) + 1))

--- a/tests/functional/blob/test_rebuilder.py
+++ b/tests/functional/blob/test_rebuilder.py
@@ -38,7 +38,7 @@ class TestBlobRebuilder(BaseTestCase):
 
         self.api.container_create(self.account, self.container)
         _, chunks = self.api.container.content_prepare(
-            self.account, self.container, self.path, 1)
+            self.account, self.container, self.path, size=1)
         if len(chunks) < 2:
             self.skipTest("need at least 2 chunks to run")
 

--- a/tests/functional/container/test_replication.py
+++ b/tests/functional/container/test_replication.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import os
+import time
+from oio.api.object_storage import ObjectStorageApi
+from tests.utils import BaseTestCase, random_str
+
+
+class TestContainerReplication(BaseTestCase):
+    """
+    Test container replication, especially what happens when one copy
+    has missed some operations (service has been down and is back up),
+    or has been lost (database file deleted).
+    """
+
+    down_cache_opts = {'client.down_cache.avoid': 'false',
+                       'client.down_cache.shorten': 'true'}
+
+    def setUp(self):
+        super(TestContainerReplication, self).setUp()
+        if int(self.conf.get('container_replicas', 1)) < 3:
+            self.skipTest('Container replication must be enabled')
+        self.api = ObjectStorageApi(self.ns, pool_manager=self.http_pool)
+        self.must_restart_meta2 = False
+        self._apply_conf_on_all('meta2', self.__class__.down_cache_opts)
+        self.wait_for_score(('meta2', ))
+
+    @classmethod
+    def tearDownClass(cls):
+        # Be kind with the next test suites
+        cls._cls_reload_proxy()
+        time.sleep(3)
+        cls._cls_reload_meta()
+        time.sleep(1)
+
+    def tearDown(self):
+        # Start all services
+        self._service('@' + self.ns, 'start')
+        super(TestContainerReplication, self).tearDown()
+        # Restart meta2 after configuration has been reset by parent tearDown
+        if self.must_restart_meta2:
+            self._service('@meta2', 'restart', wait=2.0)
+
+    def _apply_conf_on_all(self, type_, conf):
+        all_svc = [x['addr'] for x in self.conf['services'][type_]]
+        for svc in all_svc:
+            self.admin.service_set_live_config(svc, conf)
+
+    def _synchronous_restore_allowed(self):
+        dump_max_size = int(self.ns_conf.get('sqliterepo.dump.max_size',
+                                             1073741824))
+        return dump_max_size
+
+    def _test_restore_after_missed_diff(self):
+        cname = 'test_restore_' + random_str(8)
+        # Create a container
+        self.api.container_create(self.account, cname)
+        # Locate the peers
+        peers = self.api.directory.list(self.account, cname,
+                                        service_type='meta2')
+        # Stop one peer
+        kept = peers['srv'][0]['host']
+        stopped = peers['srv'][1]['host']
+        self.api.logger.info('Stopping meta2 %s', stopped)
+        self._service(self.service_to_gridinit_key(stopped, 'meta2'), 'stop')
+        # Create an object
+        self.api.object_create_ext(self.account, cname,
+                                   obj_name=cname, data=cname)
+        # Start the stopped peer
+        self.api.logger.info('Starting meta2 %s', stopped)
+        # FIXME(FVE): review all the delays
+        self._service(self.service_to_gridinit_key(stopped, 'meta2'),
+                      'start', wait=2.0)
+        # Create another object
+        self.api.object_create_ext(self.account, cname,
+                                   obj_name=cname + '_2', data=cname)
+        # Check the database has been restored (after a little while)
+        ref_props = self.api.container_get_properties(
+            self.account, cname, params={'service_id': kept})
+        copy_props = self.api.container_get_properties(
+            self.account, cname, params={'service_id': stopped})
+        self.assertEqual(ref_props['system'], copy_props['system'])
+
+    def test_disabled_synchronous_restore(self):
+        """
+        Test what happens when the synchronous DB_RESTORE mechanism has been
+        disabled, and some operations have been missed by a slave.
+        """
+        allowed = self._synchronous_restore_allowed()
+        if allowed:
+            # Disable synchronous restore, restart all meta2 services
+            opts = {'sqliterepo.dump.max_size': 0}
+            opts.update(self.__class__.down_cache_opts)
+            self.set_ns_opts(opts)
+            self._apply_conf_on_all('meta2', opts)
+            self.must_restart_meta2 = True
+        self._test_restore_after_missed_diff()
+
+    def test_synchronous_restore(self):
+        """
+        Test DB_RESTORE mechanism (the master send a dump of the whole
+        database to one of the peers).
+        """
+        if not self._synchronous_restore_allowed():
+            self.skipTest('Synchronous replication is disabled')
+        self._test_restore_after_missed_diff()
+
+    def test_asynchronous_restore(self):
+        """
+        Test DB_DUMP/DB_PIPEFROM mechanism (a slave peer knows it needs
+        a fresh copy of the database and asks the master).
+        """
+        cname = 'test_pipefrom_' + random_str(8)
+        # Create a container
+        self.api.container_create(self.account, cname)
+        # Locate the peers
+        peers = self.api.directory.list(self.account, cname,
+                                        service_type='meta2')
+        # Stop one peer
+        kept = peers['srv'][0]['host']
+        stopped = peers['srv'][1]['host']
+        self.api.logger.info('Stopping meta2 %s', stopped)
+        self._service(self.service_to_gridinit_key(stopped, 'meta2'), 'stop')
+        # Delete the database
+        vol = [x['path'] for x in self.conf['services']['meta2']
+               if x.get('service_id', x['addr']) == stopped][0]
+        path = '/'.join((vol, peers['cid'][:3], peers['cid'] + '.1.meta2'))
+        self.api.logger.info('Removing %s', path)
+        os.remove(path)
+        # Start the stopped peer
+        self.api.logger.info('Starting meta2 %s', stopped)
+        self._service(self.service_to_gridinit_key(stopped, 'meta2'),
+                      'start', wait=2.0)
+        # Create an object (to trigger a database replication)
+        self.api.object_create_ext(self.account, cname,
+                                   obj_name=cname, data=cname)
+        # Check the database has been restored
+        ref_props = self.api.container_get_properties(
+            self.account, cname, params={'service_id': kept})
+        copy_props = self.api.container_get_properties(
+            self.account, cname, params={'service_id': stopped})
+        self.assertEqual(ref_props['system'], copy_props['system'])

--- a/tests/functional/content/test_content.py
+++ b/tests/functional/content/test_content.py
@@ -56,6 +56,7 @@ class TestContentFactory(BaseTestCase):
     def setUp(self):
         super(TestContentFactory, self).setUp()
 
+        self.wait_for_score(('meta2', ))
         self.namespace = self.conf['namespace']
         self.chunk_size = self.conf['chunk_size']
         self.gridconf = {"namespace": self.namespace}

--- a/tests/functional/content/test_content_perfectible.py
+++ b/tests/functional/content/test_content_perfectible.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/content/test_content_versioning.py
+++ b/tests/functional/content/test_content_versioning.py
@@ -29,6 +29,7 @@ class TestContentVersioning(BaseTestCase):
         self.api = ObjectStorageApi(self.conf['namespace'])
         self.container = random_str(8)
         system = {'sys.m2.policy.version': '3'}
+        self.wait_for_score(('meta2', ))
         self.api.container_create(self.account, self.container, system=system)
 
     def test_versioning_enabled(self):

--- a/tests/functional/directory/test_admin.py
+++ b/tests/functional/directory/test_admin.py
@@ -17,14 +17,14 @@ import random
 import os
 
 from tests.utils import BaseTestCase, random_str
-from oio.directory.admin import AdminClient
 from oio import ObjectStorageApi
 
 
 class TestAdmin(BaseTestCase):
     def setUp(self):
         super(TestAdmin, self).setUp()
-        self.admin = AdminClient(self.conf)
+        # Created by superclass
+        # self.admin = AdminClient(self.conf)
         self.api = ObjectStorageApi(self.ns)
         self.account = "test_admin"
         self.container = "admin-"+random_str(4)

--- a/tests/functional/directory/test_refmapping.py
+++ b/tests/functional/directory/test_refmapping.py
@@ -16,7 +16,7 @@
 import logging
 from time import sleep
 
-from oio import ObjectStorageApi
+from oio.api.object_storage import ObjectStorageApi
 from oio.directory.meta1 import Meta1RefMapping
 from tests.functional.cli import execute
 from tests.utils import BaseTestCase, random_str
@@ -98,7 +98,7 @@ class TestMeta1RefMapping(BaseTestCase):
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")
@@ -121,7 +121,7 @@ class TestMeta1RefMapping(BaseTestCase):
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")
@@ -148,7 +148,7 @@ class TestMeta1RefMapping(BaseTestCase):
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")

--- a/tests/unit/api/test_objectstorage.py
+++ b/tests/unit/api/test_objectstorage.py
@@ -118,7 +118,8 @@ class ObjectStorageTest(unittest.TestCase):
                   'end_marker': end_marker,
                   'properties': False}
         api.container._direct_request.assert_called_once_with(
-            'GET', uri, params=params, headers=self.headers)
+            'GET', uri, params=params, headers=self.headers,
+            path=ANY)
         self.assertEqual(len(listing['objects']), 2)
 
     def test_container_show(self):
@@ -236,7 +237,7 @@ class ObjectStorageTest(unittest.TestCase):
 
         uri = "%s/content/get_properties" % self.uri_base
         params = {'acct': self.account, 'ref': self.container,
-                  'path': name}
+                  'path': name, 'version': None}
         api.container._direct_request.assert_called_once_with(
             'POST', uri, params=params, data=None, headers=self.headers)
         self.assertIsNotNone(obj)

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -272,7 +272,8 @@ class TestReplication(unittest.TestCase):
             handler = ReplicatedMetachunkWriter(
                 self.sysmeta, self.meta_chunk(), global_checksum,
                 self.storage_method, **kwargs)
-            bytes_transferred, checksum, chunks = handler.stream(source, size)
+            bytes_transferred, checksum, chunks = \
+                handler.stream(source, size)
         self.assertEqual(len(meta_chunk), len(chunks))
         self.assertEqual(0, bytes_transferred)
         self.assertEqual(expected_checksum, checksum)


### PR DESCRIPTION
##### SUMMARY
- Test the two mechanisms of database restoration: the synchronous one (`DB_RESTORE`) and the asynchronous one (`DB_DUMP`/`DB_PIPEFROM`).
- Include `soft_max` configuration value in the cache statistics (the `hard_max` was displayed as `max`).
- Support 'client specified' peers in some more proxy routes. This allows tests to target a request to a specified peer, and compare the results from different peers.
- Slightly modify `oio-reset.sh` deployment to use comprehensible service IDs.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- sqliterepo
- proxy

##### SDS VERSION
```
openio 4.2.7.dev27
```
