### PR TITLE
core: Forget the service subtype

### DIFF
--- a/core/oiourl.h
+++ b/core/oiourl.h
@@ -32,14 +32,11 @@ License along with this library.
 extern "C" {
 #endif
 
-#define OIOURL_DEFAULT_TYPE    ""
-
 enum oio_url_field_e
 {
 	OIOURL_NS=1,
 	OIOURL_ACCOUNT,
 	OIOURL_USER,
-	OIOURL_TYPE,
 	OIOURL_PATH,
 
 	OIOURL_VERSION,

--- a/core/proxy.c
+++ b/core/proxy.c
@@ -134,15 +134,6 @@ _curl_conscience_url (const char *ns, const char *action)
 }
 
 static GString *
-_append_type (struct oio_url_s *u, GString *hu)
-{
-	const char *type = oio_url_get (u, OIOURL_TYPE);
-	if (type && *type)
-		_append (hu, '&', "type", type);
-	return hu;
-}
-
-static GString *
 _curl_container_url (struct oio_url_s *u, const char *action)
 {
 	GString *hu = _curl_url_prefix_containers (u);
@@ -152,7 +143,6 @@ _curl_container_url (struct oio_url_s *u, const char *action)
 			oio_url_get(u, OIOURL_NS), action);
 	_append (hu, '?', "acct", oio_url_get (u, OIOURL_ACCOUNT));
 	_append (hu, '&', "ref",  oio_url_get (u, OIOURL_USER));
-	_append_type (u, hu);
 	return hu;
 }
 
@@ -166,7 +156,6 @@ _curl_content_url (struct oio_url_s *u, const char *action)
 			oio_url_get(u, OIOURL_NS), action);
 	_append (hu, '?', "acct", oio_url_get (u, OIOURL_ACCOUNT));
 	_append (hu, '&', "ref",  oio_url_get (u, OIOURL_USER));
-	_append_type (u, hu);
 	_append (hu, '&', "path", oio_url_get (u, OIOURL_PATH));
 	return hu;
 }

--- a/core/tool_roundtrip.c
+++ b/core/tool_roundtrip.c
@@ -782,18 +782,16 @@ main(int argc, char **argv)
 	oio_url_set (url, OIOURL_NS, g_getenv("OIO_NS"));
 	oio_url_set (url, OIOURL_ACCOUNT, g_getenv("OIO_ACCOUNT"));
 	oio_url_set (url, OIOURL_USER, g_getenv("OIO_USER"));
-	oio_url_set (url, OIOURL_TYPE, g_getenv("OIO_TYPE"));
 	oio_url_set (url, OIOURL_PATH, g_getenv("OIO_PATH"));
 
 	if (!oio_url_has_fq_path(url)) {
 		g_printerr ("Partial URL [%s]: requires a NS (%s), an ACCOUNT (%s),"
-				" an USER (%s) and a PATH (%s) (+ optional TYPE: %s)\n",
+				" an USER (%s) and a PATH (%s)\n",
 				oio_url_get (url, OIOURL_WHOLE),
 				oio_url_has (url, OIOURL_NS)?"ok":"missing",
 				oio_url_has (url, OIOURL_ACCOUNT)?"ok":"missing",
 				oio_url_has (url, OIOURL_USER)?"ok":"missing",
-				oio_url_has (url, OIOURL_PATH)?"ok":"missing",
-				oio_url_has (url, OIOURL_TYPE)?"ok":"missing");
+				oio_url_has (url, OIOURL_PATH)?"ok":"missing");
 		return 3;
 	}
 	GRID_DEBUG("URL valid [%s]", oio_url_get (url, OIOURL_WHOLE));

--- a/meta1v2/compound_types.c
+++ b/meta1v2/compound_types.c
@@ -26,26 +26,17 @@ compound_type_clean(struct compound_type_s *ct)
 {
 	if (!ct)
 		return;
-	if (ct->type)
-		g_free(ct->type);
 	if (ct->req.k)
 		g_free(ct->req.k);
 	if (ct->req.v)
 		g_free(ct->req.v);
-	if (ct->baretype)
-		g_free(ct->baretype);
-	if (ct->subtype)
-		g_free(ct->subtype);
-	memset(ct, 0, sizeof(*ct));
 }
 
 static void
 _parse_type(struct compound_type_s *ct, gchar *s)
 {
 	gchar **tokens = g_strsplit(s, ".", 2);
-	ct->type = s;
-	ct->baretype = tokens[0];
-	ct->subtype = tokens[1] ? tokens[1] : g_strdup("");
+	g_strlcpy(ct->type, s, sizeof(ct->type));
 	g_free(tokens);
 }
 
