### PR TITLE
Save the number of damaged objects

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -815,14 +815,58 @@ meta2_backend_purge_container(struct meta2_backend_s *m2, struct oio_url_s *url,
 
 /* Contents --------------------------------------------------------------- */
 
+static gboolean
+_is_damaged_object(struct meta2_backend_s *m2b, struct sqlx_sqlite3_s *sq3,
+		struct oio_url_s *url)
+{
+	struct namespace_info_s *nsinfo = NULL;
+	if (!(nsinfo = meta2_backend_get_nsinfo(m2b))) {
+		GRID_WARN("NS not ready");
+		return FALSE;
+	}
+
+	GSList *beans = NULL;
+	gint64 content_missing_chunks = 0;
+
+	GError *err = m2db_get_alias(sq3, url, 0,
+			_bean_list_cb, &beans);
+	if (!err) {
+		struct m2v2_sorted_content_s *sorted = NULL;
+		m2v2_sort_content(beans, &sorted);
+		err = m2db_get_content_missing_chunks(
+				sorted, nsinfo, &content_missing_chunks);
+		m2v2_sorted_content_free(sorted);
+		_bean_cleanl2(beans);
+	}
+
+	if (err) {
+		GRID_WARN("Impossible to know if object is damaged (%s): %s",
+				oio_url_get(url, OIOURL_WHOLE), err->message);
+		g_error_free(err);
+		return FALSE;
+	}
+	return content_missing_chunks > 0;
+}
+
 /**
  * @param deleted_objects: list of lists of deleted beans
  */
 static void
 _update_missing_chunks(struct meta2_backend_s *m2b, struct sqlx_sqlite3_s *sq3,
-		gint64 new_missing_chunks, GSList *deleted_objects)
+		struct oio_url_s *url, gint64 new_missing_chunks,
+		GSList *deleted_objects, gboolean partial, gboolean already_damaged)
 {
+	gboolean now_damaged = FALSE;
+	if (new_missing_chunks
+			|| (partial && _is_damaged_object(m2b, sq3, url))) {
+		now_damaged = TRUE;
+	}
+
+	gint64 damaged_objects = m2db_get_damaged_objects(sq3);
 	gint64 missing_chunks = m2db_get_missing_chunks(sq3);
+	if (now_damaged && !(partial && already_damaged)) {
+		damaged_objects++;
+	}
 	missing_chunks += new_missing_chunks;
 
 	if (!deleted_objects)
@@ -849,12 +893,17 @@ _update_missing_chunks(struct meta2_backend_s *m2b, struct sqlx_sqlite3_s *sq3,
 			g_clear_error(&err);
 		}
 		m2v2_sorted_content_free(sorted);
+		if ((!partial && content_missing_chunks)
+				|| (partial && already_damaged && !now_damaged)) {
+			damaged_objects--;
+		}
 		missing_chunks -= content_missing_chunks;
 	}
 
 	namespace_info_free(nsinfo);
 
 end:
+	m2db_set_damaged_objects(sq3, damaged_objects);
 	m2db_set_missing_chunks(sq3, missing_chunks);
 }
 
@@ -980,7 +1029,8 @@ meta2_backend_delete_alias(struct meta2_backend_s *m2b,
 				if (deleted_beans) {
 					deleted_objects = g_slist_append(
 							deleted_objects, deleted_beans);
-					_update_missing_chunks(m2b, sq3, 0, deleted_objects);
+					_update_missing_chunks(m2b, sq3, url,
+							0, deleted_objects, FALSE, FALSE);
 				}
 				m2db_increment_version(sq3);
 			}
