### PR TITLE
cmake,ci: Restore the SDK_ONLY option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
   - go get gopkg.in/ini.v1
   - go get gopkg.in/tylerb/graceful.v1
 env:
+  - TEST_SUITE=sdk
   - TEST_SUITE=3copies,with-service-id
   - TEST_SUITE=ec,with-random-service-id
   - TEST_SUITE=repli,go-rawx
@@ -70,7 +71,9 @@ script:
   - ulimit -c unlimited -S
   - set -e
   - mkdir /tmp/oio && source $HOME/oio/bin/activate
-  - export CMAKE_OPTS='-DCMAKE_INSTALL_PREFIX=/tmp/oio -DLD_LIBDIR=lib -DZK_LIBDIR=/usr/lib -DZK_INCDIR=/usr/include/zookeeper -DAPACHE2_LIBDIR=/usr/lib/apache2 -DAPACHE2_INCDIR=/usr/include/apache2 -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module'
+  - export CMAKE_OPTS='-DCMAKE_INSTALL_PREFIX=/tmp/oio -DLD_LIBDIR=lib'
+  - if [ "sdk" == "${TEST_SUITE/*sdk*/sdk}" ] ; then cmake ${CMAKE_OPTS} -D SDK_ONLY=on . && make all && make test ; exit 0 ; fi
+  - export CMAKE_OPTS="${CMAKE_OPTS} -DZK_LIBDIR=/usr/lib -DZK_INCDIR=/usr/include/zookeeper -DAPACHE2_LIBDIR=/usr/lib/apache2 -DAPACHE2_INCDIR=/usr/include/apache2 -DAPACHE2_MODDIR=/tmp/oio/lib/apache2/module"
   - if [ "build" == "${TEST_SUITE/*build*/build}" ] ; then cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Release" . && make all && make clean ; fi
   - export PYTHON_COVERAGE=1 CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_CODECOVERAGE=on"
   - cmake ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE="Debug" . && make all install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,6 @@ pkg_check_modules(ZMQ libzmq>=4.0.0)
 # Optional cache libraries
 pkg_search_module(HIREDIS hiredis)
 pkg_search_module(LIBMEMCACHED libmemcached)
-
 endif (NOT SDK_ONLY)
 
 # Load CLI-overriden configuration
