### PR TITLE
Regenerate missing chunk attributes

### DIFF
--- a/bin/oio-blob-auditor
+++ b/bin/oio-blob-auditor
@@ -23,12 +23,13 @@ from oio.common.daemon import run_daemon
 
 
 def make_arg_parser():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=BlobAuditor.__doc__)
     parser.add_argument('--namespace', '--ns', help="Namespace")
     parser.add_argument('--volume', help="Volume to audit")
     parser.add_argument('config', help="Configuration file or empty file")
-    parser.add_argument('--generate-config', action='store_true',
-                        help="Generate configuration file with given arguments")
+    parser.add_argument(
+        '--generate-config', action='store_true',
+        help="Generate configuration file with given arguments")
     parser.add_argument('--append-config', action='store_true',
                         help="Append given arguments on configuration file")
     parser.add_argument('--daemon', action='store_true',

--- a/bin/oio-blob-converter
+++ b/bin/oio-blob-converter
@@ -36,8 +36,8 @@ def make_arg_parser():
                             help="Log address")
 
     descr = """
-Convert chunks that were on the specified volume. If an input file is provided,
-convert only the listed chunks.
+Convert chunks of the specified volume to the new extended attribute format.
+If an input file is provided, convert only the listed chunks.
 """
     parser = argparse.ArgumentParser(description=descr, parents=[log_parser])
     parser.add_argument('namespace', help="Namespace")
@@ -47,7 +47,7 @@ convert only the listed chunks.
     parser.add_argument('--chunks-per-second', type=int,
                         help="Max chunks per second per worker (30)")
     parser.add_argument('--no-backup', action='store_true',
-                        help="Don't save old xattr to a file")
+                        help="Don't save old extended attributes")
     parser.add_argument('--backup-dir',
                         help="Directory where to save backups "
                              "(tempory directory by default)")

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -38,15 +38,18 @@ PARALLEL_CHUNKS_DELETE = 3
 
 def extract_headers_meta(headers):
     meta = {}
-    for k in CHUNK_HEADERS.iterkeys():
+    missing = list()
+    for mkey, hkey in CHUNK_HEADERS.iteritems():
         try:
-            if k == 'full_path':
-                meta[k] = headers[CHUNK_HEADERS[k]]
+            if mkey == 'full_path':
+                meta[mkey] = headers[hkey]
             else:
-                meta[k] = unquote(headers[CHUNK_HEADERS[k]])
-        except KeyError as err:
-            if k not in chunk_xattr_keys_optional:
-                raise err
+                meta[mkey] = unquote(headers[hkey])
+        except KeyError:
+            if mkey not in chunk_xattr_keys_optional:
+                missing.append(exc.MissingAttribute(mkey))
+    if missing:
+        raise exc.FaultyChunk(*missing)
     return meta
 
 

--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,9 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from oio.common.green import ratelimit
+from oio.common.green import ratelimit, time
 
-import time
 import os
 import tempfile
 from string import hexdigits
@@ -24,18 +23,19 @@ from datetime import datetime
 from collections import OrderedDict
 
 from oio.common.constants import chunk_xattr_keys, OIO_VERSION, \
-    STRLEN_CHUNKID
+    STRLEN_CHUNKID, CHUNK_XATTR_CONTENT_FULLPATH_PREFIX
 from oio.common.utils import cid_from_name, paths_gen
 from oio.common.fullpath import decode_fullpath, decode_old_fullpath, \
     encode_fullpath
-from oio.common.xattr import modify_xattr
+from oio.common.xattr import set_fullpath_xattr
 from oio.common.exceptions import ContentNotFound, OrphanChunk, \
-    ConfigurationException
+    ConfigurationException, FaultyChunk, MissingAttribute
 from oio.common.logger import get_logger
 from oio.common.easy_value import int_value, is_hexa, true_value
 from oio.container.client import ContainerClient
 from oio.content.factory import ContentFactory
 from oio.blob.utils import read_chunk_metadata, check_volume
+from oio.rdir.client import RdirClient
 
 
 XATTR_CHUNK_ID = chunk_xattr_keys['chunk_id']
@@ -43,6 +43,7 @@ XATTR_OLD_FULLPATH = 'oio:'
 XATTR_OLD_FULLPATH_SIZE = 4
 
 
