### PR TITLE
Improve the `directory bootstrap` fairness on multi-DC

### DIFF
--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -35,11 +35,16 @@ class DirectoryCmd(Command):
 
     def get_parser(self, prog_name):
         parser = super(DirectoryCmd, self).get_parser(prog_name)
-        parser.add_argument('--replicas', metavar='<N>', dest='replicas',
-                            type=int, default=3,
-                            help='Set the number of replicas (3 by default)')
-        parser.add_argument('--min-dist', type=int, default=1,
-                            help="Minimum distance between replicas")
+        parser.add_argument(
+            '--no-rdir', action='store_true', help='Deprecated')
+        parser.add_argument(
+            '--replicas', metavar='<N>', dest='replicas',
+            type=int, default=3,
+            help='Set the number of replicas (3 by default)')
+        parser.add_argument(
+            '--min-dist',
+            type=int, default=1,
+            help="Minimum distance between replicas")
         parser.add_argument(
             '--meta0-timeout', metavar='<SECONDS>',
             type=float, default=M0_READ_TIMEOUT,
@@ -63,8 +68,8 @@ class DirectoryCmd(Command):
                                   min_dist=parsed_args.min_dist,
                                   logger=self.log)
 
-    def _apply_mapping(self, mapping, moved=None,
-                       max_attempts=7, read_timeout=M0_READ_TIMEOUT):
+    def _apply(self, mapping, moved=None,
+               max_attempts=7, read_timeout=M0_READ_TIMEOUT):
         """
         Upload the specified mapping to the meta0 service,
         retry in case or error.
@@ -100,7 +105,9 @@ class DirectoryInit(DirectoryCmd):
     def get_parser(self, prog_name):
         parser = super(DirectoryInit, self).get_parser(prog_name)
         parser.add_argument(
-            '--no-rdir', action='store_true', help='Deprecated')
+            '--level', metavar='<0,1,2,3>', dest='level',
+            type=int, default=0,
+            help='Which location token represent the SITE')
         parser.add_argument(
             '--force',
             action='store_true',
@@ -112,9 +119,9 @@ class DirectoryInit(DirectoryCmd):
         return parser
 
     def _assign_meta1(self, parsed_args):
+        # Pre-check
         mapping = self.get_prefix_mapping(parsed_args)
-        mapping.load(read_timeout=parsed_args.meta0_timeout)
-
+        mapping.load_meta0(read_timeout=parsed_args.meta0_timeout)
         if mapping and not parsed_args.force:
             self.log.info("Meta1 prefix mapping already initialized")
             if not parsed_args.check:
@@ -122,33 +129,15 @@ class DirectoryInit(DirectoryCmd):
             self.log.info("Checking...")
             return mapping.check_replicas()
 
-        # Bootstrap with the 'random' strategy, then rebalance with the
-        # 'less_prefixes' strategy to ensure the same number of prefixes
-        # per meta1. This is faster than bootstrapping directly with the
-        # 'less_prefixes' strategy.
-        checked = False
-        for i in range(3):
-            self.log.info("Computing meta1 prefix mapping (pass %d)", i)
-            mapping.bootstrap()
+        # Reset and bootstrap
+        mapping = self.get_prefix_mapping(parsed_args)
+        mapping.bootstrap(level=parsed_args.level)
 
-            self.log.info("Equilibrating...")
-            mapping.rebalance()
-
-            if parsed_args.check:
-                self.log.info("Checking...")
-                checked = mapping.check_replicas()
-            else:
-                checked = True
-
-            if checked:
-                break
-
-        if checked:
-            self._apply_mapping(mapping,
-                                read_timeout=parsed_args.meta0_timeout)
+        if mapping.check_replicas():
+            self._apply(mapping, read_timeout=parsed_args.meta0_timeout)
+            return True
         else:
             raise Exception("Failed to initialize prefix mapping")
-        return checked
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
@@ -174,8 +163,8 @@ class DirectoryList(DirectoryCmd):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
         mapping = self.get_prefix_mapping(parsed_args)
-        mapping.load(connection_timeout=M0_CONN_TIMEOUT,
-                     read_timeout=parsed_args.meta0_timeout)
+        mapping.load_meta0(connection_timeout=M0_CONN_TIMEOUT,
+                           read_timeout=parsed_args.meta0_timeout)
         print mapping.to_json()
 
 
@@ -185,10 +174,10 @@ class DirectoryRebalance(DirectoryCmd):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
         mapping = self.get_prefix_mapping(parsed_args)
-        mapping.load(read_timeout=parsed_args.meta0_timeout)
+        mapping.load_meta0(read_timeout=parsed_args.meta0_timeout)
         moved = mapping.rebalance()
-        self._apply_mapping(mapping, moved=moved,
-                            read_timeout=parsed_args.meta0_timeout)
+        self._apply(mapping, moved=moved,
+                    read_timeout=parsed_args.meta0_timeout)
         self.log.info("Moved %s", moved)
 
 
@@ -219,7 +208,7 @@ class DirectoryRestore(DirectoryCmd):
                 self.log.info('Loading from %s...', parsed_args.backup)
                 backup = inputf.read()
         mapping = self.get_prefix_mapping(parsed_args)
-        mapping.load(backup, swap_bytes=False)
+        mapping.load_json(backup)
         self.log.info('Checking...')
         if mapping.check_replicas():
             self.log.info('OK')
@@ -229,8 +218,7 @@ class DirectoryRestore(DirectoryCmd):
             raise Exception('Bad meta1 prefix mapping')
         if parsed_args.I_know_what_I_am_doing:
             self.log.info('Applying...')
-            self._apply_mapping(mapping,
-                                read_timeout=parsed_args.meta0_timeout)
+            self._apply(mapping, read_timeout=parsed_args.meta0_timeout)
         else:
             self.log.info('Please tell me that you know what you are doing.')
 
@@ -259,14 +247,14 @@ class DirectoryDecommission(DirectoryCmd):
         if self.log.getEffectiveLevel() > INFO:
             self.log.setLevel(INFO)
         mapping = self.get_prefix_mapping(parsed_args)
-        mapping.load(read_timeout=parsed_args.meta0_timeout)
+        mapping.load_meta0(read_timeout=parsed_args.meta0_timeout)
         self.log.info("meta1_digits=%d", mapping.digits)
         moved = mapping.decommission(parsed_args.addr,
                                      bases_to_remove=parsed_args.base)
         if (mapping.check_replicas() or
                 parsed_args.ignore_replicas_number_errors):
-            self._apply_mapping(mapping, moved=moved,
-                                read_timeout=parsed_args.meta0_timeout)
+            self._apply(mapping, moved=moved,
+                        read_timeout=parsed_args.meta0_timeout)
             self.log.info("Moved %s", sorted(moved))
         else:
             self.log.warn("Did nothing due to errors.")

--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -107,13 +107,14 @@ class DirectoryInit(DirectoryCmd):
         parser = super(DirectoryInit, self).get_parser(prog_name)
         parser.add_argument(
             '--level', metavar='<LEVEL>', dest='level',
-            choices=('site', 'rack', 'host', 'volume'), default='site',
+            choices=('site', 'rack', 'host', 'volume'), default='volume',
             help='Which location level should be perfectly balanced')
         parser.add_argument(
             '--degradation', metavar='<DEGRADATION>', dest='degradation',
-            type=int, default=0,
+            type=int, default=None,
             help='How many location levels we accept to lose to keep the '
-                 'quorums valid.')
+                 'quorums valid. Not set by default, it is then autodetected '
+                 'to the replication set minus the quorum')
         parser.add_argument(
             '--force',
             action='store_true',
@@ -134,6 +135,10 @@ class DirectoryInit(DirectoryCmd):
                 return True
             self.log.info("Checking...")
             return mapping.check_replicas()
+
+        if parsed_args.degradation is None:
+            quorum = parsed_args.replicas / 2 + 1
+            parsed_args.degradation = parsed_args.replicas - quorum
 
         # Reset and bootstrap
         mapping = self.get_prefix_mapping(parsed_args)

--- a/oio/directory/meta0.py
+++ b/oio/directory/meta0.py
@@ -106,8 +106,6 @@ def _bootstrap(allsrv, allgroups, replicas, level, degradation=0):
 
     # Ensure we work on a sorted sequence of service
     allsrv = tuple(_prepare_for_bootstrap(allsrv))
-    for srv in allsrv:
-        print srv
 
     # Extract the slices of service corresponding to the location levels
     # to be perfectly balanced.

--- a/oio/directory/meta0.py
+++ b/oio/directory/meta0.py
@@ -78,6 +78,10 @@ def _patch_service(srv):
     return s
 
 
+def _prepare_for_bootstrap(allsrv):
+    return sorted((_patch_service(s) for s in allsrv), key=_location)
+
+
 def _bootstrap(allsrv, allgroups, replicas, level):
     """
     Produce a list of services (dicts), with a fields named 'bases' in each
