### PR TITLE
core/lb: Avoid spamming with warnings

### DIFF
--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -59,7 +59,7 @@ tube for broken chunks events.
     parser.add_argument('--chunks-per-second', type=int,
                         help="Max chunks per second per worker (30)")
     parser.add_argument("--random-wait", type=int,
-                        help="Random wait (in μs)")
+                        help="Random wait (in microseconds)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
     parser.add_argument('--allow-same-rawx', action='store_true',

--- a/core/lb.c
+++ b/core/lb.c
@@ -595,8 +595,6 @@ _slot_get (struct oio_lb_slot_s *slot, const int i)
 static inline gboolean
 _slot_needs_rehash (const struct oio_lb_slot_s * const slot)
 {
-	/* TODO maybe quicker to have all the flags in a single <guint8> and then
-	 * check for a given MASK */
 	return BOOL(slot->flag_dirty_order) || BOOL(slot->flag_dirty_weights);
 }
 


### PR DESCRIPTION
##### SUMMARY
A bug might still happen in the `core/lb` logic, when a polling request is executed between the refresh and rehash steps of the update. When we detect it, we send a WARN trace in the journal. 

What we fix here is sending that WARN trace just once per minute.
There is no need to spam the log file.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`core`

##### SDS VERSION
`openio 4.2.7.dev20`