+# FIXME(FVE): move to utility class and document
 class CacheDict(OrderedDict):
 
     def __init__(self, size=262144):
@@ -76,6 +77,7 @@ class BlobConverter(object):
         # client
         self.container_client = ContainerClient(conf)
         self.content_factory = ContentFactory(conf, logger=self.logger)
+        self._rdir = None  # we may never need it
         # stats/logs
         self.errors = 0
         self.passes = 0
@@ -95,6 +97,14 @@ class BlobConverter(object):
             % (self.volume_id, time.time())
         # dry run
         self.dry_run = true_value(conf.get('dry_run', False))
+
+    @property
+    def rdir(self):
+        """Get an instance of `RdirClient`."""
+        if self._rdir is None:
+            self._rdir = RdirClient(
+                self.conf, pool_manager=self.container_client.pool_manager)
+        return self._rdir
 
     def save_xattr(self, chunk_id, xattr):
         if self.no_backup:
@@ -155,6 +165,7 @@ class BlobConverter(object):
         return content_id
 
     def decode_fullpath(self, fullpath):
+        # pylint: disable=unbalanced-tuple-unpacking
         account, container, path, version, content_id = decode_fullpath(
             fullpath)
         cid = self.cid_from_name(account, container)
@@ -163,6 +174,7 @@ class BlobConverter(object):
         return account, container, cid, path, version, content_id
 
     def decode_old_fullpath(self, old_fullpath):
+        # pylint: disable=unbalanced-tuple-unpacking
         account, container, path, version = decode_old_fullpath(old_fullpath)
         cid = self.cid_from_name(account, container)
         content_id = self.content_id_from_name(cid, path, version)
@@ -357,36 +369,88 @@ class BlobConverter(object):
                 str(new_fullpaths), str(xattr_to_remove))
         else:
             # for security, if there is an error, we don't delete old xattr
-            modify_xattr(fd, new_fullpaths, success, xattr_to_remove)
+            set_fullpath_xattr(fd, new_fullpaths, success, xattr_to_remove)
         return success, None
 
-    def safe_convert_chunk(self, path, fd=None, chunk_id=None):
+    def _is_fullpath_error(self, err):
+        if (isinstance(err, MissingAttribute) and
+                err.attribute.startswith(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX)):
+            return True
+        elif isinstance(err, FaultyChunk):
+            return any(self._is_fullpath_error(x) for x in err.args)
+        return False
+
+    def safe_convert_chunk(self, path, chunk_id=None):
         if chunk_id is None:
             chunk_id = path.rsplit('/', 1)[-1]
             if len(chunk_id) != STRLEN_CHUNKID:
                 self.logger.warn('Not a chunk %s' % path)
                 return
-            for c in chunk_id:
-                if c not in hexdigits:
+            for char in chunk_id:
+                if char not in hexdigits:
                     self.logger.warn('Not a chunk %s' % path)
                     return
 
         success = False
         self.total_chunks_processed += 1
         try:
-            if fd is None:
-                with open(path) as fd:
-                    success, _ = self.convert_chunk(fd, chunk_id)
-            else:
+            with open(path) as fd:
                 success, _ = self.convert_chunk(fd, chunk_id)
+        except (FaultyChunk, MissingAttribute) as err:
+            if self._is_fullpath_error(err):
+                self.logger.warn(
+                    "Cannot convert %s: %s, will try to recover 'fullpath'",
+                    path, err)
+                try:
+                    success = self.recover_chunk_fullpath(path, chunk_id)
+                except Exception as err2:
+                    self.logger.error('Could not recover fullpath: %s', err2)
+            else:
+                self.logger.exception('ERROR while converting %s', path)
         except Exception:
-            self.logger.exception('ERROR while conversion %s', path)
+            self.logger.exception('ERROR while converting %s', path)
 
         if not success:
             self.errors += 1
         else:
             self.logger.debug('Converted %s', path)
         self.passes += 1
