### PR TITLE
CLI: add '--min-dist' option to 'rdir bootstrap'

### DIFF
--- a/oio/cli/rdir/rdir.py
+++ b/oio/cli/rdir/rdir.py
@@ -48,12 +48,18 @@ class RdirBootstrap(lister.Lister):
         parser = super(RdirBootstrap, self).get_parser(prog_name)
         parser.add_argument(
             'service_type',
-            help="Which service type to assign rdir to")
+            help="Which service type to assign rdir to.")
         parser.add_argument(
             '--max-per-rdir',
             metavar='<N>',
             type=int,
-            help="Maximum number of databases per rdir service")
+            help="Maximum number of databases per rdir service.")
+        parser.add_argument(
+            '--min-dist',
+            metavar='<N>',
+            type=int,
+            help=("Minimum required distance between any service and "
+                  "its assigned rdir service."))
         return parser
 
     def take_action(self, parsed_args):
@@ -62,6 +68,7 @@ class RdirBootstrap(lister.Lister):
         try:
             all_services = dispatcher.assign_services(
                 parsed_args.service_type, parsed_args.max_per_rdir,
+                min_dist=parsed_args.min_dist,
                 connection_timeout=30.0, read_timeout=90.0)
         except OioException as exc:
             self.log.warn('Failed to assign all %s services: %s',

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -214,7 +214,10 @@ class VolumeException(OioException):
     pass
 
 
-class ClientException(OioException):
+class StatusMessageException(OioException):
+    """
+    Error carrying an HTTP status, an OIO status and a message.
+    """
     def __init__(self, http_status, status=None, message=None):
         self.http_status = http_status
         self.message = message or 'n/a'
@@ -225,6 +228,10 @@ class ClientException(OioException):
         if self.status:
             s += ' (STATUS %s)' % self.status
         return s
+
+
+class ClientException(StatusMessageException):
+    pass
 
 
 class Forbidden(ClientException):

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -66,13 +66,14 @@ class LbClient(ProxyClient):
         else:
             raise OioException("Failed to poll %s: %s" % (pool, resp.text))
 
-    def create_pool(self, pool, targets, options=None, **kwargs):
+    def create_pool(self, pool, targets, force=False, options=None, **kwargs):
         """
         Create a service pool on the local proxy.
 
         :param pool: a name for the pool
         :type pool: `str`
         :param targets: a list of tuples like (1, "rawx-usa", "rawx", ...)
+        :param force: if the pool already exists, overwrite it
         :param options: options for the pool
         :type options: `dict`
         :exception Conflict: if a pool with same name already exists
@@ -80,7 +81,7 @@ class LbClient(ProxyClient):
         stargets = ";".join(','.join(str(y) for y in x) for x in targets)
         ibody = {'targets': stargets, 'options': options}
         _, _ = self._request('POST', "/create_pool",
-                             params={'name': pool},
+                             params={'name': pool, 'force': str(force)},
                              data=json.dumps(ibody),
                              **kwargs)
 

--- a/proxy/lb_actions.c
+++ b/proxy/lb_actions.c
@@ -305,11 +305,12 @@ enum http_rc_e
 action_lb_create_pool(struct req_args_s *args)
 {
 	GError *err = NULL;
+	gboolean force = oio_str_parse_bool(OPT("force"), FALSE);
 	if (!validate_namespace(NS()))
 		err = NEWERROR(CODE_NAMESPACE_NOTMANAGED, "Invalid NS");
 	else if	(!OPT("name"))
 		err = BADREQ("Missing name parameter");
-	else if (oio_lb__has_pool(lb, OPT("name")))
+	else if (oio_lb__has_pool(lb, OPT("name")) && !force)
 		err = NEWERROR(CODE_CONTENT_EXISTS, "A pool named [%s] already exists",
 				OPT("name"));
 	if (err)

--- a/tests/unit/common/test_exceptions.py
+++ b/tests/unit/common/test_exceptions.py
@@ -24,28 +24,28 @@ class ExceptionsTest(unittest.TestCase):
         fake_resp = FakeApiResponse()
         fake_resp.status = 500
         exc = exceptions.from_response(fake_resp, None)
-        self.assertTrue(isinstance(exc, exceptions.ClientException))
+        self.assertIsInstance(exc, exceptions.ClientException)
         self.assertEqual(exc.http_status, fake_resp.status)
         self.assertEqual(exc.message, "n/a")
-        self.assertTrue("HTTP 500" in str(exc))
+        self.assertIn("HTTP 500", str(exc))
 
     def test_from_response_with_body(self):
         fake_resp = FakeApiResponse()
         fake_resp.status = 500
         body = {"status": 300, "message": "Fake error"}
         exc = exceptions.from_response(fake_resp, body)
-        self.assertTrue(isinstance(exc, exceptions.ClientException))
+        self.assertIsInstance(exc, exceptions.ClientException)
         self.assertEqual(exc.http_status, fake_resp.status)
         self.assertEqual(exc.status, 300)
         self.assertEqual(exc.message, "Fake error")
-        self.assertTrue("HTTP 500" in str(exc))
-        self.assertTrue("STATUS 300" in str(exc))
+        self.assertIn("HTTP 500", str(exc))
+        self.assertIn("STATUS 300", str(exc))
 
     def test_from_response_http_status(self):
         fake_resp = FakeApiResponse()
         fake_resp.status = 404
         exc = exceptions.from_response(fake_resp, None)
-        self.assertTrue(isinstance(exc, exceptions.NotFound))
+        self.assertIsInstance(exc, exceptions.NotFound)
         fake_resp.status = 409
         exc = exceptions.from_response(fake_resp, None)
-        self.assertTrue(isinstance(exc, exceptions.Conflict))
+        self.assertIsInstance(exc, exceptions.Conflict)


### PR DESCRIPTION
##### SUMMARY
Implement `--min-dist` option for `openio rdir bootstrap`.
Jira: OS-281

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- CLI
- Python API

##### SDS VERSION
```
openio 4.4.0.0b1.dev26
```