@@ -1031,8 +1081,8 @@ meta2_backend_put_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_put_alias(&args, in,
 					_bean_list_cb, &deleted_objects, cb_added, u0_added))) {
-				_update_missing_chunks(m2b, sq3,
-						missing_chunks, deleted_objects);
+				_update_missing_chunks(m2b, sq3, url,
+						missing_chunks, deleted_objects, FALSE, FALSE);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);
@@ -1081,8 +1131,8 @@ meta2_backend_change_alias_policy(struct meta2_backend_s *m2b,
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
 			if (!(err = m2db_change_alias_policy(&args, in,
 					_bean_list_cb, &deleted_objects, cb_added, u0_added))) {
-				_update_missing_chunks(m2b, sq3,
-						missing_chunks, deleted_objects);
+				_update_missing_chunks(m2b, sq3, url,
+						missing_chunks, deleted_objects, FALSE, FALSE);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);
@@ -1124,10 +1174,11 @@ meta2_backend_update_content(struct meta2_backend_s *m2b, struct oio_url_s *url,
 		GSList *deleted_objects = NULL;
 
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
+			gboolean already_damaged = _is_damaged_object(m2b, sq3, url);
 			if (!(err = m2db_update_content(sq3, url, in,
 					_bean_list_cb, &deleted_objects, cb_added, u0_added))) {
-				_update_missing_chunks(m2b, sq3,
-						missing_chunks, deleted_objects);
+				_update_missing_chunks(m2b, sq3, url,
+						missing_chunks, deleted_objects, TRUE, already_damaged);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);
@@ -1165,12 +1216,14 @@ meta2_backend_truncate_content(struct meta2_backend_s *m2b,
 		GSList *deleted_objects = NULL;
 
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
+			gboolean already_damaged = _is_damaged_object(m2b, sq3, url);
 			if (!(err = m2db_truncate_content(sq3, url, truncate_size,
 						out_deleted, out_added))) {
 				if (out_deleted) {
 					deleted_objects = g_slist_append(
 							deleted_objects, *out_deleted);
-					_update_missing_chunks(m2b, sq3, 0, deleted_objects);
+					_update_missing_chunks(m2b, sq3, url,
+							0, deleted_objects, TRUE, already_damaged);
 				}
 				m2db_increment_version(sq3);
 			}
@@ -1214,8 +1267,8 @@ meta2_backend_force_alias(struct meta2_backend_s *m2b, struct oio_url_s *url,
 		if (!(err = _transaction_begin(sq3,url, &repctx))) {
 			if (!(err = m2db_force_alias(&args, in,
 					_bean_list_cb, &deleted_objects, cb_added, u0_added))) {
-				_update_missing_chunks(m2b, sq3,
-						missing_chunks, deleted_objects);
+				_update_missing_chunks(m2b, sq3, url,
+						missing_chunks, deleted_objects, FALSE, FALSE);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);
@@ -1263,7 +1316,8 @@ meta2_backend_purge_alias(struct meta2_backend_s *m2, struct oio_url_s *url,
 			if (!(err = m2db_purge(sq3, maxvers, _retention_delay(sq3),
 					oio_url_get(url, OIOURL_PATH),
 					_bean_list_cb, &deleted_objects))) {
-				_update_missing_chunks(m2, sq3, 0, deleted_objects);
+				_update_missing_chunks(m2, sq3, url,
+						0, deleted_objects, FALSE, FALSE);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);
@@ -1432,8 +1486,10 @@ meta2_backend_append_to_alias(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
+			gboolean already_damaged = _is_damaged_object(m2b, sq3, url);
 			if (!(err = m2db_append_to_alias(sq3, url, beans, cb, u0))) {
-				_update_missing_chunks(m2b, sq3, missing_chunks, NULL);
+				_update_missing_chunks(m2b, sq3, url,
+						missing_chunks, NULL, TRUE, already_damaged);
 				m2db_increment_version(sq3);
 			}
 			err = sqlx_transaction_end(repctx, err);

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -905,7 +905,8 @@ meta2_backend_get_alias(struct meta2_backend_s *m2b,
 /* TODO(jfs): maybe is there a way to keep this in a cache */
 GError*
 meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gboolean recompute, gint64 missing_chunks)
+		struct oio_url_s *url, gboolean recompute,
+		gint64 damaged_objects, gint64 missing_chunks)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -923,6 +924,7 @@ meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
 						&size, &count);
 				m2db_set_size(sq3, size);
 				m2db_set_obj_count(sq3, count);
+				m2db_set_damaged_objects(sq3, damaged_objects);
 				m2db_set_missing_chunks(sq3, missing_chunks);
 				m2db_increment_version(sq3);
 				err = sqlx_transaction_end(repctx, err);

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1397,6 +1397,8 @@ meta2_backend_insert_beans(struct meta2_backend_s *m2b,
 			}
 			err = sqlx_transaction_end(repctx, err);
 		}
+		if (!err)
+			m2b_add_modified_container(m2b, sq3);
 		m2b_close(sq3);
 	}
 

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -308,6 +308,7 @@ _container_state (struct sqlx_sqlite3_s *sq3)
 	append_int64(gs, "ctime", m2db_get_ctime(sq3));
 	append_int64(gs, "bytes-count", m2db_get_size(sq3));
 	append_int64(gs, "object-count", m2db_get_obj_count(sq3));
+	append_int64(gs, "damaged-objects", m2db_get_damaged_objects(sq3));
 	append_int64(gs, "missing-chunks", m2db_get_missing_chunks(sq3));
 	g_string_append_static (gs, "}}");
 
@@ -569,6 +570,7 @@ _init_container(struct sqlx_sqlite3_s *sq3,
 		m2db_set_ctime (sq3, oio_ext_real_time());
 		m2db_set_size(sq3, 0);
 		m2db_set_obj_count(sq3, 0);
+		m2db_set_damaged_objects(sq3, 0);
 		m2db_set_missing_chunks(sq3, 0);
 		sqlx_admin_set_status(sq3, ADMIN_STATUS_ENABLED);
 		sqlx_admin_init_i64(sq3, META2_INIT_FLAG, 1);

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -119,7 +119,8 @@ GError* meta2_backend_delete_chunks(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, GSList *beans);
 
 GError* meta2_backend_notify_container_state(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gboolean recompute, gint64 missing_chunks);
+		struct oio_url_s *url, gboolean recompute,
+		gint64 damaged_objects, gint64 missing_chunks);
 
 GError* meta2_backend_put_alias(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, GSList *in, gint64 missing_chunks,

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -517,12 +517,15 @@ meta2_filter_action_touch_container(struct gridd_filter_ctx_s *ctx,
 	gboolean recompute = FALSE;
 	metautils_message_extract_boolean(reply->request,
 			NAME_MSGKEY_RECOMPUTE, FALSE, &recompute);
+	gint64 damaged_objects = 0;
+	metautils_message_extract_strint64(reply->request,
+			NAME_MSGKEY_DAMAGED_OBJECTS, &damaged_objects);
 	gint64 missing_chunks = 0;
 	metautils_message_extract_strint64(reply->request,
 			NAME_MSGKEY_MISSING_CHUNKS, &missing_chunks);
 
 	GError *err = meta2_backend_notify_container_state(m2b, url,
-			recompute, missing_chunks);
+			recompute, damaged_objects, missing_chunks);
 	if (!err)
 		return FILTER_OK;
 	meta2_filter_ctx_set_error(ctx, err);

--- a/meta2v2/meta2_macros.h
+++ b/meta2v2/meta2_macros.h
@@ -44,6 +44,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define M2V2_ADMIN_OBJ_COUNT M2V2_ADMIN_PREFIX_SYS "objects"
 # endif
 
+# ifndef M2V2_ADMIN_DAMAGED_OBJECTS
+# define M2V2_ADMIN_DAMAGED_OBJECTS M2V2_ADMIN_PREFIX_SYS "objects.damaged"
+# endif
+
 # ifndef M2V2_ADMIN_MISSING_CHUNKS
 # define M2V2_ADMIN_MISSING_CHUNKS M2V2_ADMIN_PREFIX_SYS "chunks.missing"
 # endif

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -253,6 +253,20 @@ m2db_set_obj_count(struct sqlx_sqlite3_s *sq3, gint64 count)
 }
 
 gint64
+m2db_get_damaged_objects(struct sqlx_sqlite3_s *sq3)
+{
+	return sqlx_admin_get_i64(sq3, M2V2_ADMIN_DAMAGED_OBJECTS, 0);
+}
+
+void
+m2db_set_damaged_objects(struct sqlx_sqlite3_s *sq3, gint64 damaged)
+{
+	if (damaged < 0)
+		damaged = 0;
+	sqlx_admin_set_i64(sq3, M2V2_ADMIN_DAMAGED_OBJECTS, damaged);
+}
+
+gint64
 m2db_get_missing_chunks(struct sqlx_sqlite3_s *sq3)
 {
 	return sqlx_admin_get_i64(sq3, M2V2_ADMIN_MISSING_CHUNKS, 0);

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -120,6 +120,10 @@ gint64 m2db_get_obj_count(struct sqlx_sqlite3_s *sq3);
 
 void m2db_set_obj_count(struct sqlx_sqlite3_s *sq3, gint64 count);
 
+gint64 m2db_get_damaged_objects(struct sqlx_sqlite3_s *sq3);
+
+void m2db_set_damaged_objects(struct sqlx_sqlite3_s *sq3, gint64 damaged);
+
 gint64 m2db_get_missing_chunks(struct sqlx_sqlite3_s *sq3);
 
 void m2db_set_missing_chunks(struct sqlx_sqlite3_s *sq3, gint64 missing);

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -57,6 +57,7 @@ License along with this library.
 #define NAME_MSGKEY_CONTENTLENGTH      "CL"
 #define NAME_MSGKEY_CONTENTPATH        "CP"
 #define NAME_MSGKEY_CONTENTID          "CI"
+#define NAME_MSGKEY_DAMAGED_OBJECTS    "DAMAGED_OBJECTS"
 #define NAME_MSGKEY_DRYRUN             "DRYRUN"
 #define NAME_MSGKEY_DST                "DST"
 #define NAME_MSGKEY_EVENT              "E"

--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -53,7 +53,7 @@ class AccountBackend(RedisConn):
                  if ARGV[7] == 'True' then
                    redis.call('HSET', 'accounts:', KEYS[1], 1);
                    redis.call('HMSET', KEYS[4], 'id', KEYS[1],
-                              'bytes', 0, 'objects', 0, 'missing-chunks', 0,
+                              'bytes', 0, 'objects', 0, 'missing_chunks', 0,
                               'ctime', ARGV[8]);
                  else
                    return redis.error_reply('no_account');
@@ -73,7 +73,7 @@ class AccountBackend(RedisConn):
                local objects = redis.call('HGET', KEYS[2], 'objects');
                local bytes = redis.call('HGET', KEYS[2], 'bytes');
                local missing_chunks = redis.call('HGET', KEYS[2],
-                                                 'missing-chunks');
+                                                 'missing_chunks');
 
                -- When the keys do not exist redis return false and not nil
                if dtime == false then
@@ -117,7 +117,7 @@ class AccountBackend(RedisConn):
                  inc_bytes = -bytes;
                  inc_missing_chunks = -missing_chunks;
                  redis.call('HMSET', KEYS[2],
-                            'bytes', 0, 'objects', 0, 'missing-chunks', 0);
+                            'bytes', 0, 'objects', 0, 'missing_chunks', 0);
                  redis.call('EXPIRE', KEYS[2], tonumber(ARGV[9]));
                  redis.call('ZREM', KEYS[3], name);
                elseif is_sup(mtime,old_mtime) then
@@ -128,7 +128,7 @@ class AccountBackend(RedisConn):
                  redis.call('HMSET', KEYS[2],
                             'objects', tonumber(ARGV[4]),
                             'bytes', tonumber(ARGV[5]),
-                            'missing-chunks', tonumber(ARGV[6]));
+                            'missing_chunks', tonumber(ARGV[6]));
                  redis.call('ZADD', KEYS[3], '0', name);
                else
                  return redis.error_reply('no_update_needed');
@@ -143,7 +143,7 @@ class AccountBackend(RedisConn):
                  redis.call('HINCRBY', KEYS[4], 'bytes', inc_bytes);
                end;
                if inc_missing_chunks ~= 0 then
-                 redis.call('HINCRBY', KEYS[4], 'missing-chunks',
+                 redis.call('HINCRBY', KEYS[4], 'missing_chunks',
                             inc_missing_chunks);
                end;
                """)
@@ -165,11 +165,11 @@ class AccountBackend(RedisConn):
                                                    'objects')
             bytes_sum = bytes_sum + redis.call('HGET', container_key, 'bytes')
             missing_chunks_sum = missing_chunks_sum
-                    + redis.call('HGET', container_key, 'missing-chunks')
+                    + redis.call('HGET', container_key, 'missing_chunks')
         end;
 
         redis.call('HMSET', KEYS[1], 'objects', objects_sum,
-                   'bytes', bytes_sum, 'missing-chunks', missing_chunks_sum)
+                   'bytes', bytes_sum, 'missing_chunks', missing_chunks_sum)
         """
 
     lua_flush_account = """
@@ -179,7 +179,7 @@ class AccountBackend(RedisConn):
         end;
 
         redis.call('HMSET', KEYS[1], 'objects', 0, 'bytes', 0,
-                   'missing-chunks', 0)
+                   'missing_chunks', 0)
 
         local containers = redis.call('ZRANGE', KEYS[2], 0, -1);
         redis.call('DEL', KEYS[2]);
@@ -222,7 +222,7 @@ class AccountBackend(RedisConn):
             'id': account_id,
             'objects': 0,
             'bytes': 0,
-            'missing-chunks': 0,
+            'missing_chunks': 0,
             'ctime': Timestamp(time()).normal
         })
         pipeline.execute()
@@ -305,7 +305,7 @@ class AccountBackend(RedisConn):
         pipeline.hgetall('metadata:%s' % account_id)
         data = pipeline.execute()
         info = data[0]
-        for r in ['bytes', 'objects', 'missing-chunks']:
+        for r in ['bytes', 'objects', 'missing_chunks']:
             info[r] = int_value(info.get(r), 0)
         info['containers'] = data[1]
         info['metadata'] = data[2]

--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -50,17 +50,18 @@ class AccountBackend(RedisConn):
     lua_update_container = (lua_is_sup + """
                local account_id = redis.call('HGET', KEYS[4], 'id');
                if not account_id then
-                 if ARGV[7] == 'True' then
+                 if ARGV[8] == 'True' then
                    redis.call('HSET', 'accounts:', KEYS[1], 1);
                    redis.call('HMSET', KEYS[4], 'id', KEYS[1],
-                              'bytes', 0, 'objects', 0, 'missing_chunks', 0,
-                              'ctime', ARGV[8]);
+                              'bytes', 0, 'objects', 0,
+                              'damaged_objects', 0, 'missing_chunks', 0,
+                              'ctime', ARGV[9]);
                  else
                    return redis.error_reply('no_account');
                  end;
                end;
 
-               if ARGV[10] == 'False' then
+               if ARGV[11] == 'False' then
                  local container_name = redis.call('HGET', KEYS[2], 'name');
                  if not container_name then
                    return redis.error_reply('no_container');
@@ -72,6 +73,8 @@ class AccountBackend(RedisConn):
                local dtime = redis.call('HGET', KEYS[2], 'dtime');
                local objects = redis.call('HGET', KEYS[2], 'objects');
                local bytes = redis.call('HGET', KEYS[2], 'bytes');
+               local damaged_objects = redis.call('HGET', KEYS[2],
+                                                  'damaged_objects');
                local missing_chunks = redis.call('HGET', KEYS[2],
                                                  'missing_chunks');
 
@@ -88,17 +91,21 @@ class AccountBackend(RedisConn):
                if bytes == false then
                  bytes = 0
                end
+               if damaged_objects == false then
+                 damaged_objects = 0
+               end
                if missing_chunks == false then
                  missing_chunks = 0
                end
 
-               if ARGV[10] == 'False' and is_sup(dtime, mtime) then
+               if ARGV[11] == 'False' and is_sup(dtime, mtime) then
                  return redis.error_reply('no_container');
                end;
 
                local old_mtime = mtime;
                local inc_objects;
                local inc_bytes;
+               local inc_damaged_objects;
                local inc_missing_chunks;
 
                if not is_sup(ARGV[3],dtime) and not is_sup(ARGV[2],mtime) then
@@ -115,20 +122,24 @@ class AccountBackend(RedisConn):
                if is_sup(dtime,mtime) then
                  inc_objects = -objects;
                  inc_bytes = -bytes;
+                 inc_damaged_objects = -damaged_objects
                  inc_missing_chunks = -missing_chunks;
                  redis.call('HMSET', KEYS[2],
-                            'bytes', 0, 'objects', 0, 'missing_chunks', 0);
-                 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[9]));
+                            'bytes', 0, 'objects', 0,
+                            'damaged_objects', 0, 'missing_chunks', 0);
+                 redis.call('EXPIRE', KEYS[2], tonumber(ARGV[10]));
                  redis.call('ZREM', KEYS[3], name);
                elseif is_sup(mtime,old_mtime) then
                  redis.call('PERSIST', KEYS[2]);
                  inc_objects = tonumber(ARGV[4]) - objects
                  inc_bytes = tonumber(ARGV[5]) - bytes