+
+    def recover_chunk_fullpath(self, path, chunk_id=None):
+        if not chunk_id:
+            chunk_id = path.rsplit('/', 1)[-1]
+        # 1. Fetch chunk list from rdir (could be cached).
+        # Unfortunately we cannot seek for a chunk ID.
+        entries = [x for x in self.rdir.chunk_fetch(self.volume_id, limit=-1)
+                   if x[2] == chunk_id]
+        if not entries:
+            raise KeyError(
+                'Chunk %s not found in rdir' % chunk_id)
+        elif len(entries) > 1:
+            self.logger.info('Chunk %s appears in %d objects', len(entries))
+        # 2. Find content and container IDs
+        cid, content_id = entries[0][0:2]
+        # 3a. Call ContainerClient.content_locate()
+        #    with the container ID and content ID
+        meta, chunks = self.container_client.content_locate(
+            cid=cid, content=content_id)
+        # 3b. Resolve container ID into account and container names.
+        # FIXME(FVE): get account and container names from meta1
+        cmeta = self.container_client.container_get_properties(cid=cid)
+        aname = cmeta['system']['sys.account']
+        cname = cmeta['system']['sys.user.name']
+        fullpath = encode_fullpath(aname, cname, meta['name'],
+                                   meta['version'], content_id)
+        # 4. Check if the chunk actually belongs to the object
+        chunk_url = 'http://%s/%s' % (self.volume_id, chunk_id)
+        if chunk_url not in [x['url'] for x in chunks]:
+            raise OrphanChunk(
+                'Chunk %s not found in object %s',
+                chunk_url, fullpath)
+        # 5. Regenerate the fullpath
+        with open(path, 'w') as fd:
+            set_fullpath_xattr(fd, {chunk_id: fullpath})
+        return True
 
     def _fetch_chunks_from_file(self, input_file):
         with open(input_file, 'r') as ifile:
@@ -425,7 +489,7 @@ class BlobConverter(object):
                     'total_time': total_time,
                     'success_rate':
                         100 * ((self.total_chunks_processed - self.errors)
-                               / float(self.total_chunks_processed))
+                               / (float(self.total_chunks_processed) or 1.0))
                 }
             )
             self.passes = 0

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -56,63 +56,82 @@ class BlobIndexer(Daemon):
         self.convert_chunks = true_value(conf.get('convert_chunks'))
         self.converter = None
 
-    def index_pass(self):
+    def safe_recover_fullpath(self, path):
+        try:
+            return self.converter.recover_chunk_fullpath(path)
+        except Exception as err:
+            self.logger.error('Could not recover fullpath xattr of %s: %s',
+                              path, err)
+        return False
 
-        def safe_update_index(path):
-            chunk_id = path.rsplit('/', 1)[-1]
-            if len(chunk_id) != STRLEN_CHUNKID:
-                self.logger.warn('WARN Not a chunk %s' % path)
+    def safe_update_index(self, path):
+        chunk_id = path.rsplit('/', 1)[-1]
+        if len(chunk_id) != STRLEN_CHUNKID:
+            self.logger.warn('WARN Not a chunk %s', path)
+            return
+        for char in chunk_id:
+            if char not in hexdigits:
+                self.logger.warn('WARN Not a chunk %s', path)
                 return
-            for c in chunk_id:
-                if c not in hexdigits:
-                    self.logger.warn('WARN Not a chunk %s' % path)
-                    return
-            try:
-                self.update_index(path, chunk_id)
-                self.successes += 1
-                self.logger.debug('Updated %s', path)
-            except exc.OioNetworkException as err:
-                self.errors += 1
-                self.logger.warn('ERROR while updating %s: %s', path, err)
-            except exc.VolumeException as err:
-                self.errors += 1
-                self.logger.error('Cannot index %s: %s', path, err)
-                # All chunks of this volume are indexed in the same service,
-                # no need to try another chunk, it will generate the same
-                # error. Let the upper level retry later.
-                raise
-            except (exc.ChunkException, exc.MissingAttribute) as err:
+        try:
+            self.update_index(path, chunk_id)
+            self.successes += 1
+            self.logger.debug('Updated %s', path)
+        except exc.OioNetworkException as err:
+            self.errors += 1
+            self.logger.warn('ERROR while updating %s: %s', path, err)
+        except exc.VolumeException as err:
+            self.errors += 1
+            self.logger.error('Cannot index %s: %s', path, err)
+            # All chunks of this volume are indexed in the same service,
+            # no need to try another chunk, it will generate the same
+            # error. Let the upper level retry later.
+            raise
+        except (exc.ChunkException, exc.MissingAttribute) as err:
+            if (self.convert_chunks and self.converter and
+                    self.converter.is_fullpath_error(err)):
+                self.logger.warn(
+                    'Could not update %s: %s, will try to recover', path, err)
+                if self.safe_recover_fullpath(path):
+                    self.successes += 1
+                    self.logger.info(
+                        'Fullpath xattr of %s was recovered', path)
+                else:
+                    self.errors += 1
+                    # Logging already done by safe_recover_fullpath
+            else:
                 self.errors += 1
                 self.logger.error('ERROR while updating %s: %s', path, err)
