### PR TITLE
Lock the load balancer while reloading a service slot

### DIFF
--- a/core/oiolb.h
+++ b/core/oiolb.h
@@ -116,9 +116,14 @@ struct oio_lb_item_s *oio_lb_world__get_item(struct oio_lb_world_s *self,
 /* Ensure the slot exists in the  given world. */
 void oio_lb_world__create_slot (struct oio_lb_world_s *self, const char *name);
 
-/* Tell the world that the given service belong to the named slot. */
+/* Tell the world that the given service belongs to the named slot. */
 void oio_lb_world__feed_slot (struct oio_lb_world_s *self, const char *slot,
 		const struct oio_lb_item_s *item);
+
+/* Tell the world that all services of the list belong to the named slot.
+ * And rehash the slot. */
+void oio_lb_world__feed_slot_with_list(struct oio_lb_world_s *self,
+		const char *slot, GSList *items);
 
 /* Create a world-based implementation of a service pool. */
 struct oio_lb_pool_s * oio_lb_world__create_pool (

--- a/meta0v2/meta0_backend.c
+++ b/meta0v2/meta0_backend.c
@@ -488,6 +488,8 @@ meta0_backend_get_one(struct meta0_backend_s *m0, const guint8 *prefix,
 			return NULL;
 		return NEWERROR(CODE_UNAVAILABLE,
 				"The current META0 service is not ready yet, "
-				"it has been partially initiated.");
+				"it has been partially initiated. "
+				"Nothing found for prefix %02X%02X.",
+				prefix[0], prefix[1]);
 	}
 }

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1534,7 +1534,9 @@ meta2_backend_generate_beans(struct meta2_backend_s *m2b,
 
 	/* Get the data needed for the beans preparation.
 	 * This call may return an open database. */
-	m2b_get_prepare_data(m2b, url, &pdata, &sq3);
+	err = m2b_get_prepare_data(m2b, url, &pdata, &sq3);
+	if (err)
+		goto end;
 
 	gboolean must_check_alias = m2b->flag_precheck_on_generate && (
 			 VERSIONS_DISABLED(pdata.max_versions) ||
@@ -1604,6 +1606,7 @@ meta2_backend_generate_beans(struct meta2_backend_s *m2b,
 				policy, m2b->lb, cb, cb_data);
 	}
 
+end:
 	namespace_info_free(nsinfo);
 	storage_policy_clean(policy);
 	return err;

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -547,9 +547,6 @@ lb_cache_reload (void)
 	if (!any_loading_error) {
 		oio_lb_world__purge_old_generations(lb_world);
 	} else {
-		/* This is better than nothing, but won't totally suppress
-		 * "LB reload not followed by rehash" messages, since we do not
-		 * lock the LB world between the update and the rehash. */
 		oio_lb_world__rehash_all_slots(lb_world);
 	}
 out:

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1413,9 +1413,6 @@ _reload_lb_world(struct oio_lb_world_s *lbw, struct oio_lb_s *lb)
 		if (!any_loading_error) {
 			oio_lb_world__purge_old_generations(lbw);
 		} else {
-			/* This is better than nothing, but won't totally suppress
-			 * "LB reload not followed by rehash" messages, since we do not
-			 * lock the LB world between the update and the rehash. */
 			oio_lb_world__rehash_all_slots(lbw);
 		}
 	}

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -657,6 +657,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.blob_client.chunk_delete_many.assert_called_once()
 
     def test_container_refresh(self):
+        self._wait_account_meta2()
         account = random_str(32)
         # container_refresh on unknown container
         name = random_str(32)
@@ -700,6 +701,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(account)
 
     def test_container_refresh_user_not_found(self):
+        self._wait_account_meta2()
         name = random_str(32)
         self.api.account.container_update(name, name, {"mtime": time.time()})
         self.api.container_refresh(name, name)
@@ -709,6 +711,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(name)
 
     def test_account_refresh(self):
+        self._wait_account_meta2()
         # account_refresh on unknown account
         account = random_str(32)
         self.assertRaises(
@@ -743,6 +746,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
             exc.NoSuchAccount, self.api.account_refresh, account)
 
     def test_account_refresh_all(self):
+        self._wait_account_meta2()
         # clear accounts
         accounts = self.api.account_list()
         for account in accounts:
@@ -774,6 +778,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.api.account_delete(account2)
 
     def test_account_flush(self):
+        self._wait_account_meta2()
         # account_flush on unknown account
         account = random_str(32)
         self.assertRaises(

--- a/tools/oio-reset.sh
+++ b/tools/oio-reset.sh
@@ -95,11 +95,11 @@ if [ $verbose -ge 1 ] ; then set -x ; fi
 # Check the datadir is a directory the current user owns
 [ -n "$DATADIR" ]
 if [[ -e "$DATADIR" ]] ; then
-	[ -d "$DATADIR" ]
-	[ -O "$DATADIR" ]
-	[ -r "$DATADIR" ]
-	[ -x "$DATADIR" ]
-	[ -w "$DATADIR" ]
+    [ -d "$DATADIR" ]
+    [ -O "$DATADIR" ]
+    [ -r "$DATADIR" ]
+    [ -x "$DATADIR" ]
+    [ -w "$DATADIR" ]
 fi
 
 # Stop and clean a previous installation.
@@ -183,6 +183,12 @@ $cmd_openio cluster wait -d 30 -u -n "$COUNT" sqlx rawx meta2 meta0 meta1 rdir
 echo -e "\n### Init the meta0/meta1 directory"
 $cmd_openio directory bootstrap --check \
     --replicas $(oio-test-config.py -v directory_replicas)
+
+# Help debugging "The current META0 service is not ready yet [...]"
+if [ "$(oio-test-config.py -v directory_replicas)" -gt 1 ]
+then
+    $cmd_openio election status meta0 0000
+fi
 
 echo -e "\n### Assign rdir services"
 # Force meta1 services to reload meta0 cache


### PR DESCRIPTION
##### SUMMARY
- Fix small memory leak in meta2.
- Rework the way we feed the load balancer with lists of services. Prevent nasty messages like `LB reload not followed by rehash`.

Jira: OS-294

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- proxy
- meta2
- metautils

##### SDS VERSION
```
openio 4.2.7.dev18
```