-                 inc_missing_chunks = tonumber(ARGV[6]) - missing_chunks
+                 inc_damaged_objects = tonumber(ARGV[6]) - damaged_objects
+                 inc_missing_chunks = tonumber(ARGV[7]) - missing_chunks
                  redis.call('HMSET', KEYS[2],
                             'objects', tonumber(ARGV[4]),
                             'bytes', tonumber(ARGV[5]),
-                            'missing_chunks', tonumber(ARGV[6]));
+                            'damaged_objects', tonumber(ARGV[6]),
+                            'missing_chunks', tonumber(ARGV[7]));
                  redis.call('ZADD', KEYS[3], '0', name);
                else
                  return redis.error_reply('no_update_needed');
@@ -141,6 +152,10 @@ class AccountBackend(RedisConn):
                end;
                if inc_bytes ~= 0 then
                  redis.call('HINCRBY', KEYS[4], 'bytes', inc_bytes);
+               end;
+               if inc_damaged_objects ~= 0 then
+                 redis.call('HINCRBY', KEYS[4], 'damaged_objects',
+                            inc_damaged_objects);
                end;
                if inc_missing_chunks ~= 0 then
                  redis.call('HINCRBY', KEYS[4], 'missing_chunks',
@@ -158,18 +173,23 @@ class AccountBackend(RedisConn):
         local container_key = ''
         local bytes_sum = 0;
         local objects_sum = 0;
+        local damaged_objects_sum = 0;
         local missing_chunks_sum = 0;
         for _,container in ipairs(containers) do
             container_key = KEYS[3] .. container;
             objects_sum = objects_sum + redis.call('HGET', container_key,
                                                    'objects')
             bytes_sum = bytes_sum + redis.call('HGET', container_key, 'bytes')
+            damaged_objects_sum = damaged_objects_sum
+                    + redis.call('HGET', container_key, 'damaged_objects')
             missing_chunks_sum = missing_chunks_sum
                     + redis.call('HGET', container_key, 'missing_chunks')
         end;
 
         redis.call('HMSET', KEYS[1], 'objects', objects_sum,
-                   'bytes', bytes_sum, 'missing_chunks', missing_chunks_sum)
+                   'bytes', bytes_sum,
+                   'damaged_objects', damaged_objects_sum,
+                   'missing_chunks', missing_chunks_sum)
         """
 
     lua_flush_account = """