-            except Exception:
-                self.errors += 1
-                self.logger.exception('ERROR while updating %s', path)
-            self.total_since_last_reported += 1
+        except Exception:
+            self.errors += 1
+            self.logger.exception('ERROR while updating %s', path)
+        self.total_since_last_reported += 1
 
-        def report(tag):
-            total = self.errors + self.successes
-            now = time.time()
-            elapsed = (now - start_time) or 0.000001
-            self.logger.info(
-                '%(tag)s=%(current_time)s '
-                'elapsed=%(elapsed).02f '
-                'pass=%(pass)d '
-                'errors=%(errors)d '
-                'chunks=%(nb_chunks)d %(c_rate).2f/s' % {
-                    'tag': tag,
-                    'current_time': datetime.fromtimestamp(
-                        int(now)).isoformat(),
-                    'pass': self.passes,
-                    'errors': self.errors,
-                    'nb_chunks': total,
-                    'c_rate': self.total_since_last_reported /
-                    (now - self.last_reported),
-                    'elapsed': elapsed
-                }
-            )
-            self.last_reported = now
-            self.total_since_last_reported = 0
+    def report(self, tag, start_time):
+        total = self.errors + self.successes
+        now = time.time()
+        elapsed = (now - start_time) or 0.000001
+        self.logger.info(
+            '%(tag)s=%(current_time)s '
+            'elapsed=%(elapsed).02f '
+            'pass=%(pass)d '
+            'errors=%(errors)d '
+            'chunks=%(nb_chunks)d %(c_rate).2f/s' % {
+                'tag': tag,
+                'current_time': datetime.fromtimestamp(
+                    int(now)).isoformat(),
+                'pass': self.passes,
+                'errors': self.errors,
+                'nb_chunks': total,
+                'c_rate': self.total_since_last_reported /
+                (now - self.last_reported),
+                'elapsed': elapsed
+            }
+        )
+        self.last_reported = now
+        self.total_since_last_reported = 0
 
+    def index_pass(self):
         start_time = time.time()
         self.last_reported = start_time
         self.errors = 0
@@ -122,17 +141,17 @@ class BlobIndexer(Daemon):
             self.converter = BlobConverter(self.conf, logger=self.logger)
 
         paths = paths_gen(self.volume)
-        report('started')
+        self.report('started', start_time)
         for path in paths:
-            safe_update_index(path)
+            self.safe_update_index(path)
             self.chunks_run_time = ratelimit(
                 self.chunks_run_time,
                 self.max_chunks_per_second
             )
             now = time.time()
             if now - self.last_reported >= self.report_interval:
-                report('running')
-        report('ended')
+                self.report('running', start_time)
+        self.report('ended', start_time)
 
     def update_index(self, path, chunk_id):
         with open(path) as file_:

--- a/oio/blob/utils.py
+++ b/oio/blob/utils.py
@@ -56,21 +56,24 @@ def read_chunk_metadata(fd, chunk_id, check_chunk_id=True):
     raw_meta_copy = None
     meta = {}
     meta['links'] = dict()
+    attr_vers = 0.0
     raw_chunk_id = container_id = path = version = content_id = None
+    missing = list()
     for k, v in raw_meta.iteritems():
-        # FIXME(FVE): check for chunk_xattr_keys['oio_version']
-        # and require fullpath
-        # New chunk
-        if k.startswith(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX):
-            chunkid = k[len(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX):]
-            if chunkid == chunk_id:
-                raw_chunk_id = chunkid
+        # New chunks have a version
+        if k == chunk_xattr_keys['oio_version']:
+            attr_vers = float(v)
+        # Chunks with version >= 4.2 have a "full_path"
+        elif k.startswith(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX):
+            parsed_chunk_id = k[len(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX):]
+            if parsed_chunk_id == chunk_id:
+                raw_chunk_id = parsed_chunk_id
                 meta['full_path'] = v
                 account, container, path, version, content_id = \
                     decode_fullpath(v)
                 container_id = cid_from_name(account, container)
             else:
