### PR TITLE
Tolerate weird LB pool configurations

### DIFF
--- a/core/lb.c
+++ b/core/lb.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS load-balancing
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -950,9 +950,7 @@ _local__patch(struct oio_lb_pool_s *self,
 
 	/* Count the expected targets to build a temp storage for
 	 * polled locations */
-	guint count_targets = 0;
-	for (gchar **ptarget = lb->targets; *ptarget; ++ptarget)
-		count_targets++;
+	guint count_targets = oio_lb_world__count_pool_targets(self);
 
 	/* Copy the array of known locations because we don't know
 	 * if its allocated length is big enough */
@@ -1160,20 +1158,41 @@ oio_lb_world__add_pool_targets(struct oio_lb_pool_s *self,
 			*equal = '\0';
 			oio_lb_world__set_pool_option(self, *num_target, equal + 1);
 			continue;
+		} else if (**num_target == '\0') {
+			struct oio_lb_pool_LOCAL_s *lb = (struct oio_lb_pool_LOCAL_s *)self;
+			GRID_DEBUG("Pool %s has empty targets or a trailing separator",
+					lb->name);
+			continue;
 		}
 		const char *target = strchr(*num_target, OIO_CSV_SEP_C);
 		char *end = NULL;
 		gint64 count = g_ascii_strtoll(*num_target, &end, 10u);
 		if (end != target) {
+			/* Number conversion failed.
+			 * Either there was no separator (target == NULL),
+			 * or there was garbage before the separator.
+			 * Consider the string as the name of a target. */
 			count = 1;
 			target = *num_target;
 		} else {
+			/* Number conversion ended on the separator, the name
+			 * of the target starts one character further. */
 			target++;
 		}
 		for (int j = 0; j < count; j++)
 			oio_lb_world__add_pool_target(self, target);
 	}
 	g_strfreev(toks);
+}
+
+guint
+oio_lb_world__count_pool_targets(struct oio_lb_pool_s *self)
+{
+	struct oio_lb_pool_LOCAL_s *lb = (struct oio_lb_pool_LOCAL_s *)self;
+	guint count_targets = 0;
+	for (gchar **ptarget = lb->targets; *ptarget; ++ptarget)
+		count_targets++;
+	return count_targets;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/core/oiolb.h
+++ b/core/oiolb.h
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS load-balancing
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -160,6 +160,9 @@ void oio_lb_world__add_pool_target (struct oio_lb_pool_s *self, const char *to);
  * "2,meta2-fast-europe,meta2-slow-europe;1,meta2-fast-usa,meta2-slow-usa" */
 void oio_lb_world__add_pool_targets(struct oio_lb_pool_s *self,
 		const gchar *targets);
+
+/* Count the expected number of targets of this pool. */
+guint oio_lb_world__count_pool_targets(struct oio_lb_pool_s *self);
 
 /* -- LB pools management ------------------------------------------------- */
 

--- a/tests/functional/directory/test_refmapping.py
+++ b/tests/functional/directory/test_refmapping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,7 @@
 import logging
 from time import sleep
 
-from oio import ObjectStorageApi
+from oio.api.object_storage import ObjectStorageApi
 from oio.directory.meta1 import Meta1RefMapping
 from oio.conscience.client import ConscienceClient
 from tests.functional.cli import execute
@@ -100,7 +100,7 @@ class TestMeta1RefMapping(BaseTestCase):
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")
@@ -123,7 +123,7 @@ class TestMeta1RefMapping(BaseTestCase):
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")
@@ -144,13 +144,13 @@ class TestMeta1RefMapping(BaseTestCase):
         peers = properties['system']['sys.peers']
         new_services = peers.split(',')
         for expected_service in expected_services:
-                self.assertIn(expected_service, new_services)
+            self.assertIn(expected_service, new_services)
         self.assertNotIn(src_service, new_services)
         self.assertEqual(len(expected_services)+1, len(new_services))
 
         self.api.object_create(self.account, self.reference,
                                data="move meta2", obj_name="test")
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.api.object_show(self.account, self.reference, "test")
 
         self.api.object_delete(self.account, self.reference, "test")

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -269,11 +269,11 @@ class TestReplication(unittest.TestCase):
         size = CHUNK_SIZE
         resps = [201] * len(meta_chunk)
         with set_http_connect(*resps, headers=kwargs.get('headers')):
-                handler = ReplicatedMetachunkWriter(
-                    self.sysmeta, self.meta_chunk(), global_checksum,
-                    self.storage_method, **kwargs)
-                bytes_transferred, checksum, chunks = \
-                    handler.stream(source, size)
+            handler = ReplicatedMetachunkWriter(
+                self.sysmeta, self.meta_chunk(), global_checksum,
+                self.storage_method, **kwargs)
+            bytes_transferred, checksum, chunks = \
+                handler.stream(source, size)
         self.assertEqual(len(meta_chunk), len(chunks))
         self.assertEqual(0, bytes_transferred)
         self.assertEqual(expected_checksum, checksum)

--- a/tests/unit/test_lb.c
+++ b/tests/unit/test_lb.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS unit tests
-Copyright (C) 2016-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -610,6 +610,26 @@ test_local_pool (void)
 }
 
 static void
+test_weird_pool_configurations(void)
+{
+	struct oio_lb_world_s *lb_world = oio_lb_local__create_world();
+
+	struct oio_lb_pool_s *trailing =
+			oio_lb_world__create_pool(lb_world, "trailing");
+	oio_lb_world__add_pool_targets(trailing, "3,rawx;");
+	g_assert_cmpuint(3, ==, oio_lb_world__count_pool_targets(trailing));
+	oio_lb_pool__destroy(trailing);
+
+	struct oio_lb_pool_s *middle_empty =
+			oio_lb_world__create_pool(lb_world, "middle_empty");
+	oio_lb_world__add_pool_targets(middle_empty, "2,rawx;;1,rawx");
+	g_assert_cmpuint(3, ==, oio_lb_world__count_pool_targets(middle_empty));
+	oio_lb_pool__destroy(middle_empty);
+
+	oio_lb_world__destroy(lb_world);
+}
+
+static void
 test_local_world (void)
 {
 	for (int i=0; i<8 ;++i) {
@@ -800,6 +820,7 @@ main(int argc, char **argv)
 	g_test_add_func("/metautils/lb/item/ipv6", test_lb_item_loc_ipv6);
 	g_test_add_func("/core/lb/local/world", test_local_world);
 	g_test_add_func("/core/lb/local/pool", test_local_pool);
+	g_test_add_func("/core/lb/local/weird_pool", test_weird_pool_configurations);
 	g_test_add_func("/core/lb/local/feed", test_local_feed);
 	g_test_add_func("/core/lb/local/feed_twice", test_local_feed_twice);
 	g_test_add_func("/core/lb/local/feed_zero_scored",


### PR DESCRIPTION
##### SUMMARY
Tolerate weird service pool configurations, with empty targets or trailing separators.
Jira: OS-314

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- LB

##### SDS VERSION
```
openio 4.2.8.dev18
```