@@ -179,7 +199,7 @@ class AccountBackend(RedisConn):
         end;
 
         redis.call('HMSET', KEYS[1], 'objects', 0, 'bytes', 0,
-                   'missing_chunks', 0)
+                   'damaged_objects', 0, 'missing_chunks', 0)
 
         local containers = redis.call('ZRANGE', KEYS[2], 0, -1);
         redis.call('DEL', KEYS[2]);
@@ -222,6 +242,7 @@ class AccountBackend(RedisConn):
             'id': account_id,
             'objects': 0,
             'bytes': 0,
+            'damaged_objects': 0,
             'missing_chunks': 0,
             'ctime': Timestamp(time()).normal
         })
@@ -305,7 +326,7 @@ class AccountBackend(RedisConn):
         pipeline.hgetall('metadata:%s' % account_id)
         data = pipeline.execute()
         info = data[0]
-        for r in ['bytes', 'objects', 'missing_chunks']:
+        for r in ['bytes', 'objects', 'damaged_objects', 'missing_chunks']:
             info[r] = int_value(info.get(r), 0)
         info['containers'] = data[1]
         info['metadata'] = data[2]
@@ -317,7 +338,8 @@ class AccountBackend(RedisConn):
         return accounts
 
     def update_container(self, account_id, name, mtime, dtime,
-                         object_count, bytes_used, missing_chunks,
+                         object_count, bytes_used,
+                         damaged_objects, missing_chunks,
                          autocreate_account=None, autocreate_container=True):
         conn = self.conn
         if not account_id or not name:
@@ -338,13 +360,16 @@ class AccountBackend(RedisConn):
             object_count = 0
         if bytes_used is None:
             bytes_used = 0
+        if damaged_objects is None:
+            damaged_objects = 0
         if missing_chunks is None:
             missing_chunks = 0
 
         keys = [account_id, AccountBackend.ckey(account_id, name),
                 ("containers:%s" % (account_id)),
                 ("account:%s" % (account_id))]
-        args = [name, mtime, dtime, object_count, bytes_used, missing_chunks,
+        args = [name, mtime, dtime, object_count, bytes_used,
+                damaged_objects, missing_chunks,
                 str(autocreate_account), Timestamp(time()).normal, EXPIRE_TIME,
                 str(autocreate_container)]
         try:

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -418,11 +418,12 @@ class Account(WerkzeugApp):
         dtime = data.get('dtime')
         object_count = data.get('objects')
         bytes_used = data.get('bytes')
+        damaged_objects = data.get('damaged_objects')
         missing_chunks = data.get('missing_chunks')
         # Exceptions are catched by dispatch_request
         info = self.backend.update_container(
             account_id, name, mtime, dtime,
-            object_count, bytes_used, missing_chunks)
+            object_count, bytes_used, damaged_objects, missing_chunks)
         result = json.dumps(info)
         return Response(result)
 
@@ -470,11 +471,12 @@ class Account(WerkzeugApp):
         dtime = None
         object_count = 0
         bytes_used = 0
+        damaged_objects = 0
         missing_chunks = 0
         # Exceptions are catched by dispatch_request
         self.backend.update_container(
             account_id, name, mtime, dtime,
-            object_count, bytes_used, missing_chunks,
+            object_count, bytes_used, damaged_objects, missing_chunks,
             autocreate_container=False)
         return Response(status=204)
 

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -418,7 +418,7 @@ class Account(WerkzeugApp):
         dtime = data.get('dtime')
         object_count = data.get('objects')
         bytes_used = data.get('bytes')