-                meta['links'][chunkid] = v
+                meta['links'][parsed_chunk_id] = v
     if raw_chunk_id:
         raw_meta_copy = raw_meta.copy()
         raw_meta[chunk_xattr_keys['chunk_id']] = raw_chunk_id
@@ -78,7 +81,11 @@ def read_chunk_metadata(fd, chunk_id, check_chunk_id=True):
         raw_meta[chunk_xattr_keys['content_path']] = path
         raw_meta[chunk_xattr_keys['content_version']] = version
         raw_meta[chunk_xattr_keys['content_id']] = content_id
-    missing = list()
+    if attr_vers >= 4.2 and 'full_path' not in meta:
+        # TODO(FVE): in that case, do not warn about other attributes
+        # that could be deduced from this one.
+        missing.append(exc.MissingAttribute(
+            CHUNK_XATTR_CONTENT_FULLPATH_PREFIX + chunk_id))
     for k, v in chunk_xattr_keys.iteritems():
         if v not in raw_meta:
             if k not in chunk_xattr_keys_optional:

--- a/oio/cli/reference/reference.py
+++ b/oio/cli/reference/reference.py
@@ -276,7 +276,9 @@ class ForceReference(command.Command):
             '--replace',
             dest='replace',
             default=False,
-            help='Replace',
+            help=('Do not require the list of services of the specified '
+                  'type to be empty, replace it. By default, refuse to '
+                  'overwrite.'),
             action='store_true'
         )
         return parser

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -31,6 +31,9 @@ class MissingAttribute(OioException):
     def __str__(self):
         return '%s' % self.attribute
 
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__.__name__, self.attribute)
+
 
 class ChunkException(OioException):
     pass
@@ -41,7 +44,16 @@ class CorruptedChunk(ChunkException):
 
 
 class FaultyChunk(ChunkException):
-    pass
+    """
+    Raised when a chunk misses some extended attributes,
+    or they have invalid values.
+    """
+
+    def __repr__(self):
+        if len(self.args) > 1:
+            return "%s%r" % (self.__class__.__name__, self.args)
+        else:
+            return super(FaultyChunk, self).__repr__()
 
 
 class OrphanChunk(ChunkException):

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -150,10 +150,13 @@ class RingBuffer(list):
 
 
 def cid_from_name(account, ref):
-    h = sha256()
+    """
+    Compute a container ID from an account and a reference name.
+    """
+    hash_ = sha256()
     for v in [account, '\0', ref]:
-        h.update(v)
-    return h.hexdigest().upper()
+        hash_.update(v)
+    return hash_.hexdigest().upper()
 
 
 def fix_ranges(ranges, length):

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -81,7 +81,10 @@ def drop_privileges(user):
 
 
 def paths_gen(volume_path):
-    for root, dirs, files in os.walk(volume_path):
+    """
+    Yield paths of all regular files under `volume_path`.
+    """
+    for root, _dirs, files in os.walk(volume_path):
         for name in files:
             yield os.path.join(root, name)
 

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -355,6 +355,14 @@ class ContainerClient(ProxyClient):
 
     def container_raw_delete(self, account=None, reference=None, data=None,
                              cid=None, **kwargs):
