### PR TITLE
cli: Remove the `--no-rdir` from `directory bootstrap`

### DIFF
--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -100,8 +100,6 @@ class DirectoryInit(DirectoryCmd):
     def get_parser(self, prog_name):
         parser = super(DirectoryInit, self).get_parser(prog_name)
         parser.add_argument(
-            '--no-rdir', action='store_true', help='Deprecated')
-        parser.add_argument(
             '--force',
             action='store_true',
             help="Do the bootstrap even if already done")
@@ -152,8 +150,6 @@ class DirectoryInit(DirectoryCmd):
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-        if parsed_args.no_rdir:
-            self.log.warn('--no-rdir option is deprecated')
         checked = self._assign_meta1(parsed_args)
 
         if checked:


### PR DESCRIPTION
##### SUMMARY
The `--no-rdir` option still existed in the 4.3.x but triggered a warning.
Now it is not recognized anymore, it is an error to use it, and it should happen in the future 4.4.x

##### ISSUE TYPE
`cleanup`

##### COMPONENT NAME
`cli`

##### SDS VERSION
`openio 4.3.2.dev32`