-        missing_chunks = data.get('missing-chunks')
+        missing_chunks = data.get('missing_chunks')
         # Exceptions are catched by dispatch_request
         info = self.backend.update_container(
             account_id, name, mtime, dtime,

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -242,7 +242,7 @@ class ObjectStorageApi(object):
         return self.container.container_create(
             account, container, properties=properties, **kwargs)
 
-    def _recompute_damaged_objects(self, account, container, **kwargs):
+    def _recompute_missing_chunks(self, account, container, **kwargs):
         damaged_objects = 0
         missing_chunks = 0
         for obj_meta in depaginate(

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -345,6 +345,7 @@ class ShowContainer(ContainerCommandMixin, show.ShowOne):
         ctime = float(sys['sys.m2.ctime']) / 1000000.
         bytes_usage = sys.get('sys.m2.usage', 0)
         objects = sys.get('sys.m2.objects', 0)
+        damaged_objects = sys.get('sys.m2.objects.damaged', 0)
         missing_chunks = sys.get('sys.m2.chunks.missing', 0)
         if parsed_args.formatter == 'table':
             from oio.common.easy_value import convert_size
@@ -360,6 +361,7 @@ class ShowContainer(ContainerCommandMixin, show.ShowOne):
             'bytes_usage': bytes_usage,
             'quota': sys.get('sys.m2.quota', "Namespace default"),
             'objects': objects,
+            'damaged_objects': damaged_objects,
             'missing_chunks': missing_chunks,
             'storage_policy': sys.get('sys.m2.policy.storage',
                                       "Namespace default"),

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -368,10 +368,13 @@ class ContainerClient(ProxyClient):
         return body
 
     def container_touch(self, account=None, reference=None, cid=None,
-                        recompute=False, missing_chunks=None, **kwargs):
+                        recompute=False, damaged_objects=None,
+                        missing_chunks=None, **kwargs):
         params = self._make_params(account, reference, cid=cid)
         if recompute:
             params['recompute'] = True
+            if damaged_objects is not None:
+                params['damaged_objects'] = damaged_objects
             if missing_chunks is not None:
                 params['missing_chunks'] = missing_chunks
         self._request('POST', '/touch', params=params, **kwargs)

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -43,7 +43,7 @@ class AccountUpdateFilter(Filter):
             if event.event_type == EventTypes.CONTAINER_STATE:
                 body['objects'] = data.get('object-count', 0)
                 body['bytes'] = data.get('bytes-count', 0)
-                body['missing-chunks'] = data.get('missing-chunks', 0)
+                body['missing_chunks'] = data.get('missing_chunks', 0)
                 body['mtime'] = mtime
             elif event.event_type == EventTypes.CONTAINER_NEW:
                 body['mtime'] = mtime

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -43,7 +43,8 @@ class AccountUpdateFilter(Filter):
             if event.event_type == EventTypes.CONTAINER_STATE:
                 body['objects'] = data.get('object-count', 0)
                 body['bytes'] = data.get('bytes-count', 0)
-                body['missing_chunks'] = data.get('missing_chunks', 0)
+                body['damaged_objects'] = data.get('damaged-objects', 0)
+                body['missing_chunks'] = data.get('missing-chunks', 0)
                 body['mtime'] = mtime
             elif event.event_type == EventTypes.CONTAINER_NEW:
                 body['mtime'] = mtime

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1177,9 +1177,20 @@ action_m2_container_touch (struct req_args_s *args, struct json_object *j UNUSED
 	GError *err = NULL;
 
 	gboolean recompute = oio_str_parse_bool(OPT("recompute"), FALSE);
+	gint64 damaged_objects = 0;
 	gint64 missing_chunks = 0;
 
 	if (recompute) {
+		const char *damaged_objects_str = OPT("damaged_objects");
+		if (damaged_objects_str) {
+			char *end = NULL;
+			damaged_objects = g_ascii_strtoll(damaged_objects_str, &end, 10);
+			if (!damaged_objects && end == damaged_objects_str) {
+				err = BADREQ("Invalid damaged objects parameter: %s",
+						damaged_objects_str);
+				goto end;
+			}
+		}
 		const char *missing_chunks_str = OPT("missing_chunks");
 		if (missing_chunks_str) {
 			char *end = NULL;
@@ -1194,7 +1205,7 @@ action_m2_container_touch (struct req_args_s *args, struct json_object *j UNUSED
 
 	PACKER_VOID(_pack) {
 		return m2v2_remote_pack_TOUCHB(args->url, 0, DL(),
-				recompute, missing_chunks);
+				recompute, damaged_objects, missing_chunks);
 	}
 	err = _resolve_meta2(args, _prefer_master(), _pack, NULL, NULL);
 

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -448,7 +448,7 @@ m2v2_remote_pack_TOUCHC(struct oio_url_s *url, gint64 dl)
 
 GByteArray*
 m2v2_remote_pack_TOUCHB(struct oio_url_s *url, guint32 flags, gint64 dl,
-		gboolean recompute, gint64 missing_chunks)
+		gboolean recompute, gint64 damaged_objects, gint64 missing_chunks)
 {
 	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V1_TOUCH_CONTAINER,
 			url, NULL, dl);
@@ -457,6 +457,8 @@ m2v2_remote_pack_TOUCHB(struct oio_url_s *url, guint32 flags, gint64 dl,
 			&flags, sizeof(flags));
 	metautils_message_add_field_struint(msg, NAME_MSGKEY_RECOMPUTE,
 			BOOL(recompute));
+	metautils_message_add_field_strint64(msg, NAME_MSGKEY_DAMAGED_OBJECTS,
+			damaged_objects);
 	metautils_message_add_field_strint64(msg, NAME_MSGKEY_MISSING_CHUNKS,
 			missing_chunks);
 	return message_marshall_gba_and_clean(msg);

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -227,6 +227,7 @@ GByteArray* m2v2_remote_pack_TOUCHB(
 		guint32 flags,
 		gint64 deadline,
 		gboolean recompute,
+		gint64 damaged_objects,
 		gint64 missing_chunks);
 
 GByteArray* m2v2_remote_pack_TOUCHC(

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -150,7 +150,7 @@ class TestAccountBackend(BaseTestCase):
         # delete second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', 0, Timestamp(time()).normal,
-                                 0, 0, 0)
+                                 0, 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
@@ -223,7 +223,8 @@ class TestAccountBackend(BaseTestCase):
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, dtime, 0, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, dtime,
+                                     0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -231,7 +232,8 @@ class TestAccountBackend(BaseTestCase):
 
         # old event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0,
+                                     0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -311,7 +313,8 @@ class TestAccountBackend(BaseTestCase):
         # Old event
         old_mtime = Timestamp(time() - 1).normal
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0,
+                                     0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -358,7 +361,8 @@ class TestAccountBackend(BaseTestCase):
             for cont2 in xrange(125):
                 name = '%d-%04d' % (cont1, cont2)
                 backend.update_container(account_id, name,
-                                         Timestamp(time()).normal, 0, 0, 0, 0, 0)
+                                         Timestamp(time()).normal, 0,
+                                         0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '2-0051-%04d' % cont
@@ -368,7 +372,7 @@ class TestAccountBackend(BaseTestCase):
         for cont in xrange(125):
             name = '3-%04d-0049' % cont
             backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0)
+                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
 
         listing = backend.list_containers(account_id, marker='',
                                           delimiter='', limit=100)

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -99,48 +99,53 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['id'], account_id)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['damaged_objects'], 0)
         self.assertEqual(info['missing_chunks'], 0)
         self.assertEqual(info['containers'], 0)
         self.assertTrue(info['ctime'])
 
         # first container
         backend.update_container(account_id, 'c1', Timestamp(time()).normal, 0,
-                                 1, 1, 1)
+                                 1, 1, 1, 1)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
+        self.assertEqual(info['damaged_objects'], 1)
         self.assertEqual(info['missing_chunks'], 1)
 
         # second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', Timestamp(time()).normal, 0,
-                                 0, 0, 0)
+                                 0, 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
+        self.assertEqual(info['damaged_objects'], 1)
         self.assertEqual(info['missing_chunks'], 1)
 
         # update second container
         sleep(.00001)
         backend.update_container(account_id, 'c2', Timestamp(time()).normal, 0,
-                                 1, 1, 1)
+                                 1, 1, 1, 2)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 2)
         self.assertEqual(info['bytes'], 2)
-        self.assertEqual(info['missing_chunks'], 2)
+        self.assertEqual(info['damaged_objects'], 2)
+        self.assertEqual(info['missing_chunks'], 3)
 
         # delete first container
         sleep(.00001)
         backend.update_container(account_id, 'c1', 0, Timestamp(time()).normal,
-                                 0, 0, 0)
+                                 0, 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
-        self.assertEqual(info['missing_chunks'], 1)
+        self.assertEqual(info['damaged_objects'], 1)
+        self.assertEqual(info['missing_chunks'], 2)
 
         # delete second container
         sleep(.00001)
@@ -150,6 +155,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['damaged_objects'], 0)
         self.assertEqual(info['missing_chunks'], 0)
 
     def test_update_after_container_deletion(self):
@@ -160,16 +166,17 @@ class TestAccountBackend(BaseTestCase):
         # Container create event, sent immediately after creation
         backend.update_container(account_id, 'c1',
                                  Timestamp(time()).normal, None,
-                                 None, None, None)
+                                 None, None, None, None)
 
         # Container update event
         backend.update_container(account_id, 'c1',
                                  Timestamp(time()).normal, None,
-                                 3, 30, 5)
+                                 3, 30, 7, 5)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 3)
         self.assertEqual(info['bytes'], 30)
+        self.assertEqual(info['damaged_objects'], 7)
         self.assertEqual(info['missing_chunks'], 5)
 
         # Container is flushed, but the event is deferred
@@ -179,16 +186,17 @@ class TestAccountBackend(BaseTestCase):
         # Container delete event, sent immediately after deletion
         backend.update_container(account_id, 'c1',
                                  None, Timestamp(time()).normal,
-                                 None, None, None)
+                                 None, None, None, None)
 
         # Deferred container update event (with lower timestamp)
         backend.update_container(account_id, 'c1',
                                  flush_timestamp, None,
-                                 0, 0, 0)
+                                 0, 0, 0, 0)
         info = backend.info_account(account_id)
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
+        self.assertEqual(info['damaged_objects'], 0)
         self.assertEqual(info['missing_chunks'], 0)
 
     def test_delete_container(self):
