### PR TITLE
Save the number of missing chunks

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -957,7 +957,8 @@ meta2_backend_delete_alias(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_put_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		GSList *in, m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		GSList *in, gint64 missing_chunks,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added)
 {
 	GError *err = NULL;
@@ -981,8 +982,11 @@ meta2_backend_put_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_put_alias(&args, in, cb_deleted, u0_deleted,
-					cb_added, u0_added)))
+					cb_added, u0_added))) {
+				m2db_set_missing_chunks(
+						sq3, m2db_get_missing_chunks(sq3) + missing_chunks);
 				m2db_increment_version(sq3);
+			}
 			err = sqlx_transaction_end(repctx, err);
 			if (!err)
 				m2b_add_modified_container(m2b, sq3);
@@ -995,7 +999,7 @@ meta2_backend_put_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 
 GError*
 meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *in,
+		struct oio_url_s *url, GSList *in, gint64 missing_chunks,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added)
 {
@@ -1019,8 +1023,11 @@ meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
 
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_change_alias_policy(
-					&args, in, cb_deleted, u0_deleted, cb_added, u0_added)))
+					&args, in, cb_deleted, u0_deleted, cb_added, u0_added))) {
+				m2db_set_missing_chunks(
+						sq3, m2db_get_missing_chunks(sq3) + missing_chunks);
 				m2db_increment_version(sq3);
+			}
 			err = sqlx_transaction_end(repctx, err);
 			if (!err)
 				m2b_add_modified_container(m2b, sq3);
@@ -1033,7 +1040,8 @@ meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
 
 GError *
 meta2_backend_update_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		GSList *in, m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		GSList *in, gint64 missing_chunks,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added)
 {
 	GError *err = NULL;
@@ -1052,8 +1060,11 @@ meta2_backend_update_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_update_content(sq3, url, in,
-					cb_deleted, u0_deleted, cb_added, u0_added)))
+					cb_deleted, u0_deleted, cb_added, u0_added))) {
+				m2db_set_missing_chunks(
+						sq3, m2db_get_missing_chunks(sq3) + missing_chunks);
 				m2db_increment_version(sq3);
+			}
 			err = sqlx_transaction_end(repctx, err);
 			if (!err)
 				m2b_add_modified_container(m2b, sq3);
@@ -1096,7 +1107,8 @@ meta2_backend_truncate_content(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_force_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		GSList *in, m2_onbean_cb cb_deleted, gpointer u0_deleted,
+		GSList *in, gint64 missing_chunks,
+		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added)
 {
 	GError *err = NULL;
@@ -1120,8 +1132,11 @@ meta2_backend_force_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 
 		if (!(err = _transaction_begin(sq3,url, &repctx))) {
 			if (!(err = m2db_force_alias(&args, in, cb_deleted, u0_deleted,
-					cb_added, u0_added)))
+					cb_added, u0_added))) {
+				m2db_set_missing_chunks(
+						sq3, m2db_get_missing_chunks(sq3) + missing_chunks);
 				m2db_increment_version(sq3);
+			}
 			err = sqlx_transaction_end(repctx, err);
 		}
 		if (!err)
