### PR TITLE
rawx: Upon a DELETE, just read the necessary xattr

### DIFF
--- a/core/url.c
+++ b/core/url.c
@@ -175,11 +175,11 @@ _clean_url (struct oio_url_s *u)
 static int
 _compute_id (struct oio_url_s *url)
 {
-	if (!oio_str_is_set(url->ns) || !oio_str_is_set(url->account) || !oio_str_is_set(url->user))
+	if (!oio_str_is_set(url->account) || !oio_str_is_set(url->user))
 		return 0;
 
 	url->hexid[0] = '\0';
-	oio_str_hash_name(url->id, url->ns, url->account, url->user);
+	oio_str_hash_name(url->id, NULL, url->account, url->user);
 	oio_str_bin2hex(url->id, sizeof(url->id), url->hexid, sizeof(url->hexid));
 	return 1;
 }
@@ -203,9 +203,10 @@ _pack_fullpath(struct oio_url_s *u)
 	return g_string_free(gs, FALSE);
 }
 
-static void
+static gboolean
 _unpack_fullpath(struct oio_url_s *u, const gchar *strfullpath)
 {
+	gboolean rc = FALSE;
 	gchar **fullpath = g_strsplit(strfullpath, "/", -1);
 	if (g_strv_length(fullpath) == 5) {
 		char *account = g_uri_unescape_string(fullpath[0], NULL);
@@ -223,8 +224,10 @@ _unpack_fullpath(struct oio_url_s *u, const gchar *strfullpath)
 		char *content = g_uri_unescape_string(fullpath[4], NULL);
 		oio_url_set(u, OIOURL_CONTENTID, content);
 		g_free(content);
+		rc = TRUE;
 	}
 	g_strfreev(fullpath);
+	return rc;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -358,8 +361,9 @@ oio_url_set(struct oio_url_s *u, enum oio_url_field_e f, const char *v)
 			return NULL;
 
 		case OIOURL_FULLPATH:
-			_unpack_fullpath(u, v);
-			return u;
+			if (_unpack_fullpath(u, v))
+				return u;
+			return NULL;
 
 		case OIOURL_HEXID:
 			u->hexid[0] = 0;

--- a/metautils/lib/metatypes.h
+++ b/metautils/lib/metatypes.h
@@ -76,6 +76,7 @@ License along with this library.
 
 #define TYPE_TO_STRLEN(T)  ((sizeof(T)*2)+1)
 #define STRLEN_CHUNKID     TYPE_TO_STRLEN(hash_sha256_t)
+#define STRLEN_CONTENTID   65
 #define STRLEN_CONTAINERID TYPE_TO_STRLEN(container_id_t)
 #define STRLEN_CHUNKHASH   TYPE_TO_STRLEN(hash_md5_t)
 #define STRLEN_ADDRINFO    sizeof("[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:SSSSS")

--- a/rawx-apache2/src/rawx_repo_core.h
+++ b/rawx-apache2/src/rawx_repo_core.h
@@ -85,8 +85,6 @@ struct dav_stream
 #define RESOURCE_STAT_CHUNK_READ_ATTRS 0x01
 #define RESOURCE_STAT_CHUNK_PENDING    0x02
 
-dav_error * resource_init_decompression(dav_resource *resource, dav_rawx_server_conf *conf);
-
 void resource_stat_chunk(dav_resource *resource, int flags);
 
 void request_load_chunk_info_from_headers(request_rec *request,

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -1039,7 +1039,9 @@ remove_fullpath_from_attr(dav_resource *res,
 		const char *p, const char *hex_chunkid)
 {
 	GError *err = NULL;
-	gchar xname[256], xvalue[1024];
+	gchar xname[256], xvalue[LIMIT_LENGTH_ACCOUNTNAME + LIMIT_LENGTH_BASENAME
+		+ LIMIT_LENGTH_CONTENTPATH + LIMIT_LENGTH_VERSION + STRLEN_CONTENTID
+		+ 4];
 
 	int fd = open(p, O_WRONLY);
 	if (fd < 0) {

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -451,13 +451,13 @@ dav_rawx_get_resource(request_rec *r, const char *root_dir, const char *label,
 				flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
 			break;
 		case M_OPTIONS:
-    case M_MOVE:
-      flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
-      break;
-    case M_DELETE:
-      /* Reading the XATTR for a DELETE is overkill, we can do better */
-      break;
-    case M_PUT:
+		case M_MOVE:
+			flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
+			break;
+		case M_DELETE:
+			/* Reading the XATTR for a DELETE is overkill, we can do better */
+			break;
+		case M_PUT:
 		case M_POST:
 			flags |= RESOURCE_STAT_CHUNK_PENDING;
 			break;

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #include <unistd.h>
+#include <sys/xattr.h>
 
 #include <apr.h>
 #include <apr_file_io.h>
@@ -45,8 +46,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <metautils/lib/metacomm.h>
 #include <cluster/lib/gridcluster.h>
 #include <rawx-lib/src/rawx.h>
-
-#include <glib.h>
 
 #include "mod_dav_rawx.h"
 #include "rawx_bucket.h"
@@ -452,11 +451,13 @@ dav_rawx_get_resource(request_rec *r, const char *root_dir, const char *label,
 				flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
 			break;
 		case M_OPTIONS:
-		case M_DELETE:
-		case M_MOVE:
-			flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
-			break;
-		case M_PUT:
+    case M_MOVE:
+      flags |= RESOURCE_STAT_CHUNK_READ_ATTRS;
+      break;
+    case M_DELETE:
+      /* Reading the XATTR for a DELETE is overkill, we can do better */
+      break;
+    case M_PUT:
 		case M_POST:
 			flags |= RESOURCE_STAT_CHUNK_PENDING;
 			break;
@@ -1033,6 +1034,54 @@ end_move:
 	return e;
 }
 
+static GError *
+remove_fullpath_from_attr(dav_resource *res,
+		const char *p, const char *hex_chunkid)
+{
+	GError *err = NULL;
+	gchar xname[256], xvalue[1024];
+
+	int fd = open(p, O_WRONLY);
+	if (fd < 0) {
+		return NEWERROR(errno, "open() error: (%d) %s", errno, strerror(errno));
+	}
+
+	/* Load the fullpath */
+	memset(xvalue, 0, sizeof(xvalue));
+	g_snprintf(xname, sizeof(xname), "%s:%s",
+			   ATTR_DOMAIN_OIO "." ATTR_NAME_CONTENT_FULLPATH, hex_chunkid);
+	ssize_t rc = fgetxattr(fd, xname, xvalue, sizeof(xvalue) - 1);
+	if (rc < 0) {
+		err = NEWERROR(errno, "fgetxattr() error: (%d) %s", errno, strerror(errno));
+		goto label_exit;
+	}
+
+	struct oio_url_s *url = oio_url_empty();
+	if (!oio_url_set(url, OIOURL_FULLPATH, xvalue)) {
+		err = ERRPTF("Invalid chunk XATTR");
+		goto label_exit;
+	}
+
+	res->info->chunk.chunk_id = apr_pstrdup(res->pool, hex_chunkid);
+	res->info->chunk.content_fullpath = apr_pstrdup(res->pool, xvalue);
+	res->info->chunk.container_id = apr_pstrdup(res->pool, oio_url_get(url, OIOURL_HEXID));
+	res->info->chunk.content_path = apr_pstrdup(res->pool, oio_url_get(url, OIOURL_PATH));
+	res->info->chunk.content_id = apr_pstrdup(res->pool, oio_url_get(url, OIOURL_CONTENTID));
+	res->info->chunk.content_version = apr_pstrdup(res->pool, oio_url_get(url, OIOURL_VERSION));
+
+	oio_url_clean(url);
+
+	/* Remove the xattr, now the fullpath has been validated */
+	rc = fremovexattr(fd, xname);
+	if (rc < 0) {
+		err = NEWERROR(errno, "fremovexattr() error: (%d) %s", errno, strerror(errno));
+	}
+
+label_exit:
+	close(fd);
+	return err;
+}
+
 static dav_error *
 dav_rawx_remove_resource(dav_resource *resource, dav_response **response)
 {
@@ -1045,6 +1094,7 @@ dav_rawx_remove_resource(dav_resource *resource, dav_response **response)
 	pool = resource->pool;
 	*response = NULL;
 
+	/* Sanity checks */
 	if (resource->info->request->method_number == M_COPY) {
 		// If the destination exists and isn't versioned,
 		// Apache2 removes the destination
@@ -1052,7 +1102,6 @@ dav_rawx_remove_resource(dav_resource *resource, dav_response **response)
 		// Ignore to create an error with 'copy_resource'
 		goto end_remove;
 	}
-
 	if (DAV_RESOURCE_TYPE_REGULAR != resource->type)  {
 		e = server_create_and_stat_error(resource_get_server_config(resource), pool,
 				HTTP_CONFLICT, 0, "Cannot DELETE this type of resource.");
@@ -1064,16 +1113,14 @@ dav_rawx_remove_resource(dav_resource *resource, dav_response **response)
 		goto end_remove;
 	}
 
-	GError *local_error = NULL;
-	if (remove_fullpath_from_attr(resource_get_pathname(resource), &local_error,
-			resource->info->hex_chunkid)) {
-		if (local_error) {
-			GRID_WARN("Error to remove content fullpath: (%d) %s",
-					local_error->code, local_error->message);
-			g_error_free(local_error);
-		} else {
-			GRID_WARN("Error to remove content fullpath");
-		}
+	/* Remove the soft link on the chunk: all the information is in an XATTR
+	 * that we want to remove. No need to load all the XATTR, just 1 is enough */
+	GError *local_error = remove_fullpath_from_attr(resource,
+			resource_get_pathname(resource), resource->info->hex_chunkid);
+	if (local_error) {
+		GRID_WARN("Error to remove content fullpath: (%d) %s",
+				  local_error->code, local_error->message);
+		g_error_free(local_error);
 	}
 
 	status = apr_file_remove(resource_get_pathname(resource), pool);

--- a/rawx-lib/src/attr_handler.c
+++ b/rawx-lib/src/attr_handler.c
@@ -32,7 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "rawx.h"
 
 static volatile ssize_t longest_xattr = 2048;
-static volatile ssize_t longest_xattr_list = 16384;
 
 static gchar *
 _getxattr_from_fd(int fd, const char *attrname)
@@ -329,25 +328,6 @@ get_compression_info_in_attr(const char *p, GError ** error, GHashTable *table)
 	}
 
 	return TRUE;
-}
-
-gboolean
-remove_fullpath_from_attr(const char *p, GError **error,
-		const gchar *hex_chunkid)
-{
-	int fd = open(p, O_WRONLY);
-	if (fd < 0) {
-		GSETCODE(error, errno, "open() error: (%d) %s", errno, strerror(errno));
-		return FALSE;
-	} else {
-		gchar *xname = g_strconcat(
-				ATTR_DOMAIN_OIO "." ATTR_NAME_CONTENT_FULLPATH ":", hex_chunkid,
-				NULL);
-		const int rc = fremovexattr(fd, xname);
-		g_free(xname);
-		close(fd);
-		return rc != -1;
-	}
 }
 
 void

--- a/rawx-lib/src/rawx.h
+++ b/rawx-lib/src/rawx.h
@@ -54,21 +54,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # define ATTR_NAME_OIO_VERSION "oio.version"
 
-# define ATTR_NAME_OIO_USER_PATH "oio.user"
-
-
-#define NS_RAWX_BUFSIZE_OPTION "rawx_bufsize"
-
 #define NS_COMPRESSION_OPTION "compression"
 #define NS_COMPRESS_ALGO_OPTION "compression_algorithm"
 #define NS_COMPRESS_BLOCKSIZE_OPTION "compression_blocksize"
 
-#define DEFAULT_STREAM_BUFF_SIZE 512000
-#define RAWX_CONF_TIMEOUT 10LLU
 #define NS_COMPRESSION_ON "on"
 
-typedef struct chunk_textinfo_s
-{
+struct chunk_textinfo_s {
 	gchar *container_id;
 
 	gchar *content_id;
@@ -96,7 +88,7 @@ typedef struct chunk_textinfo_s
 
 	gchar *content_fullpath;
 
-} chunk_textinfo_t;
+};
 
 void chunk_textinfo_free_content(struct chunk_textinfo_s *cti);
 
@@ -114,8 +106,5 @@ gboolean get_rawx_info_from_fd(int fd, GError **error, gchar *hex_chunkid,
 		struct chunk_textinfo_s *chunk);
 
 gboolean get_compression_info_in_attr(const char *p, GError **error, GHashTable *table);
-
-gboolean remove_fullpath_from_attr(const char *p, GError **error,
-		const gchar *hex_chunkid);
 
 #endif /*OIO_SDS__rawx_lib__src__rawx_h*/


### PR DESCRIPTION
##### SUMMARY
Perform half less syscall when deleting a chunk.

Prior to this PR, all the XATTR were read from the chunk, and the chunk was opened twice. Now the reawx just read the xattr holding the full (logical) path of the object the chunk belongs to, and do everything with the same file descriptor.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`core`, `rawx`

##### SDS VERSION
`openio 4.2.7.dev26`

##### ADDITIONAL INFORMATION
Let's see if a bot on Twitter will relay this post from OpenIO @open-io, because we talk about #OpenSource #ObjectStorage, and sometimes used bad words like "fuck".