@@ -200,14 +208,14 @@ class TestAccountBackend(BaseTestCase):
         mtime = Timestamp(time()).normal
 
         # initial container
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         # delete event
         sleep(.00001)
         dtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, dtime, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, dtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -215,7 +223,7 @@ class TestAccountBackend(BaseTestCase):
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, dtime, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, dtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -223,7 +231,7 @@ class TestAccountBackend(BaseTestCase):
 
         # old event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -237,7 +245,7 @@ class TestAccountBackend(BaseTestCase):
         mtime = Timestamp(time()).normal
 
         # create container
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(unicode(res[0], 'utf8'), name)
 
@@ -249,7 +257,7 @@ class TestAccountBackend(BaseTestCase):
         # delete container
         sleep(.00001)
         dtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
+        backend.update_container(account_id, name, 0, dtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -257,7 +265,7 @@ class TestAccountBackend(BaseTestCase):
 
         # ensure it has been removed
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
+            backend.update_container(account_id, name, 0, dtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -271,7 +279,7 @@ class TestAccountBackend(BaseTestCase):
         # initial container
         name = '"{<container \'&\' name>}"'
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -281,7 +289,7 @@ class TestAccountBackend(BaseTestCase):
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -292,7 +300,7 @@ class TestAccountBackend(BaseTestCase):
         # New event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -303,7 +311,7 @@ class TestAccountBackend(BaseTestCase):
         # Old event
         old_mtime = Timestamp(time() - 1).normal
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0)
+            backend.update_container(account_id, name, old_mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -314,7 +322,7 @@ class TestAccountBackend(BaseTestCase):
         # Old delete event
         dtime = Timestamp(time() - 1).normal
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, 0, dtime, 0, 0, 0)
+            backend.update_container(account_id, name, 0, dtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
         self.assertEqual(self.conn.hget('container:%s:%s' %
@@ -323,7 +331,7 @@ class TestAccountBackend(BaseTestCase):
         # New delete event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, 0, mtime, 0, 0, 0)
+        backend.update_container(account_id, name, 0, mtime, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(len(res), 0)
         self.assertTrue(
@@ -332,7 +340,7 @@ class TestAccountBackend(BaseTestCase):
         # New event
         sleep(.00001)
         mtime = Timestamp(time()).normal
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
         self.assertEqual(self.conn.hget('container:%s:%s' %
@@ -350,12 +358,12 @@ class TestAccountBackend(BaseTestCase):
             for cont2 in xrange(125):
                 name = '%d-%04d' % (cont1, cont2)
                 backend.update_container(account_id, name,
-                                         Timestamp(time()).normal, 0, 0, 0, 0)
+                                         Timestamp(time()).normal, 0, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '2-0051-%04d' % cont
             backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0)
+                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '3-%04d-0049' % cont
@@ -443,7 +451,7 @@ class TestAccountBackend(BaseTestCase):
 
         name = '3-0049-'
         backend.update_container(account_id, name, Timestamp(time()).normal, 0,
-                                 0, 0, 0)
+                                 0, 0, 0, 0)
         listing = backend.list_containers(
             account_id, marker='3-0048', limit=10)
         self.assertEqual(len(listing), 10)
@@ -477,6 +485,7 @@ class TestAccountBackend(BaseTestCase):
 
         total_bytes = 0
         total_objects = 0
+        total_damaged_objects = 0
         total_missing_chunks = 0
 
         # 10 containers with bytes and objects
@@ -487,24 +496,31 @@ class TestAccountBackend(BaseTestCase):
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)
             total_objects += nb_objets
+            damaged_objects = random.randrange(100)
+            total_damaged_objects += damaged_objects
             missing_chunks = random.randrange(100)
             total_missing_chunks += missing_chunks
             backend.update_container(account_id, name, mtime, 0,
-                                     nb_objets, nb_bytes, missing_chunks)
+                                     nb_objets, nb_bytes,
+                                     damaged_objects, missing_chunks)
 
         # change values
         self.conn.hset(account_key, 'bytes', 1)
         self.conn.hset(account_key, 'objects', 2)
-        self.conn.hset(account_key, 'missing_chunks', 3)
+        self.conn.hset(account_key, 'damaged_objects', 3)
+        self.conn.hset(account_key, 'missing_chunks', 4)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '1')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '2')
-        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'), '3')
+        self.assertEqual(self.conn.hget(account_key, 'damaged_objects'), '3')
+        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'), '4')
 
         backend.refresh_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'),
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
+        self.assertEqual(self.conn.hget(account_key, 'damaged_objects'),
+                         str(total_damaged_objects))
         self.assertEqual(self.conn.hget(account_key, 'missing_chunks'),
                          str(total_missing_chunks))
 
@@ -516,20 +532,20 @@ class TestAccountBackend(BaseTestCase):
         # initial container
         name = '"{<container \'&\' name>}"'
         mtime = "12456.0000076"
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         # same event
         with ExpectedException(Conflict):
-            backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+            backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
 
         mtime = "0000012456.00005"
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -538,7 +554,7 @@ class TestAccountBackend(BaseTestCase):
                                         (account_id, name), 'mtime'), mtime)
 
         mtime = "0000012456.00035"
-        backend.update_container(account_id, name, mtime, 0, 0, 0, 0)
+        backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.conn.zrangebylex('containers:%s' % account_id, '-', '+')
         self.assertEqual(res[0], name)
@@ -585,6 +601,7 @@ class TestAccountBackend(BaseTestCase):
 
         total_bytes = 0
         total_objects = 0
+        total_damaged_objects = 0
         total_missing_chunks = 0
 
         # 10 containers with bytes and objects
@@ -595,21 +612,27 @@ class TestAccountBackend(BaseTestCase):
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)
             total_objects += nb_objets
+            damaged_objects = random.randrange(100)
+            total_damaged_objects += damaged_objects
             missing_chunks = random.randrange(100)
             total_missing_chunks += missing_chunks
             backend.update_container(account_id, name, mtime, 0,
-                                     nb_objets, nb_bytes, missing_chunks)
+                                     nb_objets, nb_bytes,
+                                     damaged_objects, missing_chunks)
 
         self.assertEqual(self.conn.hget(account_key, 'bytes'),
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
+        self.assertEqual(self.conn.hget(account_key, 'damaged_objects'),
+                         str(total_damaged_objects))
         self.assertEqual(self.conn.hget(account_key, 'missing_chunks'),
                          str(total_missing_chunks))
 
         backend.flush_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '0')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '0')
+        self.assertEqual(self.conn.hget(account_key, 'damaged_objects'), '0')
         self.assertEqual(self.conn.hget(account_key, 'missing_chunks'), '0')
         self.assertEqual(self.conn.zcard("containers:%s" % account_id), 0)
         self.assertEqual(self.conn.exists("container:test:*"), 0)

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -99,7 +99,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['id'], account_id)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
-        self.assertEqual(info['missing-chunks'], 0)
+        self.assertEqual(info['missing_chunks'], 0)
         self.assertEqual(info['containers'], 0)
         self.assertTrue(info['ctime'])
 
@@ -110,7 +110,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
-        self.assertEqual(info['missing-chunks'], 1)
+        self.assertEqual(info['missing_chunks'], 1)
 
         # second container
         sleep(.00001)
@@ -120,7 +120,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
-        self.assertEqual(info['missing-chunks'], 1)
+        self.assertEqual(info['missing_chunks'], 1)
 
         # update second container
         sleep(.00001)
@@ -130,7 +130,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 2)
         self.assertEqual(info['bytes'], 2)
-        self.assertEqual(info['missing-chunks'], 2)
+        self.assertEqual(info['missing_chunks'], 2)
 
         # delete first container
         sleep(.00001)