@@ -1295,7 +1310,7 @@ meta2_backend_get_alias_version(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_append_to_alias(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *beans,
+		struct oio_url_s *url, GSList *beans, gint64 missing_chunks,
 		m2_onbean_cb cb, gpointer u0)
 {
 	GError *err = NULL;
@@ -1313,8 +1328,11 @@ meta2_backend_append_to_alias(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
-			if (!(err = m2db_append_to_alias(sq3, url, beans, cb, u0)))
+			if (!(err = m2db_append_to_alias(sq3, url, beans, cb, u0))) {
+				m2db_set_missing_chunks(
+						sq3, m2db_get_missing_chunks(sq3) + missing_chunks);
 				m2db_increment_version(sq3);
+			}
 			err = sqlx_transaction_end(repctx, err);
 		}
 		if (!err)
@@ -1612,7 +1630,8 @@ _patch_url_with_version(struct oio_url_s *url, GSList *beans)
 
 GError *
 meta2_backend_check_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		GSList **beans, meta2_send_event_cb send_event, gboolean is_update)
+		GSList **beans, gint64 *missing_chunks,
+		meta2_send_event_cb send_event, gboolean is_update)
 {
 	GError *err = NULL;
 	struct namespace_info_s *nsinfo = NULL;
@@ -1623,6 +1642,8 @@ meta2_backend_check_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
 	m2v2_sort_content(*beans, &sorted);
 	struct checked_content_s *checked_content = NULL;
 	err = m2db_check_content(sorted, nsinfo, &checked_content, is_update);
+	if (checked_content)
+		*missing_chunks = checked_content_get_missing_chunks(checked_content);
 	if (send_event) {
 		if (err && err->code == CODE_CONTENT_UNCOMPLETE) {
 			GString *event = oio_event__create_with_id(

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -912,22 +912,9 @@ meta2_backend_get_alias(struct meta2_backend_s *m2b,
 }
 
 /* TODO(jfs): maybe is there a way to keep this in a cache */
-GError *
-meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
-		struct oio_url_s *url)
-{
-	GError *err = NULL;
-	struct sqlx_sqlite3_s *sq3 = NULL;
-	if (!(err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY, &sq3))) {
-		m2b_add_modified_container(m2b, sq3);
-		m2b_close(sq3);
-	}
-	return err;
-}
-
 GError*
-meta2_backend_refresh_container_size(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gboolean recompute)
+meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
+		struct oio_url_s *url, gboolean recompute, gint64 missing_chunks)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -937,14 +924,21 @@ meta2_backend_refresh_container_size(struct meta2_backend_s *m2b,
 
 	if (!(err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY, &sq3))) {
 		if (recompute) {
-			guint64 size = 0u;
-			gint64 count = 0;
-			m2db_get_container_size_and_obj_count(sq3->db, FALSE,
-					&size, &count);
-			m2db_set_size(sq3, size);
-			m2db_set_obj_count(sq3, count);
+			struct sqlx_repctx_s *repctx = NULL;
+			if (!(err = _transaction_begin(sq3, url, &repctx))) {
+				guint64 size = 0u;
+				gint64 count = 0;
+				m2db_get_container_size_and_obj_count(sq3->db, FALSE,
+						&size, &count);
+				m2db_set_size(sq3, size);
+				m2db_set_obj_count(sq3, count);
+				m2db_set_missing_chunks(sq3, missing_chunks);
+				m2db_increment_version(sq3);
+				err = sqlx_transaction_end(repctx, err);
+			}
 		}
-		m2b_add_modified_container(m2b, sq3);
+		if (!err)
+			m2b_add_modified_container(m2b, sq3);
 		m2b_close(sq3);
 	}
 

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -314,10 +314,11 @@ _container_state (struct sqlx_sqlite3_s *sq3)
 
 	GString *gs = oio_event__create (META2_EVENTS_PREFIX ".container.state", u);
 	g_string_append_static (gs, ",\"data\":{");
-	append_const (gs, "policy", sqlx_admin_get_str(sq3, M2V2_ADMIN_STORAGE_POLICY));
-	append_int64 (gs, "ctime", m2db_get_ctime(sq3));
-	append_int64 (gs, "bytes-count", m2db_get_size(sq3));
-	append_int64 (gs, "object-count", m2db_get_obj_count(sq3));
+	append_const(gs, "policy", sqlx_admin_get_str(sq3, M2V2_ADMIN_STORAGE_POLICY));
+	append_int64(gs, "ctime", m2db_get_ctime(sq3));
+	append_int64(gs, "bytes-count", m2db_get_size(sq3));
+	append_int64(gs, "object-count", m2db_get_obj_count(sq3));
+	append_int64(gs, "missing-chunks", m2db_get_missing_chunks(sq3));
 	g_string_append_static (gs, "}}");
 
 	oio_url_clean (u);
@@ -579,6 +580,7 @@ _init_container(struct sqlx_sqlite3_s *sq3,
 		m2db_set_ctime (sq3, oio_ext_real_time());
 		m2db_set_size(sq3, 0);
 		m2db_set_obj_count(sq3, 0);
+		m2db_set_missing_chunks(sq3, 0);
 		sqlx_admin_set_status(sq3, ADMIN_STATUS_ENABLED);
 		sqlx_admin_init_i64(sq3, META2_INIT_FLAG, 1);
 	}

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -864,8 +864,6 @@ _update_missing_chunks(struct meta2_backend_s *m2b, struct sqlx_sqlite3_s *sq3,
 	namespace_info_free(nsinfo);
 
 end:
-	if (missing_chunks < 0)
-		missing_chunks = 0;
 	m2db_set_missing_chunks(sq3, missing_chunks);
 }
 
@@ -1316,9 +1314,15 @@ meta2_backend_insert_beans(struct meta2_backend_s *m2b,
 				err = _db_save_beans_list (sq3->db, beans);
 			else
 				err = _db_insert_beans_list (sq3->db, beans);
-			if (!err)
+			if (!err) {
+				gint64 missing_chunks = m2db_get_missing_chunks(sq3);
+				for (GSList *bean=beans; bean; bean=bean->next) {
+					if (DESCR(bean->data) == &descr_struct_CHUNKS)
+						missing_chunks--;
+				}
+				m2db_set_missing_chunks(sq3, missing_chunks);
 				m2db_increment_version(sq3);
-			else {
+			} else {
 				/* A constraint error is usually raised by an actual constraint
 				 * violation in the DB (inside the transaction) or also by a
 				 * failure of the commit hook (on the final COMMIT). */

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -118,11 +118,8 @@ GError* meta2_backend_update_beans(struct meta2_backend_s *m2b,
 GError* meta2_backend_delete_chunks(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, GSList *beans);
 
-GError * meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
-		struct oio_url_s *url);
-
-GError* meta2_backend_refresh_container_size(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gboolean bRecalc);
+GError* meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
+		struct oio_url_s *url, gboolean recompute, gint64 missing_chunks);
 
 GError* meta2_backend_put_alias(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, GSList *in, gint64 missing_chunks,

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -125,29 +125,29 @@ GError* meta2_backend_refresh_container_size(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, gboolean bRecalc);
 
 GError* meta2_backend_put_alias(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *in,
+		struct oio_url_s *url, GSList *in, gint64 missing_chunks,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 
 GError* meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *in,
+		struct oio_url_s *url, GSList *in, gint64 missing_chunks,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 
 GError* meta2_backend_append_to_alias(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *beans,
+		struct oio_url_s *url, GSList *beans, gint64 missing_chunks,
 		m2_onbean_cb cb, gpointer u0);
 
 typedef void (*meta2_send_event_cb)(gchar *event, gpointer udata);
 
 GError* meta2_backend_check_content(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList **beans, meta2_send_event_cb send_event,
-		gboolean update);
+		struct oio_url_s *url, GSList **beans, gint64 *missing_chunks,
+		meta2_send_event_cb send_event, gboolean update);
 
 /** Update a content with the given chunks replacing the existing chunks
  *  at the same position. */
 GError *meta2_backend_update_content(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *in,
+		struct oio_url_s *url, GSList *in, gint64 missing_chunks,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 
@@ -160,7 +160,7 @@ GError * meta2_backend_truncate_content(struct meta2_backend_s *m2b,
 /** Create a new version of the ALIAS but with the given chunks linked to
  * the existing CONTENT.  */
 GError* meta2_backend_force_alias(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, GSList *in,
+		struct oio_url_s *url, GSList *in, gint64 missing_chunks,
 		m2_onbean_cb cb_deleted, gpointer u0_deleted,
 		m2_onbean_cb cb_added, gpointer u0_added);
 

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -509,12 +509,20 @@ meta2_filter_action_update_beans(struct gridd_filter_ctx_s *ctx,
 
 int
 meta2_filter_action_touch_container(struct gridd_filter_ctx_s *ctx,
-		struct gridd_reply_ctx_s *reply UNUSED)
+		struct gridd_reply_ctx_s *reply)
 {
 	struct oio_url_s *url = meta2_filter_ctx_get_url(ctx);
 	struct meta2_backend_s *m2b = meta2_filter_ctx_get_backend(ctx);
 
-	GError *err = meta2_backend_notify_container_state(m2b, url);
+	gboolean recompute = FALSE;
+	metautils_message_extract_boolean(reply->request,
+			NAME_MSGKEY_RECOMPUTE, FALSE, &recompute);
+	gint64 missing_chunks = 0;
+	metautils_message_extract_strint64(reply->request,
+			NAME_MSGKEY_MISSING_CHUNKS, &missing_chunks);
+
+	GError *err = meta2_backend_notify_container_state(m2b, url,
+			recompute, missing_chunks);
 	if (!err)
 		return FILTER_OK;
 	meta2_filter_ctx_set_error(ctx, err);

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_filters_action_content.c
+++ b/meta2v2/meta2_filters_action_content.c
@@ -231,9 +231,16 @@ meta2_filter_action_check_content(struct gridd_filter_ctx_s * ctx,
 		meta2_filter_ctx_defer_event(ctx, event);
 	}
 	GSList *beans = meta2_filter_ctx_get_input_udata(ctx);
-	err = meta2_backend_check_content(m2b, url, &beans, _send_event, is_update);
+	gint64 missing_chunks = 0;
+	err = meta2_backend_check_content(m2b, url, &beans, &missing_chunks,
+			_send_event, is_update);
 	meta2_filter_ctx_set_input_udata2(ctx, beans,
 			(GDestroyNotify)_bean_cleanl2, FALSE);
+	gchar *missing_chunks_str = g_strdup_printf(
+            "%"G_GINT64_FORMAT, missing_chunks);
+	meta2_filter_ctx_add_param(ctx, NAME_MSGKEY_MISSING_CHUNKS,
+			missing_chunks_str);
+	g_free(missing_chunks_str);
 	if (err) {
 		if (err->code != CODE_CONTENT_UNCOMPLETE) {
 			meta2_filter_ctx_set_error(ctx, err);
@@ -269,20 +276,26 @@ meta2_filter_action_put_content(struct gridd_filter_ctx_s *ctx,
 			meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_CHANGE_POLICY)?
 			" (policy change)":"");
 
+	gint64 missing_chunks = 0;
+	const gchar *missing_chunks_str = meta2_filter_ctx_get_param(
+			ctx, NAME_MSGKEY_MISSING_CHUNKS);
+	if (missing_chunks_str)
+		missing_chunks = g_ascii_strtoll(missing_chunks_str, NULL, 10);
+
 	if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_OVERWRITE)) {
-		e = meta2_backend_force_alias(m2b, url, beans, _bean_list_cb, &deleted,
-				_bean_list_cb, &added);
+		e = meta2_backend_force_alias(m2b, url, beans, missing_chunks,
+				_bean_list_cb, &deleted, _bean_list_cb, &added);
 	} else if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_UPDATE)) {
 		reply->subject("(update)");
-		e = meta2_backend_update_content(m2b, url, beans,
+		e = meta2_backend_update_content(m2b, url, beans, missing_chunks,
 				_bean_list_cb, &deleted, _bean_list_cb, &added);
 	} else if (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_CHANGE_POLICY)) {
 		reply->subject("(policy change)");
-		e = meta2_backend_change_alias_policy(m2b, url, beans,
+		e = meta2_backend_change_alias_policy(m2b, url, beans, missing_chunks,
 				_bean_list_cb, &deleted, _bean_list_cb, &added);
 	} else {
-		e = meta2_backend_put_alias(m2b, url, beans, _bean_list_cb, &deleted,
-				_bean_list_cb, &added);
+		e = meta2_backend_put_alias(m2b, url, beans, missing_chunks,
+				_bean_list_cb, &deleted, _bean_list_cb, &added);
 	}
 
 	if (NULL != e) {
@@ -317,7 +330,14 @@ meta2_filter_action_append_content(struct gridd_filter_ctx_s *ctx,
 	struct on_bean_ctx_s *obc = _on_bean_ctx_init(ctx, reply);
 	GRID_DEBUG("Appending %d beans", g_slist_length(beans));
 
-	e = meta2_backend_append_to_alias(m2b, url, beans, _bean_list_cb, &obc->l);
+	gint64 missing_chunks = 0;
+	const gchar *missing_chunks_str = meta2_filter_ctx_get_param(
+			ctx, NAME_MSGKEY_MISSING_CHUNKS);
+	if (missing_chunks_str)
+		missing_chunks = g_ascii_strtoll(missing_chunks_str, NULL, 10);
+
+	e = meta2_backend_append_to_alias(m2b, url, beans, missing_chunks,
+			_bean_list_cb, &obc->l);
 	if(NULL != e) {
 		GRID_DEBUG("Fail to append to alias (%s)", oio_url_get(url, OIOURL_WHOLE));
 		meta2_filter_ctx_set_error(ctx, e);

--- a/meta2v2/meta2_filters_action_content.c
+++ b/meta2v2/meta2_filters_action_content.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_macros.h
+++ b/meta2v2/meta2_macros.h
@@ -44,6 +44,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define M2V2_ADMIN_OBJ_COUNT M2V2_ADMIN_PREFIX_SYS "objects"
 # endif
 
+# ifndef M2V2_ADMIN_MISSING_CHUNKS
+# define M2V2_ADMIN_MISSING_CHUNKS M2V2_ADMIN_PREFIX_SYS "chunks.missing"
+# endif
+
 # ifndef M2V2_ADMIN_CTIME
 # define M2V2_ADMIN_CTIME M2V2_ADMIN_PREFIX_SYS "ctime"
 # endif

--- a/meta2v2/meta2_macros.h
+++ b/meta2v2/meta2_macros.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -2365,6 +2365,12 @@ checked_content_append_json_string(struct checked_content_s *checked_content,
 	g_string_append_c(message, ']');
 }
 
+guint
+checked_content_get_missing_chunks(struct checked_content_s *checked_content)
+{
+	return g_slist_length(checked_content->missing_pos);
+}
+
 static gboolean
 _check_metachunk_plain_content(GSList *chunks, struct checked_content_s *plain)
 {

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -261,6 +261,8 @@ m2db_get_missing_chunks(struct sqlx_sqlite3_s *sq3)
 void
 m2db_set_missing_chunks(struct sqlx_sqlite3_s *sq3, gint64 missing)
 {
+	if (missing < 0)
+		missing = 0;
 	sqlx_admin_set_i64(sq3, M2V2_ADMIN_MISSING_CHUNKS, missing);
 }
 

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -252,6 +252,17 @@ m2db_set_obj_count(struct sqlx_sqlite3_s *sq3, gint64 count)
 	sqlx_admin_set_i64(sq3, M2V2_ADMIN_OBJ_COUNT, count);
 }
 
+gint64
+m2db_get_missing_chunks(struct sqlx_sqlite3_s *sq3)
+{
+	return sqlx_admin_get_i64(sq3, M2V2_ADMIN_MISSING_CHUNKS, 0);
+}
+
+void
+m2db_set_missing_chunks(struct sqlx_sqlite3_s *sq3, gint64 missing)
+{
+	sqlx_admin_set_i64(sq3, M2V2_ADMIN_MISSING_CHUNKS, missing);
+}
 
 /* GET ---------------------------------------------------------------------- */
 

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -66,6 +66,7 @@ struct m2v2_sorted_content_s {
 	GSList *aliases;    // GSList<struct bean_ALIASES_s*>
 	GSList *properties; // GSList<struct bean_PROPERTIES_s*>
 	GTree *metachunks;  // GTree<gint,GSList<struct bean_CHUNKS_s*>>
+	gint64 n_chunks;
 };
 
 struct checked_content_s;
@@ -181,6 +182,10 @@ guint checked_content_get_missing_chunks(struct checked_content_s *checked_conte
 GError* m2db_check_content(struct m2v2_sorted_content_s *sorted_content,
 		struct namespace_info_s *nsinfo,
 		struct checked_content_s **checked_content, gboolean update);
+
+GError* m2db_get_content_missing_chunks(
+		struct m2v2_sorted_content_s *sorted_content,
+		struct namespace_info_s *nsinfo, gint64 *missing_chunks);
 
 void m2db_check_content_quality(
 		struct m2v2_sorted_content_s *sorted_content, GSList *chunk_meta,

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -176,6 +176,8 @@ void checked_content_free(struct checked_content_s *checked_content);
 void checked_content_append_json_string(struct checked_content_s *checked_content,
 		GString *message);
 
+guint checked_content_get_missing_chunks(struct checked_content_s *checked_content);
+
 GError* m2db_check_content(struct m2v2_sorted_content_s *sorted_content,
 		struct namespace_info_s *nsinfo,
 		struct checked_content_s **checked_content, gboolean update);

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -119,6 +119,10 @@ gint64 m2db_get_obj_count(struct sqlx_sqlite3_s *sq3);
 
 void m2db_set_obj_count(struct sqlx_sqlite3_s *sq3, gint64 count);
 
+gint64 m2db_get_missing_chunks(struct sqlx_sqlite3_s *sq3);
+
+void m2db_set_missing_chunks(struct sqlx_sqlite3_s *sq3, gint64 missing);
+
 gint64 m2db_get_version(struct sqlx_sqlite3_s *sq3);
 
 void m2db_increment_version(struct sqlx_sqlite3_s *sq3);

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -74,6 +74,7 @@ License along with this library.
 #define NAME_MSGKEY_MAXVERS            "MAXVERS"
 #define NAME_MSGKEY_MESSAGE            "MSG"
 #define NAME_MSGKEY_METAURL            "METAURL"
+#define NAME_MSGKEY_MISSING_CHUNKS     "MISSING_CHUNKS"
 #define NAME_MSGKEY_NAMESPACE          "NS"
 #define NAME_MSGKEY_NEXTMARKER         "MRK_NXT"
 #define NAME_MSGKEY_NEW                "NEW"

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS metautils
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -85,6 +85,7 @@ License along with this library.
 #define NAME_MSGKEY_OVERWRITE          "OVERWRITE"
 #define NAME_MSGKEY_PREFIX             "PREFIX"
 #define NAME_MSGKEY_QUERY              "Q"
+#define NAME_MSGKEY_RECOMPUTE          "RECOMPUTE"
 #define NAME_MSGKEY_REPLICAS           "REPLICAS"
 #define NAME_MSGKEY_SEQNUM             "SEQ_NUM"
 #define NAME_MSGKEY_SPARE              "SPARE"

--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -50,52 +50,58 @@ class AccountBackend(RedisConn):
     lua_update_container = (lua_is_sup + """
                local account_id = redis.call('HGET', KEYS[4], 'id');
                if not account_id then
-                 if ARGV[6] == 'True' then
+                 if ARGV[7] == 'True' then
                    redis.call('HSET', 'accounts:', KEYS[1], 1);
                    redis.call('HMSET', KEYS[4], 'id', KEYS[1],
-                              'bytes', 0, 'objects', 0, 'ctime', ARGV[7]);
+                              'bytes', 0, 'objects', 0, 'missing-chunks', 0,
+                              'ctime', ARGV[8]);
                  else
                    return redis.error_reply('no_account');
                  end;
                end;
 
-               if ARGV[9] == 'False' then
+               if ARGV[10] == 'False' then
                  local container_name = redis.call('HGET', KEYS[2], 'name');
                  if not container_name then
                    return redis.error_reply('no_container');
                  end;
                end;
 
-               local objects = redis.call('HGET', KEYS[2], 'objects');
                local name = ARGV[1];
                local mtime = redis.call('HGET', KEYS[2], 'mtime');
                local dtime = redis.call('HGET', KEYS[2], 'dtime');
+               local objects = redis.call('HGET', KEYS[2], 'objects');
                local bytes = redis.call('HGET', KEYS[2], 'bytes');
+               local missing_chunks = redis.call('HGET', KEYS[2],
+                                                 'missing-chunks');
 
                -- When the keys do not exist redis return false and not nil
-               if objects == false then
-                 objects = 0
-               end
                if dtime == false then
                  dtime = '0'
                end
                if mtime == false then
                  mtime = '0'
                end
+               if objects == false then
+                 objects = 0
+               end
                if bytes == false then
                  bytes = 0
                end
+               if missing_chunks == false then
+                 missing_chunks = 0
+               end
 
-               if ARGV[9] == 'False' and is_sup(dtime, mtime) then
+               if ARGV[10] == 'False' and is_sup(dtime, mtime) then
                  return redis.error_reply('no_container');
                end;
 
                local old_mtime = mtime;
                local inc_objects;
                local inc_bytes;
+               local inc_missing_chunks;
 
-               if not is_sup(ARGV[3],dtime) and
-                  not is_sup(ARGV[2],mtime) then
+               if not is_sup(ARGV[3],dtime) and not is_sup(ARGV[2],mtime) then
                  return redis.error_reply('no_update_needed');
                end;
 
@@ -109,15 +115,20 @@ class AccountBackend(RedisConn):
                if is_sup(dtime,mtime) then
                  inc_objects = -objects;
                  inc_bytes = -bytes;
-                 redis.call('HMSET', KEYS[2], 'bytes', 0, 'objects', 0);
-                 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[8]));
+                 inc_missing_chunks = -missing_chunks;
+                 redis.call('HMSET', KEYS[2],
+                            'bytes', 0, 'objects', 0, 'missing-chunks', 0);
+                 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[9]));
                  redis.call('ZREM', KEYS[3], name);
                elseif is_sup(mtime,old_mtime) then
                  redis.call('PERSIST', KEYS[2]);
                  inc_objects = tonumber(ARGV[4]) - objects
                  inc_bytes = tonumber(ARGV[5]) - bytes
-                 redis.call('HMSET', KEYS[2], 'bytes', tonumber(ARGV[5]),
-                            'objects', tonumber(ARGV[4]));
+                 inc_missing_chunks = tonumber(ARGV[6]) - missing_chunks
+                 redis.call('HMSET', KEYS[2],
+                            'objects', tonumber(ARGV[4]),
+                            'bytes', tonumber(ARGV[5]),
+                            'missing-chunks', tonumber(ARGV[6]));
                  redis.call('ZADD', KEYS[3], '0', name);
                else
                  return redis.error_reply('no_update_needed');
@@ -131,6 +142,10 @@ class AccountBackend(RedisConn):
                if inc_bytes ~= 0 then
                  redis.call('HINCRBY', KEYS[4], 'bytes', inc_bytes);
                end;
+               if inc_missing_chunks ~= 0 then
+                 redis.call('HINCRBY', KEYS[4], 'missing-chunks',
+                            inc_missing_chunks);
+               end;
                """)
 
     lua_refresh_account = """
@@ -143,15 +158,18 @@ class AccountBackend(RedisConn):
         local container_key = ''
         local bytes_sum = 0;
         local objects_sum = 0;
+        local missing_chunks_sum = 0;
         for _,container in ipairs(containers) do
             container_key = KEYS[3] .. container;
-            bytes_sum = bytes_sum + redis.call('HGET', container_key, 'bytes')
             objects_sum = objects_sum + redis.call('HGET', container_key,
                                                    'objects')
+            bytes_sum = bytes_sum + redis.call('HGET', container_key, 'bytes')
+            missing_chunks_sum = missing_chunks_sum
+                    + redis.call('HGET', container_key, 'missing-chunks')
         end;
 
-        redis.call('HMSET', KEYS[1], 'bytes', bytes_sum,
-                   'objects', objects_sum)
+        redis.call('HMSET', KEYS[1], 'objects', objects_sum,
+                   'bytes', bytes_sum, 'missing-chunks', missing_chunks_sum)
         """
 
     lua_flush_account = """
@@ -160,7 +178,8 @@ class AccountBackend(RedisConn):
             return redis.error_reply('no_account');
         end;
 
-        redis.call('HMSET', KEYS[1], 'bytes', 0, 'objects', 0)
+        redis.call('HMSET', KEYS[1], 'objects', 0, 'bytes', 0,
+                   'missing-chunks', 0)
 
         local containers = redis.call('ZRANGE', KEYS[2], 0, -1);
         redis.call('DEL', KEYS[2]);
@@ -201,8 +220,9 @@ class AccountBackend(RedisConn):
         pipeline.hset('accounts:', account_id, 1)
         pipeline.hmset('account:%s' % account_id, {
             'id': account_id,
-            'bytes': 0,
             'objects': 0,
+            'bytes': 0,
+            'missing-chunks': 0,
             'ctime': Timestamp(time()).normal
         })
         pipeline.execute()
@@ -285,8 +305,8 @@ class AccountBackend(RedisConn):
         pipeline.hgetall('metadata:%s' % account_id)
         data = pipeline.execute()
         info = data[0]
-        for r in ['bytes', 'objects']:
-            info[r] = int_value(info[r], 0)
+        for r in ['bytes', 'objects', 'missing-chunks']:
+            info[r] = int_value(info.get(r), 0)
         info['containers'] = data[1]
         info['metadata'] = data[2]
         return info
@@ -296,9 +316,9 @@ class AccountBackend(RedisConn):
         accounts = conn.hkeys('accounts:')
         return accounts
 
-    def update_container(self, account_id, name, mtime, dtime, object_count,
-                         bytes_used, autocreate_account=None,
-                         autocreate_container=True):
+    def update_container(self, account_id, name, mtime, dtime,
+                         object_count, bytes_used, missing_chunks,
+                         autocreate_account=None, autocreate_container=True):
         conn = self.conn
         if not account_id or not name:
             raise BadRequest("Missing account or container")
@@ -318,11 +338,13 @@ class AccountBackend(RedisConn):
             object_count = 0
         if bytes_used is None:
             bytes_used = 0
+        if missing_chunks is None:
+            missing_chunks = 0
 
         keys = [account_id, AccountBackend.ckey(account_id, name),
                 ("containers:%s" % (account_id)),
                 ("account:%s" % (account_id))]
-        args = [name, mtime, dtime, object_count, bytes_used,
+        args = [name, mtime, dtime, object_count, bytes_used, missing_chunks,
                 str(autocreate_account), Timestamp(time()).normal, EXPIRE_TIME,
                 str(autocreate_container)]
         try:
@@ -416,6 +438,7 @@ class AccountBackend(RedisConn):
         i = 0
         for container in raw_list:
             if not container[3]:
+                # FIXME(adu) Convert to dict
                 container[1] = int_value(res[i][0], 0)
                 container[2] = int_value(res[i][1], 0)
                 container[4] = float_value(res[i][2], 0.0)

--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -144,7 +144,7 @@ class AccountClient(HttpApi):
         :type to_delete: `list`
         """
         data = json.dumps({"metadata": metadata, "to_delete": to_delete})
-        self.account_request(account, 'POST', 'update', data=data, **kwargs)
+        self.account_request(account, 'PUT', 'update', data=data, **kwargs)
 
     def container_list(self, account, limit=None, marker=None,
                        end_marker=None, prefix=None, delimiter=None,
@@ -191,7 +191,7 @@ class AccountClient(HttpApi):
         :type metadata: `dict`
         """
         metadata['name'] = container
-        _resp, body = self.account_request(account, 'POST', 'container/update',
+        _resp, body = self.account_request(account, 'PUT', 'container/update',
                                            data=json.dumps(metadata), **kwargs)
         return body
 
@@ -208,7 +208,7 @@ class AccountClient(HttpApi):
         metadata = dict()
         metadata["name"] = container
         metadata["mtime"] = mtime
-        self.account_request(account, 'POST', 'container/reset',
+        self.account_request(account, 'PUT', 'container/reset',
                              data=json.dumps(metadata), **kwargs)
 
     def account_refresh(self, account, **kwargs):

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -412,15 +412,17 @@ class Account(WerkzeugApp):
     # }}ACCT
     def on_account_container_update(self, req):
         account_id = self._get_account_id(req)
-        d = json.loads(req.get_data())
-        name = d.get('name')
-        mtime = d.get('mtime')
-        dtime = d.get('dtime')
-        object_count = d.get('objects')
-        bytes_used = d.get('bytes')
+        data = json.loads(req.get_data())
+        name = data.get('name')
+        mtime = data.get('mtime')
+        dtime = data.get('dtime')
+        object_count = data.get('objects')
+        bytes_used = data.get('bytes')
+        missing_chunks = data.get('missing-chunks')
         # Exceptions are catched by dispatch_request
         info = self.backend.update_container(
-            account_id, name, mtime, dtime, object_count, bytes_used)
+            account_id, name, mtime, dtime,
+            object_count, bytes_used, missing_chunks)
         result = json.dumps(info)
         return Response(result)
 
@@ -468,9 +470,11 @@ class Account(WerkzeugApp):
         dtime = None
         object_count = 0
         bytes_used = 0
+        missing_chunks = 0
         # Exceptions are catched by dispatch_request
         self.backend.update_container(
-            account_id, name, mtime, dtime, object_count, bytes_used,
+            account_id, name, mtime, dtime,
+            object_count, bytes_used, missing_chunks,
             autocreate_container=False)
         return Response(status=204)
 

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -50,18 +50,28 @@ class Account(WerkzeugApp):
 
         self.url_map = Map([
             Rule('/status', endpoint='status'),
-            Rule('/v1.0/account/create', endpoint='account_create'),
-            Rule('/v1.0/account/delete', endpoint='account_delete'),
-            Rule('/v1.0/account/list', endpoint='account_list'),
-            Rule('/v1.0/account/update', endpoint='account_update'),
-            Rule('/v1.0/account/show', endpoint='account_show'),
-            Rule('/v1.0/account/containers', endpoint='account_containers'),
-            Rule('/v1.0/account/refresh', endpoint='account_refresh'),
-            Rule('/v1.0/account/flush', endpoint='account_flush'),
+            Rule('/v1.0/account/create', endpoint='account_create',
+                 methods=['PUT']),
+            Rule('/v1.0/account/delete', endpoint='account_delete',
+                 methods=['POST']),
+            Rule('/v1.0/account/list', endpoint='account_list',
+                 methods=['GET']),
+            Rule('/v1.0/account/update', endpoint='account_update',
+                 methods=['PUT', 'POST']),  # FIXME(adu) only PUT
+            Rule('/v1.0/account/show', endpoint='account_show',
+                 methods=['GET']),
+            Rule('/v1.0/account/containers', endpoint='account_containers',
+                 methods=['GET']),
+            Rule('/v1.0/account/refresh', endpoint='account_refresh',
+                 methods=['POST']),
+            Rule('/v1.0/account/flush', endpoint='account_flush',
+                 methods=['POST']),
             Rule('/v1.0/account/container/update',
-                 endpoint='account_container_update'),
+                 endpoint='account_container_update',
+                 methods=['PUT', 'POST']),  # FIXME(adu) only PUT
             Rule('/v1.0/account/container/reset',
-                 endpoint='account_container_reset')
+                 endpoint='account_container_reset',
+                 methods=['PUT', 'POST']),  # FIXME(adu) only PUT
         ])
         super(Account, self).__init__(self.url_map, self.logger)
 
@@ -186,7 +196,7 @@ class Account(WerkzeugApp):
     #
     # .. code-block:: http
     #
-    #    PUT /v1.0/account/delete?id=myaccount HTTP/1.1
+    #    POST /v1.0/account/delete?id=myaccount HTTP/1.1
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
@@ -366,7 +376,7 @@ class Account(WerkzeugApp):
         return Response(result, mimetype='text/json')
 
     # ACCT{{
-    # POST /v1.0/account/container/update?id=<account_name>
+    # PUT /v1.0/account/container/update?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #
     # .. code-block:: json
@@ -383,7 +393,7 @@ class Account(WerkzeugApp):
     #
     # .. code-block:: http
     #
-    #    POST /v1.0/account/container/update?id=myaccount HTTP/1.1
+    #    PUT /v1.0/account/container/update?id=myaccount HTTP/1.1
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*
@@ -415,7 +425,7 @@ class Account(WerkzeugApp):
         return Response(result)
 
     # ACCT{{
-    # POST /v1.0/account/container/reset?id=<account_name>
+    # PUT /v1.0/account/container/reset?id=<account_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #
     # Reset statistics of the specified container.
@@ -425,7 +435,7 @@ class Account(WerkzeugApp):
     #
     # .. code-block:: http
     #
-    #    POST /v1.0/account/container/reset?id=myaccount HTTP/1.1
+    #    PUT /v1.0/account/container/reset?id=myaccount HTTP/1.1
     #    Host: 127.0.0.1:6013
     #    User-Agent: curl/7.47.0
     #    Accept: */*

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -338,6 +338,7 @@ class ShowContainer(ContainerCommandMixin, show.ShowOne):
         ctime = float(sys['sys.m2.ctime']) / 1000000.
         bytes_usage = sys.get('sys.m2.usage', 0)
         objects = sys.get('sys.m2.objects', 0)
+        missing_chunks = sys.get('sys.m2.chunks.missing', 0)
         if parsed_args.formatter == 'table':
             from oio.common.easy_value import convert_size
 
@@ -352,6 +353,7 @@ class ShowContainer(ContainerCommandMixin, show.ShowOne):
             'bytes_usage': bytes_usage,
             'quota': sys.get('sys.m2.quota', "Namespace default"),
             'objects': objects,
+            'missing_chunks': missing_chunks,
             'storage_policy': sys.get('sys.m2.policy.storage',
                                       "Namespace default"),
             'max_versions': sys.get('sys.m2.policy.version',

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -238,6 +238,13 @@ class TouchContainer(ContainersCommandMixin, command.Command):
     def get_parser(self, prog_name):
         parser = super(TouchContainer, self).get_parser(prog_name)
         self.patch_parser_container(parser)
+        parser.add_argument(
+            '--recompute',
+            dest='recompute',
+            default=False,
+            help='Recompute the statistics of the specified container',
+            action="store_true"
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -246,13 +253,13 @@ class TouchContainer(ContainersCommandMixin, command.Command):
             for container in parsed_args.containers:
                 self.app.client_manager.storage.container_touch(
                     self.app.client_manager.account,
-                    None, cid=container
+                    None, recompute=parsed_args.recompute, cid=container
                 )
         else:
             for container in parsed_args.containers:
                 self.app.client_manager.storage.container_touch(
                     self.app.client_manager.account,
-                    container
+                    container, recompute=parsed_args.recompute
                 )
 
 

--- a/oio/cli/events/events.py
+++ b/oio/cli/events/events.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -340,8 +340,12 @@ class ContainerClient(ProxyClient):
         return body
 
     def container_touch(self, account=None, reference=None, cid=None,
-                        **kwargs):
+                        recompute=False, missing_chunks=None, **kwargs):
         params = self._make_params(account, reference, cid=cid)
+        if recompute:
+            params['recompute'] = True
+            if missing_chunks is not None:
+                params['missing_chunks'] = missing_chunks
         self._request('POST', '/touch', params=params, **kwargs)
 
     def container_dedup(self, account=None, reference=None, cid=None,

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -41,8 +41,9 @@ class AccountUpdateFilter(Filter):
             url = event.env.get('url')
             body = dict()
             if event.event_type == EventTypes.CONTAINER_STATE:
-                body['bytes'] = data.get('bytes-count', 0)
                 body['objects'] = data.get('object-count', 0)
+                body['bytes'] = data.get('bytes-count', 0)
+                body['missing-chunks'] = data.get('missing-chunks', 0)
                 body['mtime'] = mtime
             elif event.event_type == EventTypes.CONTAINER_NEW:
                 body['mtime'] = mtime

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS proxy
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1199,8 +1199,31 @@ action_m2_container_dedup (struct req_args_s *args, struct json_object *j UNUSED
 static enum http_rc_e
 action_m2_container_touch (struct req_args_s *args, struct json_object *j UNUSED)
 {
-	PACKER_VOID(_pack) { return m2v2_remote_pack_TOUCHB (args->url, 0, DL()); }
-	GError *err = _resolve_meta2(args, _prefer_master(), _pack, NULL, NULL);
+	GError *err = NULL;
+
+	gboolean recompute = oio_str_parse_bool(OPT("recompute"), FALSE);
+	gint64 missing_chunks = 0;
+
+	if (recompute) {
+		const char *missing_chunks_str = OPT("missing_chunks");
+		if (missing_chunks_str) {
+			char *end = NULL;
+			missing_chunks = g_ascii_strtoll(missing_chunks_str, &end, 10);
+			if (!missing_chunks && end == missing_chunks_str) {
+				err = BADREQ("Invalid missing chunks parameter: %s",
+						missing_chunks_str);
+				goto end;
+			}
+		}
+	}
+
+	PACKER_VOID(_pack) {
+		return m2v2_remote_pack_TOUCHB(args->url, 0, DL(),
+				recompute, missing_chunks);
+	}
+	err = _resolve_meta2(args, _prefer_master(), _pack, NULL, NULL);
+
+end:
 	if (NULL != err) {
 		if (CODE_IS_NOTFOUND(err->code))
 			return _reply_forbidden_error (args, err);

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -447,9 +447,19 @@ m2v2_remote_pack_TOUCHC(struct oio_url_s *url, gint64 dl)
 }
 
 GByteArray*
-m2v2_remote_pack_TOUCHB(struct oio_url_s *url, guint32 flags, gint64 dl)
+m2v2_remote_pack_TOUCHB(struct oio_url_s *url, guint32 flags, gint64 dl,
+		gboolean recompute, gint64 missing_chunks)
 {
-	return _m2v2_pack_request_with_flags(NAME_MSGNAME_M2V1_TOUCH_CONTAINER, url, NULL, flags, dl);
+	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V1_TOUCH_CONTAINER,
+			url, NULL, dl);
+	flags = g_htonl(flags);
+	metautils_message_add_field(msg, NAME_MSGKEY_FLAGS,
+			&flags, sizeof(flags));
+	metautils_message_add_field_struint(msg, NAME_MSGKEY_RECOMPUTE,
+			BOOL(recompute));
+	metautils_message_add_field_strint64(msg, NAME_MSGKEY_MISSING_CHUNKS,
+			missing_chunks);
+	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta2v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -225,7 +225,9 @@ GByteArray* m2v2_remote_pack_PROP_GET(
 GByteArray* m2v2_remote_pack_TOUCHB(
 		struct oio_url_s *url,
 		guint32 flags,
-		gint64 deadline);
+		gint64 deadline,
+		gboolean recompute,
+		gint64 missing_chunks);
 
 GByteArray* m2v2_remote_pack_TOUCHC(
 		struct oio_url_s *url,

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -97,54 +97,60 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(backend.create_account(account_id), account_id)
         info = backend.info_account(account_id)
         self.assertEqual(info['id'], account_id)
-        self.assertEqual(info['bytes'], 0)
         self.assertEqual(info['objects'], 0)
+        self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['missing-chunks'], 0)
         self.assertEqual(info['containers'], 0)
         self.assertTrue(info['ctime'])
 
         # first container
         backend.update_container(account_id, 'c1', Timestamp(time()).normal, 0,
-                                 1, 1)
+                                 1, 1, 1)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
+        self.assertEqual(info['missing-chunks'], 1)
 
         # second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', Timestamp(time()).normal, 0,
-                                 0, 0)
+                                 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
+        self.assertEqual(info['missing-chunks'], 1)
 
         # update second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', Timestamp(time()).normal, 0,
-                                 1, 1)
+                                 1, 1, 1)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 2)
         self.assertEqual(info['bytes'], 2)
+        self.assertEqual(info['missing-chunks'], 2)
 
         # delete first container
         sleep(.00001)
         backend.update_container(account_id, 'c1', 0, Timestamp(time()).normal,
-                                 0, 0)
+                                 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
+        self.assertEqual(info['missing-chunks'], 1)
 
         # delete second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', 0, Timestamp(time()).normal,
-                                 0, 0)
+                                 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['missing-chunks'], 0)
 
     def test_update_after_container_deletion(self):
         backend = AccountBackend({}, self.conn)
@@ -154,16 +160,17 @@ class TestAccountBackend(BaseTestCase):
         # Container create event, sent immediately after creation
         backend.update_container(account_id, 'c1',
                                  Timestamp(time()).normal, None,
-                                 None, None)
+                                 None, None, None)
 
         # Container update event
         backend.update_container(account_id, 'c1',
                                  Timestamp(time()).normal, None,
-                                 3, 30)
+                                 3, 30, 5)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 3)
         self.assertEqual(info['bytes'], 30)
+        self.assertEqual(info['missing-chunks'], 5)
 
         # Container is flushed, but the event is deferred
         flush_timestamp = Timestamp(time()).normal
@@ -172,16 +179,17 @@ class TestAccountBackend(BaseTestCase):
         # Container delete event, sent immediately after deletion
         backend.update_container(account_id, 'c1',
                                  None, Timestamp(time()).normal,
-                                 None, None)
+                                 None, None, None)
 
         # Deferred container update event (with lower timestamp)
         backend.update_container(account_id, 'c1',
                                  flush_timestamp, None,
-                                 0, 0)
+                                 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['missing-chunks'], 0)
 
     def test_delete_container(self):
         backend = AccountBackend({}, self.conn)
@@ -192,14 +200,14 @@ class TestAccountBackend(BaseTestCase):
         mtime = Timestamp(time()).normal
 
         # initial container
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         # delete event
         sleep(.00001)
         dtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, dtime, 0, 0)
+        backend.update_container(account_id, name, mtime, dtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -207,7 +215,7 @@ class TestAccountBackend(BaseTestCase):
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, dtime, 0, 0)
+            backend.update_container(account_id, name, mtime, dtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -215,7 +223,7 @@ class TestAccountBackend(BaseTestCase):
 
         # old event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -229,7 +237,7 @@ class TestAccountBackend(BaseTestCase):
         mtime = Timestamp(time()).normal
 
         # create container
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(unicode(res[0], 'utf8'), name)
 
@@ -241,7 +249,7 @@ class TestAccountBackend(BaseTestCase):
         # delete container
         sleep(.00001)
         dtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, 0, dtime, 0, 0)
+        backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -249,7 +257,7 @@ class TestAccountBackend(BaseTestCase):
 
         # ensure it has been removed
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, 0, dtime, 0, 0)
+            backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -263,7 +271,7 @@ class TestAccountBackend(BaseTestCase):
         # initial container
         name = '"{<container \'&\' name>}"'
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -273,7 +281,7 @@ class TestAccountBackend(BaseTestCase):
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -284,7 +292,7 @@ class TestAccountBackend(BaseTestCase):
         # New event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -295,7 +303,7 @@ class TestAccountBackend(BaseTestCase):
         # Old event
         old_mtime = Timestamp(time() - 1).normal
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -306,7 +314,7 @@ class TestAccountBackend(BaseTestCase):
         # Old delete event
         dtime = Timestamp(time() - 1).normal
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, 0, dtime, 0, 0)
+            backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
         self.assertEqual(self.conn.hget('container:%s:%s' %
@@ -315,7 +323,7 @@ class TestAccountBackend(BaseTestCase):
         # New delete event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, 0, mtime, 0, 0)
+        backend.update_container(account_id, name, 0, mtime, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -324,7 +332,7 @@ class TestAccountBackend(BaseTestCase):
         # New event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
         self.assertEqual(self.conn.hget('container:%s:%s' %
@@ -342,17 +350,17 @@ class TestAccountBackend(BaseTestCase):
             for cont2 in xrange(125):
                 name = '%d-%04d' % (cont1, cont2)
                 backend.update_container(account_id, name,
-                                         Timestamp(time()).normal, 0, 0, 0)
+                                         Timestamp(time()).normal, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '2-0051-%04d' % cont
             backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0)
+                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '3-%04d-0049' % cont
             backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0)
+                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0)
 
         listing = backend.list_containers(account_id, marker='',
                                           delimiter='', limit=100)
@@ -435,7 +443,7 @@ class TestAccountBackend(BaseTestCase):
 
         name = '3-0049-'
         backend.update_container(account_id, name, Timestamp(time()).normal, 0,
-                                 0, 0)
+                                 0, 0, 0)
         listing = backend.list_containers(
             account_id, marker='3-0048', limit=10)
         self.assertEqual(len(listing), 10)
@@ -469,6 +477,7 @@ class TestAccountBackend(BaseTestCase):
 
         total_bytes = 0
         total_objects = 0
+        total_missing_chunks = 0
 
         # 10 containers with bytes and objects
         for i in range(10):
@@ -478,20 +487,26 @@ class TestAccountBackend(BaseTestCase):
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)
             total_objects += nb_objets
+            missing_chunks = random.randrange(100)
+            total_missing_chunks += missing_chunks
             backend.update_container(account_id, name, mtime, 0,
-                                     nb_objets, nb_bytes)
+                                     nb_objets, nb_bytes, missing_chunks)
 
         # change values
         self.conn.hset(account_key, 'bytes', 1)
         self.conn.hset(account_key, 'objects', 2)
+        self.conn.hset(account_key, 'missing-chunks', 3)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '1')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '2')
+        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'), '3')
 
         backend.refresh_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'),
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
+        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'),
+                         str(total_missing_chunks))
 
     def test_update_container_wrong_timestamp_format(self):
         backend = AccountBackend({}, self.conn)
@@ -501,20 +516,20 @@ class TestAccountBackend(BaseTestCase):
         # initial container
         name = '"{<container \'&\' name>}"'
         mtime = "12456.0000076"
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         mtime = "0000012456.00005"
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -523,7 +538,7 @@ class TestAccountBackend(BaseTestCase):
                                         (account_id, name), 'mtime'), mtime)
 
         mtime = "0000012456.00035"
-        backend.update_container(account_id, name, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -570,6 +585,7 @@ class TestAccountBackend(BaseTestCase):
 
         total_bytes = 0
         total_objects = 0
+        total_missing_chunks = 0
 
         # 10 containers with bytes and objects
         for i in range(10):
@@ -579,16 +595,21 @@ class TestAccountBackend(BaseTestCase):
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)
             total_objects += nb_objets
+            missing_chunks = random.randrange(100)
+            total_missing_chunks += missing_chunks
             backend.update_container(account_id, name, mtime, 0,
-                                     nb_objets, nb_bytes)
+                                     nb_objets, nb_bytes, missing_chunks)
 
         self.assertEqual(self.conn.hget(account_key, 'bytes'),
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
+        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'),
+                         str(total_missing_chunks))
 
         backend.flush_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '0')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '0')
+        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'), '0')
         self.assertEqual(self.conn.zcard("containers:%s" % account_id), 0)
         self.assertEqual(self.conn.exists("container:test:*"), 0)

--- a/tests/functional/account/test_server.py
+++ b/tests/functional/account/test_server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/account/test_server.py
+++ b/tests/functional/account/test_server.py
@@ -65,22 +65,22 @@ class TestAccountServer(BaseTestCase):
     def test_account_update(self):
         data = {'metadata': {'foo': 'bar'}, 'to_delete': []}
         data = json.dumps(data)
-        resp = self.app.post('/v1.0/account/update',
-                             data=data, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/update',
+                            data=data, query_string={'id': self.account_id})
         self.assertEqual(resp.status_code, 204)
 
     def test_account_container_update(self):
         data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
                 'objects': 0, 'bytes': 0}
         data = json.dumps(data)
-        resp = self.app.post('/v1.0/account/container/update',
-                             data=data, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/container/update',
+                            data=data, query_string={'id': self.account_id})
         self.assertEqual(resp.status_code, 200)
 
     def test_account_containers(self):
         args = {'id': self.account_id}
-        resp = self.app.post('/v1.0/account/containers',
-                             query_string=args)
+        resp = self.app.get('/v1.0/account/containers',
+                            query_string=args)
         self.assertEqual(resp.status_code, 200)
         data = self.json_loads(resp.data)
         for f in ["ctime", "objects", "bytes", "listing", "containers",
@@ -94,21 +94,23 @@ class TestAccountServer(BaseTestCase):
         data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
                 'objects': 12, 'bytes': 42}
         dataj = json.dumps(data)
-        resp = self.app.post('/v1.0/account/container/update',
-                             data=dataj, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/container/update',
+                            data=dataj, query_string={'id': self.account_id})
 
         data = {'name': 'foo', 'mtime': Timestamp(time()).normal}
         dataj = json.dumps(data)
-        resp = self.app.post('/v1.0/account/container/reset',
-                             data=dataj, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/container/reset',
+                            data=dataj, query_string={'id': self.account_id})
         self.assertEqual(resp.status_code, 204)
 
-        dataj = json.dumps({'prefix': 'foo'})
-        resp = self.app.post('/v1.0/account/containers',
-                             data=dataj, query_string={'id': self.account_id})
+        resp = self.app.get('/v1.0/account/containers',
+                            query_string={'id': self.account_id,
+                                          'prefix': 'foo'})
         resp = self.json_loads(resp.data)
         for container in resp["listing"]:
             name, nb_objects, nb_bytes, _, mtime = container
+            if not name.startswith('foo'):
+                self.fail("No prefix foo: %s" % name)
             if name == 'foo':
                 self.assertEqual(0, nb_objects)
                 self.assertEqual(0, nb_bytes)
@@ -120,15 +122,15 @@ class TestAccountServer(BaseTestCase):
         data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
                 'objects': 12, 'bytes': 42}
         data = json.dumps(data)
-        resp = self.app.post('/v1.0/account/container/update',
-                             data=data, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/container/update',
+                            data=data, query_string={'id': self.account_id})
 
         resp = self.app.post('/v1.0/account/refresh',
                              query_string={'id': self.account_id})
         self.assertEqual(resp.status_code, 204)
 
-        resp = self.app.post('/v1.0/account/show',
-                             query_string={'id': self.account_id})
+        resp = self.app.get('/v1.0/account/show',
+                            query_string={'id': self.account_id})
         resp = self.json_loads(resp.data)
         self.assertEqual(resp["bytes"], 42)
         self.assertEqual(resp["objects"], 12)
@@ -137,20 +139,20 @@ class TestAccountServer(BaseTestCase):
         data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
                 'objects': 12, 'bytes': 42}
         data = json.dumps(data)
-        resp = self.app.post('/v1.0/account/container/update',
-                             data=data, query_string={'id': self.account_id})
+        resp = self.app.put('/v1.0/account/container/update',
+                            data=data, query_string={'id': self.account_id})
 
         resp = self.app.post('/v1.0/account/flush',
                              query_string={'id': self.account_id})
         self.assertEqual(resp.status_code, 204)
 
-        resp = self.app.post('/v1.0/account/show',
-                             query_string={'id': self.account_id})
+        resp = self.app.get('/v1.0/account/show',
+                            query_string={'id': self.account_id})
         resp = self.json_loads(resp.data)
         self.assertEqual(resp["bytes"], 0)
         self.assertEqual(resp["objects"], 0)
 
-        resp = self.app.post('/v1.0/account/containers',
-                             query_string={'id': self.account_id})
+        resp = self.app.get('/v1.0/account/containers',
+                            query_string={'id': self.account_id})
         resp = self.json_loads(resp.data)
         self.assertEqual(len(resp["listing"]), 0)

--- a/tests/functional/cli/account/test_account.py
+++ b/tests/functional/cli/account/test_account.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/cli/account/test_account.py
+++ b/tests/functional/cli/account/test_account.py
@@ -21,7 +21,7 @@ from testtools.matchers import Equals
 
 HEADERS = ['Name', 'Created']
 ACCOUNT_FIELDS = ['bytes', 'containers', 'ctime', 'account', 'metadata',
-                  'objects']
+                  'objects', 'missing-chunks']
 
 
 class AccountTest(CliTestCase):
@@ -47,6 +47,7 @@ class AccountTest(CliTestCase):
         self.assertThat(data['bytes'], Equals(0))
         self.assertThat(data['containers'], Equals(0))
         self.assertThat(data['objects'], Equals(0))
+        self.assertThat(data['missing-chunks'], Equals(0))
         self.assertThat(data['metadata']['test'], Equals('1'))
         output = self.openio('account delete ' + self.NAME)
         self.assertOutput('', output)
@@ -58,6 +59,7 @@ class AccountTest(CliTestCase):
         regex = r"|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
+        self.assertIsNotNone(re.match(regex % ("missing-chunks", "0"), output))
 
     def test_account_refresh(self):
         self.openio('account create ' + self.NAME)
@@ -69,6 +71,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['missing-chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
     def test_account_refresh_all(self):
@@ -81,6 +84,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['missing-chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
     def test_account_flush(self):
@@ -94,5 +98,6 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['missing-chunks'], 0)
         self.openio('container delete ' + self.NAME)
         self.openio('account delete ' + self.NAME)

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -27,7 +27,7 @@ OBJ_HEADERS = ['Name', 'Size', 'Hash']
 CONTAINER_LIST_HEADERS = ['Name', 'Bytes', 'Count']
 CONTAINER_FIELDS = ['account', 'base_name', 'bytes_usage', 'quota',
                     'container', 'ctime', 'storage_policy', 'objects',
-                    'max_versions', 'status']
+                    'max_versions', 'status', 'missing_chunks']
 OBJ_FIELDS = ['account', 'container', 'ctime', 'hash', 'id', 'mime-type',
               'mtime', 'object', 'policy', 'size', 'version']
 

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -127,7 +127,7 @@ class TestMeta2Containers(BaseTestCase):
         args = {'id': self.account, 'prefix': 'container-'}
         url = ''.join(['http://', self.conf['services']['account'][0]['addr'],
                        '/v1.0/account/containers'])
-        resp = self.request('POST', url, params=args)
+        resp = self.request('GET', url, params=args)
         self.assertEqual(resp.status, 200)
         data = self.json_loads(resp.data)
 

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -414,13 +414,15 @@ class TestMeta2Containers(BaseTestCase):
         del_properties(p0.keys())
         check_properties(p1)
 
-    def _create_content(self, name):
+    def _create_content(self, name, missing_chunks=0):
         headers = {'X-oio-action-mode': 'autocreate'}
         params = self.param_content(self.ref, name)
         resp = self.request('POST', self.url_content('prepare'), params=params,
                             headers=headers, data=json.dumps({'size': '1024'}))
         self.assertEqual(200, resp.status)
         chunks = self.json_loads(resp.data)
+        for _ in range(0, missing_chunks):
+            chunks.pop()
 
         stgpol = resp.getheader('x-oio-content-meta-policy')
         headers = {'x-oio-action-mode': 'autocreate',
@@ -537,6 +539,64 @@ class TestMeta2Containers(BaseTestCase):
             self._create_content("content%02d" % i)
         flush_and_check(truncated=True, objects=16, usage=16384)
         flush_and_check()
+
+    def _check_missing_chunks(self, expected_missing_chunks):
+        params = self.param_ref(self.ref)
+        resp = self.request('POST', self.url_container('get_properties'),
+                            params=params)
+        self.assertEqual(resp.status, 200)
+        data = self.json_loads(resp.data)
+        self.assertEqual(str(expected_missing_chunks),
+                         data['system']['sys.m2.chunks.missing'])
+
+    def _delete_content(self, obj_name):
+        params = self.param_content(self.ref, obj_name)
+        resp = self.request('POST', self.url_content('delete'), params=params)
+        self.assertEqual(resp.status, 204)
+
+    def test_missing_chunks(self):
+        stg_policy = self.conscience.info().get(
+            'options', dict()).get('storage_policy')
+        if stg_policy != 'THREECOPIES' and stg_policy != 'EC':
+            self.skipTest('The storage policy must be THREECOPIES or EC')
+
+        self._create_content('content0', missing_chunks=0)
+        self._check_missing_chunks(0)
+
+        self._create_content('content1', missing_chunks=1)
+        self._check_missing_chunks(1)
+
+        self._create_content('content2', missing_chunks=0)
+        self._check_missing_chunks(1)
+        self._create_content('content2', missing_chunks=1)
+        self._check_missing_chunks(2)
+
+        self._create_content('content3', missing_chunks=1)
+        self._check_missing_chunks(3)
+        self._create_content('content3', missing_chunks=0)
+        self._check_missing_chunks(2)
+
+        self._delete_content('content1')
+        self._check_missing_chunks(1)
+
+        if stg_policy != "EC":
+            return
+
+        self._create_content('content4', missing_chunks=2)
+        self._check_missing_chunks(3)
+
+        self._create_content('content5', missing_chunks=0)
+        self._check_missing_chunks(3)
+        self._create_content('content5', missing_chunks=2)
+        self._check_missing_chunks(5)
+
+        self._create_content('content6', missing_chunks=2)
+        self._check_missing_chunks(7)
+        self._create_content('content6', missing_chunks=0)
+        self._check_missing_chunks(5)
+
+        self._delete_content('content4')
+        self._check_missing_chunks(3)
 
 
 class TestMeta2Contents(BaseTestCase):

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS unit tests
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/tools/event-benchmark/fake_service.c
+++ b/tools/event-benchmark/fake_service.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS oio-event-benchmark
-Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2017-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/tools/event-benchmark/fake_service.c
+++ b/tools/event-benchmark/fake_service.c
@@ -280,7 +280,7 @@ configure_request_handlers(void)
 
 	SET("v1/rdir/push/#POST", action_chunk_new);
 	SET("v1/rdir/delete/#DELETE", action_chunk_delete);
-	SET("v1.0/account/container/update/#POST", action_account);
+	SET("v1.0/account/container/update/#PUT", action_account);
 	SET("rawx/#DELETE", action_rawx);
 }
 


### PR DESCRIPTION
##### SUMMARY

- Save the number of missing chunks in the meta2 database
- Use the event (`container.state`) to update the account
- Increase the counter to each chunk not uploaded
- Decrease the counter to each deleted object with missing chunks
- Decrease the counter to each rebuilt chunk (chunk not uploaded)
- Recompute the counter of missing chunks

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- Python API
- `account`
- `proxy`
- `meta2`

##### SDS VERSION

```
openio 4.3.1.dev32
```