+        """
+        Delete raw 'beans' from a container.
+
+        :param data: dictionaries representing the beans to delete. They must
+            have a key for each column of the meta2 database, plus a 'type'
+            telling which type of bean it is.
+        :type data: `list` of `dict` items
+        """
         params = self._make_params(account, reference, cid=cid)
         data = json.dumps(data)
         self._request(

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -186,6 +186,10 @@ class Checker(object):
             self.chunk_not_found += 1
             error = True
             print('  Not found chunk "%s": %s' % (target, str(e)))
+        except exc.FaultyChunk as err:
+            self.chunk_exceptions += 1
+            error = True
+            print('  Exception chunk "%s": %r' % (target, err))
         except Exception as e:
             self.chunk_exceptions += 1
             error = True

--- a/oio/directory/client.py
+++ b/oio/directory/client.py
@@ -165,6 +165,10 @@ class DirectoryClient(ProxyClient):
               **kwargs):
         """
         Associate the specified services to the reference.
+
+        :param replace: do not require the list of services
+            of the specified type to be empty, overwrite it.
+        :type replace: `bool`
         """
         params = self._make_params(account, reference, service_type, cid=cid)
         if replace:

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -317,25 +317,33 @@ class RdirClient(HttpApi):
                            json=body, **kwargs)
 
     def chunk_fetch(self, volume, limit=100, rebuild=False,
-                    container_id=None, max_attempts=3, **kwargs):
+                    container_id=None, max_attempts=3,
+                    start_after=None, **kwargs):
         """
         Fetch the list of chunks belonging to the specified volume.
 
         :param volume: the volume to get chunks from
         :type volume: `str`
-        :param limit: maximum number of results to return
+        :param limit: maximum number of results to return per request
+            to the rdir server.
         :type limit: `int`
-        :param rebuild:
+        :param rebuild: fetch only the chunks that were there
+            before the last incident.
         :type rebuild: `bool`
         :keyword container_id: get only chunks belonging to
            the specified container
         :type container_id: `str`
+        :keyword start_after: fetch only chunk that appear after
+            this container ID
+        :type start_after: `str`
         """
         req_body = {'limit': limit}
         if rebuild:
             req_body['rebuild'] = True
         if container_id:
             req_body['container_id'] = container_id
+        if start_after:
+            req_body['start_after'] = start_after
 
         while True:
             for i in range(max_attempts):

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -524,25 +524,26 @@ resource_stat_chunk(dav_resource *resource, int flags)
 	resource->collection = 0;
 	resource->exists = (status == APR_SUCCESS || status == APR_INCOMPLETE);
 
-	if (!resource->exists)
-		DAV_DEBUG_RES(resource, 0, "Resource does not exist [%s]", resource_get_pathname(resource));
-	else  {
-		gboolean rc;
+	if (!resource->exists) {
+		DAV_DEBUG_RES(resource, 0, "Resource does not exist [%s]",
+				resource_get_pathname(resource));
+	} else {
 		GError *err = NULL;
 
-		DAV_DEBUG_RES(resource, 0, "Resource exists [%s]", resource_get_pathname(resource));
+		DAV_DEBUG_RES(resource, 0, "Resource exists [%s]",
+				resource_get_pathname(resource));
 
 		memset(&(ctx->chunk), 0, sizeof(ctx->chunk));
 		if (flags & RESOURCE_STAT_CHUNK_READ_ATTRS) {
-			rc = get_rawx_info_from_file(resource_get_pathname(resource), &err,
+			gboolean rc = get_rawx_info_from_file(
+					resource_get_pathname(resource), &err,
 					resource->info->hex_chunkid, &(ctx->chunk));
 			if (!rc) {
-				DAV_DEBUG_RES(resource, 0, "Chunk xattr loading error [%s] : %s",
+				DAV_ERROR_RES(resource, 0, "Chunk xattr loading error [%s]: %s",
 						resource_get_pathname(resource),
 						apr_pstrdup(resource->pool, gerror_get_message(err)));
-			}
-			else {
-				chunk_info_fields__glib2apr (resource->pool, &resource->info->chunk);
+			} else {
+				chunk_info_fields__glib2apr(resource->pool, &resource->info->chunk);
 			}
 			if (err)
 				g_clear_error(&err);

--- a/tests/functional/blob/__init__.py
+++ b/tests/functional/blob/__init__.py
@@ -57,6 +57,16 @@ def convert_to_old_chunk(chunk_path, account, container, path, version,
             pass
 
 
+def remove_fullpath_xattr(chunk_path):
+    key = 'user.%s%s' % (CHUNK_XATTR_CONTENT_FULLPATH_PREFIX,
+                         chunk_path.rsplit('/', 1)[-1])
+    with open(chunk_path, 'w') as fd:
+        try:
+            xattr.removexattr(fd, key)
+        except IOError as err:
+            print 'Failed to remove fullpath: %s' % err
+
+
 def random_buffer(dictionary, n):
     slot = 512
     pattern = ''.join(random.choice(dictionary) for _ in range(slot))


### PR DESCRIPTION
##### SUMMARY
A flaw in the `xfs_repair` tool can remove some chunk extended attributes. This PR aims at updating our various tools to tolerate missing attributes, and regenerate them, especially the famous "fullpath".

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API
- `oio-crawler-integrity`
- `oio-blob-auditor`

##### SDS VERSION
```
openio 4.2.7.dev24
```