### PR TITLE
sqliterepo: Faster exit of services

### DIFF
--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -219,8 +219,7 @@ guint election_manager_play_exits (struct election_manager_s *m);
  * and returns a boolean instead of asserting. */
 gboolean election_manager_is_operational(struct election_manager_s *manager);
 
-void election_manager_exit_all (struct election_manager_s *m,
-		gint64 oldest, gboolean persist);
+void election_manager_exit_all (struct election_manager_s *m, gint64 oldest);
 
 void election_manager_whatabout (struct election_manager_s *m,
 		const struct sqlx_name_s *n, GString *out);

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -895,7 +895,7 @@ sqlx_service_specific_fini(void)
 	}
 	if (election_manager_is_operational(SRV.election_manager))
 		election_manager_exit_all(SRV.election_manager,
-				sqliterepo_server_exit_ttl, TRUE);
+				sqliterepo_server_exit_ttl);
 	if (SRV.sync_tab) {
 		for (guint i=0; i<SRV.sync_tab->len ;++i)
 			sqlx_sync_close(SRV.sync_tab->pdata[i]);


### PR DESCRIPTION
##### SUMMARY
We do not exit elections but we hard-reset them instead. No need to wait for them.

##### ISSUE TYPE
`Enhancement`

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.3.2.dev22`