@@ -413,6 +412,7 @@ include_directories(AFTER
 link_directories(${GLIB2_LIBRARY_DIRS})
 
 add_subdirectory(./core)
+add_subdirectory(./tests/unit)
 
 if (NOT SDK_ONLY)
 add_subdirectory(./metautils/lib)
@@ -436,10 +436,9 @@ add_subdirectory(./sqliterepo)
 add_subdirectory(./sqlx)
 add_subdirectory(./rdir)
 add_subdirectory(./tools)
-add_subdirectory(./tests/unit)
 add_subdirectory(./tests/func)
 add_subdirectory(./tools/event-benchmark)
-endif (NOT SDK_ONLY)
-
 add_custom_target(python-openio-docs
 	COMMAND epydoc -v --graph=all --docformat=restructuredtext -o python-openio-docs oio)
+endif (NOT SDK_ONLY)
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,12 @@
 add_definitions(-DG_LOG_DOMAIN="oio.tests.unit")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
+set(COMMON oiocore oiosds ${GLIB2_LIBRARIES})
+
+if (NOT SDK_ONLY)
+set(ENLARGED ${COMMON} metautils)
+
 include_directories(BEFORE
-		${CMAKE_SOURCE_DIR}
-		${CMAKE_BINARY_DIR}
 		${CMAKE_BINARY_DIR}/metautils/lib
 		${CMAKE_BINARY_DIR}/metautils/asn1c)
 
@@ -14,13 +17,11 @@ include_directories(ATER
 link_directories(
 		${ZK_LIBRARY_DIRS}
 		${SQLITE3_LIBRARY_DIRS})
+endif (NOT SDK_ONLY)
 
-set(COMMON oiocore oiosds metautils ${GLIB2_LIBRARIES})
-
-add_definitions(-DLB_TESTS_DATASETS="${CMAKE_SOURCE_DIR}/tests/datasets")
-add_executable(test_lb test_lb.c)
-target_link_libraries(test_lb metautils ${COMMON})
-add_test(NAME core/lb COMMAND test_lb)
+include_directories(BEFORE
+		${CMAKE_SOURCE_DIR}
+		${CMAKE_BINARY_DIR})
 
 add_executable(test_oio_ext test_ext.c)
 target_link_libraries(test_oio_ext ${COMMON})
@@ -38,90 +39,98 @@ add_executable(test_core_sysstat test_core_sysstat.c)
 target_link_libraries(test_core_sysstat ${COMMON})
 add_test(NAME core/sysstat COMMAND test_core_sysstat)
 
+if (NOT SDK_ONLY)
 add_executable(test_cache_lru test_cache_lru.c)
 target_link_libraries(test_cache_lru oiocache)
 add_test(NAME cache/lru COMMAND test_cache_lru)
 
+add_definitions(-DLB_TESTS_DATASETS="${CMAKE_SOURCE_DIR}/tests/datasets")
+add_executable(test_lb test_lb.c)
+target_link_libraries(test_lb ${ENLARGED})
+add_test(NAME core/lb COMMAND test_lb)
+
 add_executable(test_nsinfo test_nsinfo.c)
-target_link_libraries(test_nsinfo metautils ${COMMON})
+target_link_libraries(test_nsinfo ${ENLARGED})
 add_test(NAME metautils/nsinfo COMMAND test_nsinfo)
 
 add_executable(test_stg_policy test_stg_policy.c)
-target_link_libraries(test_stg_policy ${COMMON})
+target_link_libraries(test_stg_policy ${ENLARGED})
 add_test(NAME metautils/stgpol COMMAND test_stg_policy)
 
 add_executable(test_svc_policy test_svc_policy.c)
-target_link_libraries(test_svc_policy ${COMMON})
+target_link_libraries(test_svc_policy ${ENLARGED})
 add_test(NAME metautils/svc_policy COMMAND test_svc_policy)
 
 add_executable(test_logger test_logger.c)
-target_link_libraries(test_logger ${COMMON})
+target_link_libraries(test_logger ${ENLARGED})
 add_test(NAME metautils/logger COMMAND test_logger)
 
 add_executable(test_addr test_addr.c)
-target_link_libraries(test_addr ${COMMON})
+target_link_libraries(test_addr ${ENLARGED})
 add_test(NAME metautils/addr COMMAND test_addr)
 
 add_executable(test_gridd_client test_gridd_client.c)
-target_link_libraries(test_gridd_client ${COMMON})
+target_link_libraries(test_gridd_client ${ENLARGED})
 add_test(NAME metautils/gridd_client COMMAND test_gridd_client)
 
 add_executable(test_lrutree test_lrutree.c)
-target_link_libraries(test_lrutree ${COMMON})
+target_link_libraries(test_lrutree ${ENLARGED})
 add_test(NAME metautils/lru COMMAND test_lrutree)
 
 add_executable(test_str test_str.c)
-target_link_libraries(test_str ${COMMON})
+target_link_libraries(test_str ${ENLARGED})
 add_test(NAME metautils/str COMMAND test_str)
 
 add_executable(test_gba test_gba.c)
-target_link_libraries(test_gba ${COMMON})
+target_link_libraries(test_gba ${ENLARGED})
 add_test(NAME metautils/gba COMMAND test_gba)
 
 add_executable(test_meta2_backend test_meta2_backend.c)
-target_link_libraries(test_meta2_backend meta2v2 ${COMMON})
+target_link_libraries(test_meta2_backend meta2v2 ${ENLARGED})
 add_test(NAME meta2/backend COMMAND test_meta2_backend)
 
 add_executable(test_meta1_backend test_meta1_backend.c)
-target_link_libraries(test_meta1_backend meta1v2 oioevents ${COMMON})
+target_link_libraries(test_meta1_backend meta1v2 oioevents ${ENLARGED})
 add_test(NAME meta1/backend COMMAND test_meta1_backend)
 
 add_executable(test_stats_holder test_stats_holder.c)
-target_link_libraries(test_stats_holder server ${COMMON})
+target_link_libraries(test_stats_holder server ${ENLARGED})
 add_test(NAME server/stats COMMAND test_stats_holder)
 
 add_executable(test_network_server test_network_server.c)
-target_link_libraries(test_network_server ${COMMON} server)
+target_link_libraries(test_network_server ${ENLARGED} server)
 add_test(NAME server/server_core COMMAND test_network_server)
 
 add_executable(test_sqliterepo_version test_sqliterepo_version.c)
-target_link_libraries(test_sqliterepo_version sqliterepo ${COMMON})
+target_link_libraries(test_sqliterepo_version sqliterepo ${ENLARGED})
 add_test(NAME sqliterepo/version COMMAND test_sqliterepo_version)
 
 add_executable(test_sqliterepo_election test_sqliterepo_election.c)
-target_link_libraries(test_sqliterepo_election sqliterepo ${COMMON})
+target_link_libraries(test_sqliterepo_election sqliterepo ${ENLARGED})
 add_test(NAME sqliterepo/election COMMAND test_sqliterepo_election)
 
 add_executable(test_sqliterepo_cache test_sqliterepo_cache.c)
-target_link_libraries(test_sqliterepo_cache sqliterepo sqlitereporemote ${COMMON})
+target_link_libraries(test_sqliterepo_cache sqliterepo sqlitereporemote ${ENLARGED})
 add_test(NAME sqliterepo/cache COMMAND test_sqliterepo_cache)
 
 add_executable(test_sqliterepo_repo test_sqliterepo_repo.c)
-target_link_libraries(test_sqliterepo_repo sqliterepo sqlitereporemote ${COMMON})
+target_link_libraries(test_sqliterepo_repo sqliterepo sqlitereporemote ${ENLARGED})
 add_test(NAME sqliterepo/repository COMMAND test_sqliterepo_repo)
 
 add_executable(test_gridd_client_pool test_gridd_client_pool.c)
-target_link_libraries(test_gridd_client_pool sqliterepo ${COMMON})
+target_link_libraries(test_gridd_client_pool sqliterepo ${ENLARGED})
 add_test(NAME sqliterepo/gridd_client_pool COMMAND test_gridd_client_pool)
 
 add_executable(test_sqlx_client_mem test_sqlx_client.c)
-target_link_libraries(test_sqlx_client_mem oiosqlx oiosqlx_local ${COMMON})
+target_link_libraries(test_sqlx_client_mem oiosqlx oiosqlx_local ${ENLARGED})
 add_test(NAME sqlx/client/mem COMMAND test_sqlx_client_mem)
 
 add_executable(test_events_queue test_events_queue.c)
-target_link_libraries(test_events_queue sqlxsrv oioevents ${COMMON})
+target_link_libraries(test_events_queue sqlxsrv oioevents ${ENLARGED})
 add_test(NAME events/abstract COMMAND test_events_queue)
 
 add_executable(test_events_beanstalkd test_events_beanstalkd.c)
-target_link_libraries(test_events_beanstalkd ${COMMON} oioevents server)
+target_link_libraries(test_events_beanstalkd ${ENLARGED} oioevents server)
 add_test(NAME events/beanstalkd COMMAND test_events_beanstalkd)
+
+endif (NOT SDK_ONLY)

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -270,6 +270,12 @@ if is_running_test_suite "variables" ; then
 	tox -e variables
 fi
 
+if is_running_test_suite "sdk" ; then
+	echo -e "\n### SDK tests"
+	cd $WRKDIR
+	make -C tests/unit test
+fi
+
 if is_running_test_suite "unit" ; then
 	echo -e "\n### UNIT tests"
 	cd $SRCDIR

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -270,12 +270,6 @@ if is_running_test_suite "variables" ; then
 	tox -e variables
 fi
 
-if is_running_test_suite "sdk" ; then
-	echo -e "\n### SDK tests"
-	cd $WRKDIR
-	make -C tests/unit test
-fi
-
 if is_running_test_suite "unit" ; then
 	echo -e "\n### UNIT tests"
 	cd $SRCDIR


### PR DESCRIPTION
##### SUMMARY
There are reports of users expecting the SDK_ONLY option of cmake to be functional.
This is now fixed.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`cmake`, `ci`

##### SDS VERSION
`openio 4.3.3.dev11`