@@ -140,7 +140,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
         self.assertEqual(info['bytes'], 1)
-        self.assertEqual(info['missing-chunks'], 1)
+        self.assertEqual(info['missing_chunks'], 1)
 
         # delete second container
         sleep(.00001)
@@ -150,7 +150,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
-        self.assertEqual(info['missing-chunks'], 0)
+        self.assertEqual(info['missing_chunks'], 0)
 
     def test_update_after_container_deletion(self):
         backend = AccountBackend({}, self.conn)
@@ -170,7 +170,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 3)
         self.assertEqual(info['bytes'], 30)
-        self.assertEqual(info['missing-chunks'], 5)
+        self.assertEqual(info['missing_chunks'], 5)
 
         # Container is flushed, but the event is deferred
         flush_timestamp = Timestamp(time()).normal
@@ -189,7 +189,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
         self.assertEqual(info['bytes'], 0)
-        self.assertEqual(info['missing-chunks'], 0)
+        self.assertEqual(info['missing_chunks'], 0)
 
     def test_delete_container(self):
         backend = AccountBackend({}, self.conn)
@@ -495,17 +495,17 @@ class TestAccountBackend(BaseTestCase):
         # change values
         self.conn.hset(account_key, 'bytes', 1)
         self.conn.hset(account_key, 'objects', 2)
-        self.conn.hset(account_key, 'missing-chunks', 3)
+        self.conn.hset(account_key, 'missing_chunks', 3)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '1')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '2')
-        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'), '3')
+        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'), '3')
 
         backend.refresh_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'),
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
-        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'),
+        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'),
                          str(total_missing_chunks))
 
     def test_update_container_wrong_timestamp_format(self):
@@ -604,12 +604,12 @@ class TestAccountBackend(BaseTestCase):
                          str(total_bytes))
         self.assertEqual(self.conn.hget(account_key, 'objects'),
                          str(total_objects))
-        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'),
+        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'),
                          str(total_missing_chunks))
 
         backend.flush_account(account_id)
         self.assertEqual(self.conn.hget(account_key, 'bytes'), '0')
         self.assertEqual(self.conn.hget(account_key, 'objects'), '0')
-        self.assertEqual(self.conn.hget(account_key, 'missing-chunks'), '0')
+        self.assertEqual(self.conn.hget(account_key, 'missing_chunks'), '0')
         self.assertEqual(self.conn.zcard("containers:%s" % account_id), 0)
         self.assertEqual(self.conn.exists("container:test:*"), 0)

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -422,6 +422,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.assertEqual('10', objects)
         usage = meta['system']['sys.m2.usage']
         self.assertEqual('40', usage)
+        damaged_objects = meta['system']['sys.m2.objects.damaged']
         missing_chunks = meta['system']['sys.m2.chunks.missing']
         self.beanstalk.wait_until_empty('oio', initial_delay=2)
         containers = self.api.container_list(self.account)
@@ -453,6 +454,8 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         meta = self.api.container_get_properties(self.account, name)
         self.assertEqual(objects, meta['system']['sys.m2.objects'])
         self.assertEqual(usage, meta['system']['sys.m2.usage'])
+        self.assertEqual(damaged_objects,
+                         meta['system']['sys.m2.objects.damaged'])
         self.assertEqual(missing_chunks,
                          meta['system']['sys.m2.chunks.missing'])
         containers = self.api.container_list(self.account)

--- a/tests/functional/cli/account/test_account.py
+++ b/tests/functional/cli/account/test_account.py
@@ -21,7 +21,7 @@ from testtools.matchers import Equals
 
 HEADERS = ['Name', 'Created']
 ACCOUNT_FIELDS = ['bytes', 'containers', 'ctime', 'account', 'metadata',
-                  'objects', 'missing_chunks']
+                  'objects', 'damaged_objects', 'missing_chunks']
 
 
 class AccountTest(CliTestCase):
@@ -47,6 +47,7 @@ class AccountTest(CliTestCase):
         self.assertThat(data['bytes'], Equals(0))
         self.assertThat(data['containers'], Equals(0))
         self.assertThat(data['objects'], Equals(0))
+        self.assertThat(data['damaged_objects'], Equals(0))
         self.assertThat(data['missing_chunks'], Equals(0))
         self.assertThat(data['metadata']['test'], Equals('1'))
         output = self.openio('account delete ' + self.NAME)
@@ -59,6 +60,7 @@ class AccountTest(CliTestCase):
         regex = r"|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
+        self.assertIsNotNone(re.match(regex % ("damaged_objects", "0"), output))
         self.assertIsNotNone(re.match(regex % ("missing_chunks", "0"), output))
 
     def test_account_refresh(self):