@@ -89,7 +93,7 @@ def _bootstrap(allsrv, allgroups, replicas, level):
                  significance. Tokens over that position are ignored
     """
     # Ensure we work on a sorted sequence of service
-    allsrv = tuple(sorted((_patch_service(s) for s in allsrv), key=_location))
+    allsrv = tuple(_prepare_for_bootstrap(allsrv))
 
     # Extract the slices of service corresponding to the location levels
     # to be perfectly balanced.

--- a/tests/unit/test_prefixmapping.py
+++ b/tests/unit/test_prefixmapping.py
@@ -75,15 +75,13 @@ class TestMeta0Bootstrap(unittest.TestCase):
             groups = list(groups)
             for replicas in range(2, 5):
                 for sites in range(1, replicas):
-                    srv = list(self.generate_services(sites*3, \
-                                                      nb_sites=sites, \
+                    srv = list(self.generate_services(sites*3,
+                                                      nb_sites=sites,
                                                       fill_token=2))
-                    print "srv =", len(srv), "sites =", sites, \
-                          "repli =", replicas
-                    for s in srv: print '>', s
                     self.assertRaises(PreconditionFailed,
                                       _bootstrap, srv, groups,
-                                      replicas=replicas, level=0, degradation=1)
+                                      replicas=replicas, level=0,
+                                      degradation=1)
 
     def test_bootstrap_enough_sites(self):
         for groups in (prefixes(1),  # 16

--- a/tests/unit/test_prefixmapping.py
+++ b/tests/unit/test_prefixmapping.py
@@ -52,7 +52,6 @@ class TestMeta0Bootstrap(unittest.TestCase):
         print "srv =", nb_services, "sites =", sites, "repli =", replicas
         srv = list(self.generate_services(nb_services, nb_sites=sites,
                                           fill_token=fill_token))
-        print repr(srv)
         _after = _bootstrap(srv, groups, replicas, level)
         ideal_per_slice = (len(groups) * replicas) / sites
         for start, end in _slice_services(_after, level):
@@ -101,9 +100,9 @@ class TestMeta0Bootstrap(unittest.TestCase):
             # is well padded left
             srv = list(self.generate_services(9, nb_sites=3, fill_token=0))
             self.assertRaises(Exception, _bootstrap,
-                              srv, groups, replicas=2, level=0)
+                              srv, groups, replicas=2, level=0, degradation=1)
             self.assertRaises(Exception, _bootstrap,
-                              srv, groups, replicas=2, level=1)
+                              srv, groups, replicas=2, level=1, degradation=1)
             self._test_ok(groups, sites=3, replicas=1,
                           level=2, fill_token=2)
 

--- a/tests/unit/test_prefixmapping.py
+++ b/tests/unit/test_prefixmapping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -177,7 +177,7 @@ class TestMeta0PrefixMapping(unittest.TestCase):
         mapping = self.make_mapping(replicas=replicas, digits=digits)
         mapping._admin = Mock()
         mapping._admin.election_status = Mock(return_value={'peers': {}})
-        mapping.load(mapping_str, swap_bytes=False)
+        mapping.load_json(mapping_str)
 
         svc = mapping.services.values()[0]
         self.logger.info("Decommissioning everything from %s", svc['addr'])


### PR DESCRIPTION
##### SUMMARY
* Brings a fair distribution of the meta1 prefixes over the multiple sites
* At most one replica of any prefix is on a single site
* Requirement that locations have max 4 tokens, with the site coming first.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`cli`

##### SDS VERSION
`openio 4.3.2.dev3`