### PR TITLE
oio-blob-indexer: Disable the backup when converting chunks

### DIFF
--- a/etc/blob-indexer.conf-sample
+++ b/etc/blob-indexer.conf-sample
@@ -29,5 +29,3 @@ autocreate = true
 
 # oio-blob-converter configuration
 # convert_chunks = False
-# backup = True
-# backup_dir = /tmp

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -138,7 +138,9 @@ class BlobIndexer(Daemon):
         self.successes = 0
 
         if self.convert_chunks:
-            self.converter = BlobConverter(self.conf, logger=self.logger)
+            converter_conf = self.conf.copy()
+            converter_conf['no_backup'] = True
+            self.converter = BlobConverter(converter_conf, logger=self.logger)
 
         paths = paths_gen(self.volume)
         self.report('started', start_time)


### PR DESCRIPTION
##### SUMMARY

Desable the backup when converting chunks for the `oio-blob-indexer`

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `oio-blob-indexer`

##### SDS VERSION

```
openio 4.2.8.dev26
```