@@ -78,9 +69,8 @@ compound_type_parse(struct compound_type_s *ct, const gchar *srvtype)
 	_parse_args(ct, tokens[1]);
 	g_free(tokens);
 
-	GRID_TRACE("CT full[%s] type[%s] bare[%s] sub[%s] args[%s|%s]",
-			ct->fulltype, ct->type, ct->baretype, ct->subtype,
-			ct->req.k, ct->req.v);
+	GRID_TRACE("CT full[%s] type[%s] args[%s|%s]",
+			ct->fulltype, ct->type, ct->req.k, ct->req.v);
 
 	return NULL;
 }
@@ -91,7 +81,7 @@ compound_type_update_arg(struct compound_type_s *ct,
 {
 	gchar *k = NULL, *v = NULL;
 
-	if (service_update_tagfilter(pol, ct->baretype, &k, &v)) {
+	if (service_update_tagfilter(pol, ct->type, &k, &v)) {
 		if (override || !ct->req.k) {
 			oio_str_reuse(&(ct->req.k),  k);
 			oio_str_reuse(&(ct->req.v),  v);
@@ -104,4 +94,3 @@ compound_type_update_arg(struct compound_type_s *ct,
 	if (v)
 		g_free(v);
 }
-

--- a/meta1v2/compound_types.h
+++ b/meta1v2/compound_types.h
@@ -21,15 +21,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define OIO_SDS__meta1v2__compound_types_h 1
 
 #include <glib.h>
+#include <metautils/lib/metatypes.h>
 
 struct service_update_policies_s;
 
 struct compound_type_s
 {
 	const gchar *fulltype;
-	gchar *baretype;
-	gchar *subtype;
-	gchar *type; // baretype . subtype
+	gchar type[LIMIT_LENGTH_SRVTYPE]; // type without args
 
 	struct { // <key,value> to be matched
 		gchar *k;

--- a/meta1v2/meta1_backend_references.c
+++ b/meta1v2/meta1_backend_references.c
@@ -164,7 +164,7 @@ meta1_backend_user_destroy(struct meta1_backend_s *m1,
 		if (!(err = __info_user(sq3, url, FALSE, NULL)))
 			err = __destroy_container(sq3, url, force, NULL);
 		if (NULL != err)
-			g_prefix_error(&err, "Query error: ");  
+			g_prefix_error(&err, "Query error: ");
 		err = sqlx_transaction_end(repctx, err);
 	}
 

--- a/meta1v2/meta1_server.c
+++ b/meta1v2/meta1_server.c
@@ -158,9 +158,8 @@ _get_peers(struct sqlx_service_s *ss UNUSED, const struct sqlx_name_s *n,
 	struct oio_url_s *u = oio_url_empty();
 	oio_url_set(u, OIOURL_NS, ss->ns_name);
 
-	if (!sqlx_name_extract(n, u, ss->service_config->srvtype, &seq)) {
-		err = BADREQ("Invalid type name: '%s'", n->type);
-	} else {
+	err = sqlx_name_extract(n, u, NAME_SRVTYPE_META1, &seq);
+	if (!err) {
 		err = hc_resolve_reference_directory(ss->resolver, u, &peers, oio_ext_get_deadline());
 	}
 	if (!err) {

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -302,16 +302,6 @@ _container_state (struct sqlx_sqlite3_s *sq3)
 	}
 
 	struct oio_url_s *u = sqlx_admin_get_url (sq3);
-
-	/* Patch the SUBTYPE: the URL must represent an object as managed by meta2
-	 * services (and also by end-user APIs). Unlike for sqlx services, the user
-	 * doesn't know anything about the meta2, and never mentions it in URL.
-	 * This is why we strip this from the service type. */
-	if (!strcmp(sq3->name.type, NAME_SRVTYPE_META2))
-		oio_url_set (u, OIOURL_TYPE, "");
-	else if (g_str_has_prefix (sq3->name.type, NAME_SRVTYPE_META2 "."))
-		oio_url_set (u, OIOURL_TYPE, sq3->name.type + sizeof(NAME_SRVTYPE_META2));
-
 	GString *gs = oio_event__create (META2_EVENTS_PREFIX ".container.state", u);
 	g_string_append_static (gs, ",\"data\":{");
 	append_const (gs, "policy", sqlx_admin_get_str(sq3, M2V2_ADMIN_STORAGE_POLICY));
@@ -433,7 +423,6 @@ m2b_open(struct meta2_backend_s *m2, struct oio_url_s *url,
 	set (SQLX_ADMIN_NAMESPACE, OIOURL_NS);
 	set (SQLX_ADMIN_ACCOUNT, OIOURL_ACCOUNT);
 	set (SQLX_ADMIN_USERNAME, OIOURL_USER);
-	set (SQLX_ADMIN_USERTYPE, OIOURL_TYPE);
 
 	*result = sq3;
 	return NULL;

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -59,12 +59,15 @@ meta2_on_close(struct sqlx_sqlite3_s *sq3, gboolean deleted, gpointer cb_data)
 	struct oio_url_s *u = oio_url_empty ();
 	oio_url_set (u, OIOURL_NS, PSRV(cb_data)->ns_name);
 	NAME2CONST(n, sq3->name);
-	if (!sqlx_name_extract (&n, u, NAME_SRVTYPE_META2, &seq)) {
-		GRID_WARN("Invalid base name [%s]", sq3->name.base);
-		return;
+
+	GError *err = sqlx_name_extract (&n, u, NAME_SRVTYPE_META2, &seq);
+	if (err) {
+		GRID_WARN("Invalid base name [%s]: %s", sq3->name.base, err->message);
+		g_clear_error(&err);
+	} else {
+		hc_decache_reference_service(PSRV(cb_data)->resolver, u, NAME_SRVTYPE_META2);
+		oio_url_pclean(&u);
 	}
-	hc_decache_reference_service(PSRV(cb_data)->resolver, u, NAME_SRVTYPE_META2);
-	oio_url_pclean(&u);
 }
 
 static gboolean

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -2743,7 +2743,6 @@ m2db_set_container_name(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url)
 		{SQLX_ADMIN_NAMESPACE, OIOURL_NS},
 		{SQLX_ADMIN_ACCOUNT, OIOURL_ACCOUNT},
 		{SQLX_ADMIN_USERNAME, OIOURL_USER},
-		{SQLX_ADMIN_USERTYPE, OIOURL_TYPE},
 		{NULL,0},
 	};
 	for (struct map_s *p = map; p->f; ++p) {

--- a/metautils/lib/comm_message.c
+++ b/metautils/lib/comm_message.c
@@ -369,7 +369,6 @@ static struct map_s
 	{NAME_MSGKEY_NAMESPACE,   OIOURL_NS,        NULL, LIMIT_LENGTH_NSNAME},
 	{NAME_MSGKEY_ACCOUNT,     OIOURL_ACCOUNT,   NULL, LIMIT_LENGTH_ACCOUNTNAME},
 	{NAME_MSGKEY_USER,        OIOURL_USER,      NULL, LIMIT_LENGTH_BASENAME},
-	{NAME_MSGKEY_TYPENAME,    OIOURL_TYPE,      OIOURL_DEFAULT_TYPE, LIMIT_LENGTH_SRVTYPE},
 	{NAME_MSGKEY_CONTENTPATH, OIOURL_PATH,      NULL, LIMIT_LENGTH_CONTENTPATH},
 	{NAME_MSGKEY_CONTENTID,   OIOURL_CONTENTID, NULL, STRLEN_CONTAINERID},
 	{NAME_MSGKEY_VERSION,     OIOURL_VERSION,   NULL, LIMIT_LENGTH_VERSION},
@@ -400,7 +399,7 @@ metautils_message_add_url_no_type (MESSAGE m, struct oio_url_s *url)
 	if (!m)
 		return;
 	for (struct map_s *p = url2msg_map; p->f ;++p) {
-		if (p->u != OIOURL_TYPE && oio_url_has (url, p->u)) {
+		if (oio_url_has (url, p->u)) {
 			const char *s = oio_url_get (url, p->u);
 			if (!p->avoid || strcmp(p->avoid, s))
 				metautils_message_add_field_str(m, p->f, s);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -169,9 +169,6 @@ _metacd_load_url (struct req_args_s *args, struct oio_url_s *url)
 	if (NULL != (s = REF()))
 		oio_url_set (url, OIOURL_USER, s);
 
-	if (NULL != (s = TYPE()))
-		oio_url_set (url, OIOURL_TYPE, s);
-
 	if (NULL != (s = PATH())) {
 		oio_url_set (url, OIOURL_PATH, s);
 		if (NULL != (s = VERSION()))

--- a/rawx-apache2/src/rawx_event.c
+++ b/rawx-apache2/src/rawx_event.c
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <events/oio_events_queue.h>
 #include <core/internals.h>
+#include <metautils/lib/metautils_macros.h>
 #include "rawx_event.h"
 
 struct oio_events_queue_s *q = NULL;

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -448,22 +448,22 @@ sqlx_alert_dirty_base(struct sqlx_sqlite3_s *sq3, const char *msg)
 	g_assert (!sq3->admin_dirty);
 }
 
+#define _set(which,k) do { \
+		gchar *s = sqlx_admin_get_str(sq3, k); \
+		if (s) { \
+			oio_url_set (u, which, s); \
+			g_free (s); \
+		} \
+	} while (0)
+
 struct oio_url_s*
 sqlx_admin_get_url (struct sqlx_sqlite3_s *sq3)
 {
 	EXTRA_ASSERT(sq3 != NULL);
 	struct oio_url_s *u = oio_url_empty ();
-	void _set (int which, const char *k) {
-		gchar *s = sqlx_admin_get_str(sq3, k);
-		if (s) {
-			oio_url_set (u, which, s);
-			g_free (s);
-		}
-	}
 	_set (OIOURL_NS, SQLX_ADMIN_NAMESPACE);
 	_set (OIOURL_ACCOUNT, SQLX_ADMIN_ACCOUNT);
 	_set (OIOURL_USER, SQLX_ADMIN_USERNAME);
-	oio_url_set (u, OIOURL_TYPE, sq3->name.type);
 	return u;
 }
 

--- a/sqliterepo/sqlx_remote.h
+++ b/sqliterepo/sqlx_remote.h
@@ -60,15 +60,14 @@ struct sqlx_name_s
 	const char *type;
 };
 
-void sqlx_inline_name_fill  (struct sqlx_name_inline_s *n,
-		struct oio_url_s *url, const char *srvtype, gint64 seq);
+#define sqlx_inline_name_fill sqlx_inline_name_fill_type_asis
 
 void sqlx_inline_name_fill_type_asis  (struct sqlx_name_inline_s *n,
 		struct oio_url_s *url, const char *srvtype, gint64 seq);
 
 
-gboolean sqlx_name_extract (const struct sqlx_name_s *n, struct oio_url_s *url,
-		const char *srvtype, gint64 *pseq);
+GError* sqlx_name_extract (const struct sqlx_name_s *n,
+		struct oio_url_s *url, const char *srvtype, gint64 *pseq);
 
 // sqliterepo-related requests coders ------------------------------------------
 

--- a/sqlx/sqlx_client_direct.c
+++ b/sqlx/sqlx_client_direct.c
@@ -131,17 +131,6 @@ oio_sqlx_client_factory__create_sds (const char *ns,
 /* -------------------------------------------------------------------------- */
 
 static void
-_sds_client_get_srvtype (struct oio_sqlx_client_SDS_s *self, gchar *d, gsize dlen)
-{
-	g_strlcpy (d, NAME_SRVTYPE_SQLX, dlen);
-	const char *subtype = oio_url_get (self->url, OIOURL_TYPE);
-	if (subtype && *subtype) {
-		g_strlcat (d, ".", dlen);
-		g_strlcat (d, subtype, dlen);
-	}
-}
-
-static void
 _sds_client_destroy (struct oio_sqlx_client_s *self)
 {
 	g_assert (self != NULL);
@@ -164,12 +153,9 @@ _sds_client_create_db (struct oio_sqlx_client_s *self)
 	g_assert (c->vtable == &vtable_SDS);
 
 	/* Link with the directory */
-	gchar srvtype[64] = "";
-	_sds_client_get_srvtype (c, srvtype, sizeof(srvtype));
-
 	gchar **allsrv = NULL;
 	GError *err = oio_directory__link (c->factory->dir,
-			c->url, srvtype, TRUE/*autocreate*/, &allsrv);
+			c->url, NAME_SRVTYPE_SQLX, TRUE/*autocreate*/, &allsrv);
 	if (err) {
 		g_prefix_error (&err, "Directory error: ");
 		EXTRA_ASSERT (allsrv == NULL);
@@ -373,12 +359,9 @@ _sds_client_batch (struct oio_sqlx_client_s *self,
 	g_assert (c->factory != NULL);
 
 	/* locate the sqlx server via the directory object */
-	gchar srvtype[64] = "";
-	_sds_client_get_srvtype (c, srvtype, sizeof(srvtype));
-
 	gchar **allsrv = NULL;
 	GError *err = oio_directory__list (c->factory->dir,
-			c->url, srvtype, NULL, &allsrv);
+			c->url, NAME_SRVTYPE_SQLX, NULL, &allsrv);
 	if (NULL != err) {
 		g_prefix_error (&err, "Directory error: ");
 		g_assert (allsrv == NULL);

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -506,9 +506,8 @@ sqlx_service_resolve_peers(struct sqlx_service_s *ss,
 	struct oio_url_s *u = oio_url_empty ();
 	oio_url_set(u, OIOURL_NS, ss->ns_name);
 
-	if (!sqlx_name_extract(n, u, ss->service_config->srvtype, &seq)) {
-		err = BADREQ("Invalid type name: '%s'", n->type);
-	} else {
+	err = sqlx_name_extract(n, u, NAME_SRVTYPE_SQLX, &seq);
+	if (!err) {
 label_retry:
 		if (nocache)
 			hc_decache_reference_service(ss->resolver, u, n->type);

--- a/tests/functional/event/test_events_emission.py
+++ b/tests/functional/event/test_events_emission.py
@@ -89,7 +89,6 @@ class TestMeta2EventsEmission(BaseTestCase):
             'account': self.account,
             'user': self.container_name,
             'id': self.container_id,
-            'type': 'meta2'
         })
 
         # Get the peers list and verify it's the same as received

--- a/tests/unit/test_url.c
+++ b/tests/unit/test_url.c
@@ -31,13 +31,12 @@ struct test_data_s {
 	const char *ns;
 	const char *account;
 	const char *ref;
-	const char *type;
 	const char *path;
 
 	const char *hexa;
 };
 
-#define TEST_END {NULL,NULL, NULL,NULL,NULL,NULL,NULL, NULL}
+#define TEST_END {NULL,NULL, NULL,NULL,NULL,NULL, NULL}
 
 static void
 _test_field (const char *expected, struct oio_url_s *u, enum oio_url_field_e f)
@@ -59,7 +58,6 @@ _test_url (guint idx, struct oio_url_s *u, struct test_data_s *td)
 	_test_field (td->ns, u, OIOURL_NS);
 	_test_field (td->account, u, OIOURL_ACCOUNT);
 	_test_field (td->ref, u, OIOURL_USER);
-	_test_field (td->type, u, OIOURL_TYPE);
 	_test_field (td->path, u, OIOURL_PATH);
 	if (td->hexa) {
 		g_assert_true (oio_url_has (u, OIOURL_HEXID));
@@ -80,7 +78,6 @@ _init_url (struct test_data_s *td)
 	if (td->ns) oio_url_set (url, OIOURL_NS, td->ns);
 	if (td->account) oio_url_set (url, OIOURL_ACCOUNT, td->account);
 	if (td->ref) oio_url_set (url, OIOURL_USER, td->ref);
-	if (td->type) oio_url_set (url, OIOURL_TYPE, td->type);
 	if (td->path) oio_url_set (url, OIOURL_PATH, td->path);
 	return url;
 }
@@ -90,31 +87,31 @@ test_configure_valid (void)
 {
 	static struct test_data_s tab[] = {
 		{ "/NS/ACCT/JFS", "NS/ACCT/JFS/",
-			"NS", "ACCT", "JFS", OIOURL_DEFAULT_TYPE, NULL,
+			"NS", "ACCT", "JFS", NULL,
 			"9006CE70B59E5777D6BB410C57944812EB05FCDB5BA85D520A14B3051D1D094F"},
 
 		{ "NS/ACCT/JFS//1.", "NS/ACCT/JFS//1.",
-			"NS", "ACCT", "JFS", OIOURL_DEFAULT_TYPE, "1.",
+			"NS", "ACCT", "JFS", "1.",
 			"9006CE70B59E5777D6BB410C57944812EB05FCDB5BA85D520A14B3051D1D094F"},
 
 		{ "NS/ACCT/JFS//x x", "NS/ACCT/JFS//x%20x",
-			"NS", "ACCT", "JFS", OIOURL_DEFAULT_TYPE, "x x",
+			"NS", "ACCT", "JFS", "x x",
 			"9006CE70B59E5777D6BB410C57944812EB05FCDB5BA85D520A14B3051D1D094F"},
 
 		{ "NS/ACCT/JFS//x%20x", "NS/ACCT/JFS//x%20x",
-			"NS", "ACCT", "JFS", OIOURL_DEFAULT_TYPE, "x x",
+			"NS", "ACCT", "JFS", "x x",
 			"9006CE70B59E5777D6BB410C57944812EB05FCDB5BA85D520A14B3051D1D094F"},
 
 		/* if no ACCOUNT is set, no hexa ID can be computed */
-		{ NULL, "NS", "NS", NULL, "JFS", NULL, NULL, NULL},
-		{ NULL, "NS", "NS", NULL, "JFS", OIOURL_DEFAULT_TYPE, "x", NULL},
+		{ NULL, "NS", "NS", NULL, "JFS", NULL, NULL},
+		{ NULL, "NS", "NS", NULL, "JFS", "x", NULL},
 
 		/* if no USER is set, no hexa ID can be computed */
-		{ NULL, "NS/ACCT", "NS", "ACCT", NULL, NULL, NULL, NULL},
-		{ NULL, "NS/ACCT", "NS", "ACCT", NULL, OIOURL_DEFAULT_TYPE, "x", NULL},
+		{ NULL, "NS/ACCT", "NS", "ACCT", NULL, NULL, NULL},
+		{ NULL, "NS/ACCT", "NS", "ACCT", NULL, "x", NULL},
 
 		{ NULL, "NS/ACCT/JFS/",
-			"NS", "ACCT", "JFS", NULL, NULL,
+			"NS", "ACCT", "JFS", NULL,
 			"9006CE70B59E5777D6BB410C57944812EB05FCDB5BA85D520A14B3051D1D094F"},
 
 		TEST_END
@@ -203,9 +200,6 @@ test_dup (void)
 
 	(void) oio_url_get_id (u0);
 	(void) oio_url_get_id_size (u0);
-	_round_dup_cleanup (u0);
-
-	oio_url_set (u0, OIOURL_TYPE, "mail");
 	_round_dup_cleanup (u0);
 
 	oio_url_set (u0, OIOURL_PATH, "path");

--- a/tools/event-benchmark/event_benchmark.c
+++ b/tools/event-benchmark/event_benchmark.c
@@ -51,7 +51,6 @@ link_rawx_fake_service(void)
 	oio_url_set(rdir_rawx_url, OIOURL_NS, namespace);
 	oio_url_set(rdir_rawx_url, OIOURL_ACCOUNT, NAME_ACCOUNT_RDIR);
 	oio_url_set(rdir_rawx_url, OIOURL_USER, RAWX_ADDRESS);
-	oio_url_set(rdir_rawx_url, OIOURL_TYPE, NAME_SRVTYPE_RDIR);
 
 	char *id = g_strdup_printf("%s|" NAME_SRVTYPE_RDIR "|" FAKE_SERVICE_ADDRESS,
 			namespace);


### PR DESCRIPTION
##### SUMMARY
The current PR removes that service subtype from objects URL.

The oio_url_s represents the official composite path to a logical entity (either an account, a container or an object). Prior to this PR, is contained a token called "type" that acted as a subtype of the actual service type.

The use case was to allow an end user to have a single `reference` (meta1) but several `containers` (meta2). The problem is that a container (a.k.a. a base on a meta2 service) is identified with the ID ... of the reference (plus a service type and a sequence number). With a subtype we could multiply the number of containers with an action of one element of the identifier tuple.

All the containers of a given reference could be listed easily. But now the notion of account exist and is listable, playing the same role. The "url type" feature has been forgotten, became useless then obsolete. Now it bloats the code but serves no purpose.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`core`, `metautils`, `sqliterepo`, `meta1`, `meta2`, `rawx`

##### SDS VERSION
`openio 4.2.7.dev28`