@@ -71,6 +73,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['damaged_objects'], 0)
         self.assertEqual(data['missing_chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
@@ -84,6 +87,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['damaged_objects'], 0)
         self.assertEqual(data['missing_chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
@@ -98,6 +102,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
+        self.assertEqual(data['damaged_objects'], 0)
         self.assertEqual(data['missing_chunks'], 0)
         self.openio('container delete ' + self.NAME)
         self.openio('account delete ' + self.NAME)

--- a/tests/functional/cli/account/test_account.py
+++ b/tests/functional/cli/account/test_account.py
@@ -60,7 +60,8 @@ class AccountTest(CliTestCase):
         regex = r"|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
-        self.assertIsNotNone(re.match(regex % ("damaged_objects", "0"), output))
+        self.assertIsNotNone(re.match(regex % ("damaged_objects", "0"),
+                                      output))
         self.assertIsNotNone(re.match(regex % ("missing_chunks", "0"), output))
 
     def test_account_refresh(self):

--- a/tests/functional/cli/account/test_account.py
+++ b/tests/functional/cli/account/test_account.py
@@ -21,7 +21,7 @@ from testtools.matchers import Equals
 
 HEADERS = ['Name', 'Created']
 ACCOUNT_FIELDS = ['bytes', 'containers', 'ctime', 'account', 'metadata',
-                  'objects', 'missing-chunks']
+                  'objects', 'missing_chunks']
 
 
 class AccountTest(CliTestCase):
@@ -47,7 +47,7 @@ class AccountTest(CliTestCase):
         self.assertThat(data['bytes'], Equals(0))
         self.assertThat(data['containers'], Equals(0))
         self.assertThat(data['objects'], Equals(0))
-        self.assertThat(data['missing-chunks'], Equals(0))
+        self.assertThat(data['missing_chunks'], Equals(0))
         self.assertThat(data['metadata']['test'], Equals('1'))
         output = self.openio('account delete ' + self.NAME)
         self.assertOutput('', output)
@@ -59,7 +59,7 @@ class AccountTest(CliTestCase):
         regex = r"|\s*%s\s*|\s*%s\s*|"
         self.assertIsNotNone(re.match(regex % ("bytes", "0B"), output))
         self.assertIsNotNone(re.match(regex % ("objects", "0"), output))
-        self.assertIsNotNone(re.match(regex % ("missing-chunks", "0"), output))
+        self.assertIsNotNone(re.match(regex % ("missing_chunks", "0"), output))
 
     def test_account_refresh(self):
         self.openio('account create ' + self.NAME)
@@ -71,7 +71,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
-        self.assertEqual(data['missing-chunks'], 0)
+        self.assertEqual(data['missing_chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
     def test_account_refresh_all(self):
@@ -84,7 +84,7 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
-        self.assertEqual(data['missing-chunks'], 0)
+        self.assertEqual(data['missing_chunks'], 0)
         self.openio('account delete ' + self.NAME)
 
     def test_account_flush(self):
@@ -98,6 +98,6 @@ class AccountTest(CliTestCase):
         self.assertEqual(data['bytes'], 0)
         self.assertEqual(data['containers'], 0)
         self.assertEqual(data['objects'], 0)
-        self.assertEqual(data['missing-chunks'], 0)
+        self.assertEqual(data['missing_chunks'], 0)
         self.openio('container delete ' + self.NAME)
         self.openio('account delete ' + self.NAME)

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -27,7 +27,8 @@ OBJ_HEADERS = ['Name', 'Size', 'Hash']
 CONTAINER_LIST_HEADERS = ['Name', 'Bytes', 'Count']
 CONTAINER_FIELDS = ['account', 'base_name', 'bytes_usage', 'quota',
                     'container', 'ctime', 'storage_policy', 'objects',
-                    'max_versions', 'status', 'missing_chunks']
+                    'max_versions', 'status', 'damaged_objects',
+                    'missing_chunks']
 OBJ_FIELDS = ['account', 'container', 'ctime', 'hash', 'id', 'mime-type',
               'mtime', 'object', 'policy', 'size', 'version']
 

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -434,6 +434,35 @@ class TestMeta2Containers(BaseTestCase):
                             headers=headers, data=json.dumps(chunks))
         self.assertEqual(204, resp.status)
 
+    def _append_content(self, name, missing_chunks=0):
+        headers = {'X-oio-action-mode': 'autocreate'}
+        params = self.param_content(self.ref, name)
+        resp = self.request('POST', self.url_content('prepare'), params=params,
+                            headers=headers, data=json.dumps({'size': '1024'}))
+        self.assertEqual(resp.status, 200)
+        chunks = self.json_loads(resp.data)
+        for _ in range(0, missing_chunks):
+            chunks.pop()
+
+        params['append'] = 1
+        stgpol = resp.getheader('x-oio-content-meta-policy')
+        chunk_method = resp.getheader('x-oio-content-meta-chunk-method')
+        headers = {'x-oio-action-mode': 'autocreate',
+                   'x-oio-content-meta-length': '1024',
+                   'x-oio-content-meta-policy': stgpol,
+                   'x-oio-content-meta-chunk-method': chunk_method,
+                   'x-oio-content-meta-id': random_id(32)}
+        resp = self.request('POST', self.url_content('create'), params=params,
+                            headers=headers, data=json.dumps(chunks))
+        self.assertEqual(204, resp.status)
+
+    def _truncate_content(self, name):
+        params = self.param_content(self.ref, name)
+        params['size'] = 1048576
+        resp = self.request('POST', self.url_content('truncate'),
+                            params=params)
+        self.assertEqual(204, resp.status)
+
     def test_purge(self):
         params = self.param_ref(self.ref)
 
@@ -600,6 +629,44 @@ class TestMeta2Containers(BaseTestCase):
 
         self._delete_content('content4')
         self._check_missing_chunks(2, 3)
+
+    def test_missing_chunks_append_truncate(self):
+        stg_policy = self.conscience.info().get(
+            'options', dict()).get('storage_policy')
+        if stg_policy != 'THREECOPIES' and stg_policy != 'EC':
+            self.skipTest('The storage policy must be THREECOPIES or EC')
+
+        self._create_content('content0', missing_chunks=0)
+        self._check_missing_chunks(0, 0)
+        self._append_content('content0', missing_chunks=0)
+        self._check_missing_chunks(0, 0)
+
+        self._create_content('content1', missing_chunks=0)
+        self._check_missing_chunks(0, 0)
+        self._append_content('content1', missing_chunks=1)
+        self._check_missing_chunks(1, 1)
+
+        self._create_content('content2', missing_chunks=1)
+        self._check_missing_chunks(2, 2)
+        self._append_content('content2', missing_chunks=0)
+        self._check_missing_chunks(2, 2)
+
+        self._create_content('content3', missing_chunks=1)
+        self._check_missing_chunks(3, 3)
+        self._append_content('content3', missing_chunks=1)
+        self._check_missing_chunks(3, 4)
+
+        self._truncate_content('content0')
+        self._check_missing_chunks(3, 4)
+
+        self._truncate_content('content1')
+        self._check_missing_chunks(2, 3)
+
+        self._truncate_content('content2')
+        self._check_missing_chunks(2, 3)
+
+        self._truncate_content('content3')
+        self._check_missing_chunks(2, 2)
 
 
 class TestMeta2Contents(BaseTestCase):

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -749,7 +749,7 @@ on_die=cry
 template_gridinit_blob_rebuilder = """
 [Service.${NS}-${SRVTYPE}-${SRVNUM}]
 group=${NS},localhost,${SRVTYPE}
-command=oio-blob-rebuilder --workers 10 --beanstalkd ${QUEUE_URL} --log-facility local0 --log-syslog-prefix OIO,OPENIO,${SRVTYPE},${SRVNUM} ${NS}
+command=oio-blob-rebuilder --workers 10 --allow-same-rawx --beanstalkd ${QUEUE_URL} --log-facility local0 --log-syslog-prefix OIO,OPENIO,${SRVTYPE},${SRVNUM} ${NS}
 enabled=true
 start_at_boot=false
 on_die=cry

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -746,6 +746,15 @@ start_at_boot=false
 on_die=cry
 """
 
+template_gridinit_blob_rebuilder = """
+[Service.${NS}-${SRVTYPE}-${SRVNUM}]
+group=${NS},localhost,${SRVTYPE}
+command=oio-blob-rebuilder --workers 10 --beanstalkd ${QUEUE_URL} --log-facility local0 --log-syslog-prefix OIO,OPENIO,${SRVTYPE},${SRVNUM} ${NS}
+enabled=true
+start_at_boot=false
+on_die=cry
+"""
+
 template_local_header = """
 [default]
 """
@@ -784,7 +793,6 @@ enabled=true
 start_at_boot=false
 command=oio-event-agent ${CFGDIR}/${NS}-${SRVTYPE}-${SRVNUM}.conf
 env.PYTHONPATH=${CODEDIR}/@LD_LIBDIR@/python2.7/site-packages
-
 """
 
 template_event_agent = """
@@ -1613,6 +1621,16 @@ def generate(options):
             f.write(tpl.safe_substitute(env))
         with open(CFGDIR + '/event-handlers-'+str(num)+'.conf', 'w+') as f:
             tpl = Template(template_event_agent_handlers)
+            f.write(tpl.safe_substitute(env))
+
+    # blob-rebuilder configuration -> one per beanstalkd
+    for num, host, port in all_beanstalkd:
+        bnurl = 'beanstalk://{0}:{1}'.format(host, port)
+        env = subenv({'SRVTYPE': 'blob-rebuilder', 'SRVNUM': num,
+                      'QUEUE_URL': bnurl})
+        add_service(env)
+        with open(gridinit(env), 'a+') as f:
+            tpl = Template(template_gridinit_blob_rebuilder)
             f.write(tpl.safe_substitute(env))
 
     # webhook test server


### PR DESCRIPTION
##### SUMMARY

* Save the number of damaged objects in the meta2 database
* Use the event (`container.state`) to update the account
* Increase the counter for each chunk not uploaded
* Decrease the counter for each deleted object with missing chunks
* Decrease the counter for each rebuilt chunk (chunk not uploaded)
* Recompute the counter of damaged objects

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

* Python API
* `account`
* `proxy`
* `meta2`

##### SDS VERSION

```
openio 4.4.0.0b1.dev36
```