### PR TITLE
cmake: Explicit the ABI version of each shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,6 @@ endif ()
 
 set(OIOSDS_PROJECT_VERSION "${OIOSDS_RELEASE}/${OIOSDS_PROJECT_VERSION_SHORT}")
 
-if (NOT ABI_VERSION)
-	set(ABI_VERSION 0)
-endif()
-
 set(CMAKE_C_FLAGS "-g -fPIC -pipe -Wall -Wextra -std=gnu99")
 set(PYTHON python)
 

--- a/cache/CMakeLists.txt
+++ b/cache/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 include_directories(BEFORE . ..)
 
 add_library(oiocache SHARED cache.c cache_noop.c cache_lru.c cache_multilayer.c)
+set_target_properties(oiocache PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiocache metautils ${GLIB2_LIBRARIES})
 
 install(TARGETS oiocache
@@ -14,6 +15,7 @@ install(TARGETS oiocache
 if (DEFINED ALLOW_HIREDIS)
 	if (HIREDIS_FOUND)
 		add_library(oiocache_redis SHARED cache_redis.c)
+		set_target_properties(oiocache_redis PROPERTIES VERSION 0.0.0 SOVERSION 0)
 		target_link_libraries(oiocache_redis ${HIREDIS_LIBRARIES})
 
 		install(TARGETS oiocache_redis
@@ -26,6 +28,7 @@ endif ()
 if (DEFINED ALLOW_LIBMEMCACHED)
 	if (LIBMEMCACHED_FOUND)
 		add_library(oiocache_memcached SHARED cache_memcached.c)
+		set_target_properties(oiocache_memcached PROPERTIES VERSION 0.0.0 SOVERSION 0)
 		target_link_libraries(oiocache_memcached ${LIBMEMCACHED_LIBRARIES})
 
 		install(TARGETS oiocache_memcached

--- a/cluster/lib/CMakeLists.txt
+++ b/cluster/lib/CMakeLists.txt
@@ -7,12 +7,11 @@ include_directories(BEFORE
 	${CMAKE_BINARY_DIR})
 
 add_library(gridcluster SHARED gridcluster.c)
-
-set_target_properties(gridcluster PROPERTIES SOVERSION ${ABI_VERSION})
-
+set_target_properties(gridcluster PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(gridcluster
 		metautils oiosds
-		-lm ${GLIB2_LIBRARIES})
+		${GLIB2_LIBRARIES}
+		-lm)
 
 install(TARGETS gridcluster
 	LIBRARY DESTINATION ${LD_LIBDIR}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -57,11 +57,9 @@ add_library(oiocore SHARED url.c cfg.c str.c ext.c log.c lb.c var.c
 	${CMAKE_CURRENT_BINARY_DIR}/lb_variables.h
 	${CMAKE_CURRENT_BINARY_DIR}/lb_variables.c)
 
+set_target_properties(oiocore PROPERTIES PUBLIC_HEADER "oio_core.h" VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiocore
 		${JSONC_LIBRARIES} ${GLIB2_LIBRARIES})
-set_target_properties(oiocore PROPERTIES
-		PUBLIC_HEADER "oio_core.h"
-		SOVERSION ${ABI_VERSION})
 
 add_library(oiosds SHARED
 	http_put.c
@@ -69,11 +67,10 @@ add_library(oiosds SHARED
 	headers.c
 	proxy.c
 	sds.c dir.c cs.c)
+
+set_target_properties(oiosds PROPERTIES PUBLIC_HEADER "oio_sds.h" VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiosds oiocore
 		${GLIB2_LIBRARIES} ${CURL_LIBRARIES} ${JSONC_LIBRARIES})
-set_target_properties(oiosds PROPERTIES
-		PUBLIC_HEADER "oio_sds.h"
-		SOVERSION ${ABI_VERSION})
 
 add_executable(tool_sdk_noconf tool_sdk_noconf.c)
 target_link_libraries(tool_sdk_noconf oiosds)

--- a/events/CMakeLists.txt
+++ b/events/CMakeLists.txt
@@ -40,8 +40,10 @@ add_library(oioevents SHARED
 	oio_events_queue_beanstalkd.c
 	${CMAKE_CURRENT_BINARY_DIR}/events_variables.c)
 
-set_target_properties(oioevents PROPERTIES SOVERSION ${ABI_VERSION})
-target_link_libraries(oioevents metautils ${GLIB2_LIBRARIES} ${ZMQ_LIBRARIES})
+set_target_properties(oioevents PROPERTIES VERSION 0.0.0 SOVERSION 0)
+target_link_libraries(oioevents
+	metautils
+	${GLIB2_LIBRARIES} ${ZMQ_LIBRARIES})
 
 install(TARGETS oioevents
 		LIBRARY DESTINATION ${LD_LIBDIR}

--- a/meta0v2/CMakeLists.txt
+++ b/meta0v2/CMakeLists.txt
@@ -17,21 +17,21 @@ link_directories(
 		${SQLITE3_LIBRARY_DIRS})
 
 add_library(meta0remote SHARED meta0_remote.c meta0_remote.h)
-set_target_properties(meta0remote PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(meta0remote PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta0remote
 		metautils
 		${GLIB2_LIBRARIES})
 
 
 add_library(meta0utils SHARED meta0_utils.c meta0_utils.h)
-set_target_properties(meta0utils PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(meta0utils PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta0utils
 		metautils gridcluster
 		${GLIB2_LIBRARIES})
 
 
 add_library(meta0v2 SHARED meta0_backend.h meta0_backend.c)
-set_target_properties(meta0v2 PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(meta0v2 PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta0v2
 		meta0utils metautils gridcluster sqliterepo
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})

--- a/meta1v2/CMakeLists.txt
+++ b/meta1v2/CMakeLists.txt
@@ -25,14 +25,14 @@ add_library(meta1v2 SHARED
 		meta1_prefixes.c meta1_prefixes.h
 		internals.h internals_sqlite.h)
 
-set_target_properties(meta1v2 PROPERTIES SOVERSION ${ABI_VERSION})
+	set_target_properties(meta1v2 PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta1v2
 		metautils gridcluster sqliterepo
 		meta0utils meta0remote
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
 add_library(meta1remote SHARED meta1_remote.c meta1_remote.h)
-set_target_properties(meta1remote PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(meta1remote PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta1remote
 		metautils
 		${GLIB2_LIBRARIES})

--- a/meta2v2/CMakeLists.txt
+++ b/meta2v2/CMakeLists.txt
@@ -70,10 +70,12 @@ add_library(meta2v2utils SHARED
 		meta2_utils_json.h
 )
 
+set_target_properties(meta2v2utils PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta2v2utils
 		metautils gridcluster sqliteutils
 		${LIBRAIN_LIBRARIES}
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES} ${JSONC_LIBRARIES})
+
 
 add_library(meta2v2 SHARED
 		${CMAKE_CURRENT_BINARY_DIR}/autogen.h generic.h
@@ -82,12 +84,14 @@ add_library(meta2v2 SHARED
 		meta2_backend.h
 		meta2_backend.c)
 
+set_target_properties(meta2v2 PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(meta2v2
 		metautils sqliterepo
 		meta1remote meta0remote meta0utils
 		meta2v2utils
 		sqlxsrv
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
+
 
 add_executable(meta2_server
 		meta2_gridd_dispatcher.c

--- a/metautils/lib/CMakeLists.txt
+++ b/metautils/lib/CMakeLists.txt
@@ -339,7 +339,7 @@ add_library(metautils SHARED
 		comm_converter.c
 		comm_meta_reply.c
 )
-
+set_target_properties(metautils PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(metautils
 		oiocore
 		${GLIB2_LIBRARIES} ${JSONC_LIBRARIES}

--- a/rawx-lib/src/CMakeLists.txt
+++ b/rawx-lib/src/CMakeLists.txt
@@ -16,8 +16,7 @@ add_library(rawx SHARED
 		compression.c
 		zlib_compress.c)
 
-set_target_properties(rawx PROPERTIES SOVERSION ${ABI_VERSION})
-
+set_target_properties(rawx PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(rawx
 		metautils gridcluster
 		${ATTR_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/rdir/CMakeLists.txt
+++ b/rdir/CMakeLists.txt
@@ -44,9 +44,9 @@ add_executable(rdir
 		../proxy/transport_http.c)
 
 bin_prefix(rdir -rdir-server)
-
-target_link_libraries(rdir metautils oiocore server
-	 ${LEVELDB_LIBRARIES})
+target_link_libraries(rdir
+		metautils oiocore server
+		${LEVELDB_LIBRARIES})
 
 install(TARGETS rdir
 		LIBRARY DESTINATION ${LD_LIBDIR}

--- a/resolver/CMakeLists.txt
+++ b/resolver/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(hcresolve SHARED
 	hc_resolver.c
 	${CMAKE_CURRENT_BINARY_DIR}/resolver_variables.c
 	${CMAKE_CURRENT_BINARY_DIR}/resolver_variables.h)
-
+bin_prefix(hcresolve -directory-resolve)
 target_link_libraries(hcresolve
 		meta0remote meta1remote metautils gridcluster
 		${GLIB2_LIBRARIES})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(server SHARED
         transport_gridd.c
 		${CMAKE_CURRENT_BINARY_DIR}/server_variables.c)
 
-set_target_properties(server PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(server PROPERTIES VERSION 0.0.0 SOVERSION 0)
 
 target_link_libraries(server
 		metautils

--- a/sqliterepo/CMakeLists.txt
+++ b/sqliterepo/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_command(
 
 add_library(sqliteutils SHARED rc.c sqlite_utils.c)
 
-set_target_properties(sqliteutils PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(sqliteutils PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(sqliteutils metautils
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
@@ -65,7 +65,7 @@ add_library(sqlitereporemote SHARED
 		${CMAKE_CURRENT_BINARY_DIR}/sqliterepo_remote_variables.c
 		${CMAKE_CURRENT_BINARY_DIR}/sqliterepo_remote_variables.h)
 
-set_target_properties(sqlitereporemote PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(sqlitereporemote PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(sqlitereporemote metautils
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
@@ -84,7 +84,7 @@ add_library(sqliterepo SHARED
 		${CMAKE_CURRENT_BINARY_DIR}/sqliterepo_variables.c
 		${CMAKE_CURRENT_BINARY_DIR}/sqliterepo_variables.h)
 
-set_target_properties(sqliterepo PROPERTIES SOVERSION ${ABI_VERSION})
+	set_target_properties(sqliterepo PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(sqliterepo metautils
 		sqlitereporemote sqliteutils
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES} ${ZK_LIBRARIES})

--- a/sqlx/CMakeLists.txt
+++ b/sqlx/CMakeLists.txt
@@ -16,7 +16,7 @@ link_directories(
 
 
 add_library(sqlxsrv SHARED sqlx_service.c)
-set_target_properties(sqlxsrv PROPERTIES SOVERSION ${ABI_VERSION})
+set_target_properties(sqlxsrv PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(sqlxsrv
 		server metautils gridcluster sqliterepo
 		hcresolve meta0remote meta1remote
@@ -26,25 +26,19 @@ target_link_libraries(sqlxsrv
 
 
 add_library(oiosqlx SHARED sqlx_client.c)
-set_target_properties(oiosqlx PROPERTIES
-		PUBLIC_HEADER "sqlx_client.h"
-		SOVERSION ${ABI_VERSION})
+set_target_properties(oiosqlx PROPERTIES PUBLIC_HEADER "sqlx_client.h" VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiosqlx
 		oiocore oiosds
 		${GLIB2_LIBRARIES})
 
 add_library(oiosqlx_local SHARED sqlx_client_local.c)
-set_target_properties(oiosqlx_local PROPERTIES
-		PUBLIC_HEADER "sqlx_client_local.h"
-		SOVERSION ${ABI_VERSION})
+set_target_properties(oiosqlx_local PROPERTIES PUBLIC_HEADER "sqlx_client_local.h" VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiosqlx_local
 		oiosqlx ${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
 
 add_library(oiosqlx_direct SHARED sqlx_client_direct.c)
-set_target_properties(oiosqlx_direct PROPERTIES
-		PUBLIC_HEADER "sqlx_client_direct.h"
-		SOVERSION ${ABI_VERSION})
+set_target_properties(oiosqlx_direct PROPERTIES PUBLIC_HEADER "sqlx_client_direct.h" VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiosqlx_direct
 		oiosqlx sqlitereporemote ${GLIB2_LIBRARIES})
 

--- a/tests/func/CMakeLists.txt
+++ b/tests/func/CMakeLists.txt
@@ -34,17 +34,15 @@ if (DEFINED ALLOW_LIBMEMCACHED)
 endif ()
 
 add_library(oiosds_test SHARED testlib_sds.c)
+set_target_properties(oiosds_test PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiosds_test oiosds)
-set_target_properties(oiosds_test PROPERTIES
-		SOVERSION ${ABI_VERSION})
 add_test(NAME core/sds
 		COMMAND /usr/bin/env ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/test_oiosds.py ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(core/sds PROPERTIES ENVIRONMENT CTEST_OUTPUT_ON_FAILURE=1)
 
 add_library(oiohttp_test SHARED testlib_http.c)
+set_target_properties(oiohttp_test PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oiohttp_test oiosds)
-set_target_properties(oiohttp_test PROPERTIES
-		SOVERSION ${ABI_VERSION})
 add_test(NAME core/http
 		COMMAND /usr/bin/env ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/test_oiohttp.py ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(core/http PROPERTIES ENVIRONMENT CTEST_OUTPUT_ON_FAILURE=1)

--- a/tools/event-benchmark/CMakeLists.txt
+++ b/tools/event-benchmark/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(
 )
 
 bin_prefix(event_benchmark -event-benchmark)
-
 target_link_libraries(event_benchmark
 		oioevents
 		server gridcluster


### PR DESCRIPTION
##### SUMMARY
Prior to this PR, the `0.0.0` ABI version is appended by default to the shared object (.so) files we generate, and the main ABI_VERSION variable was useless.
Now each library might evolve independently, and the starting point is the same `0.0.0` for the sake of backward compliance.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`*`

##### SDS VERSION
`openio 4.4.0.0b1.dev26`
