### PR TITLE
Python API: forward timeouts, compute a deadline

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -45,27 +45,27 @@ class AccountClient(HttpApi):
         self._refresh_delay = refresh_delay if not self.endpoint else -1.0
         self._last_refresh = 0.0
 
-    def _get_account_addr(self):
+    def _get_account_addr(self, **kwargs):
         """Fetch IP and port of an account service from Conscience."""
-        acct_instance = self.cs.next_instance('account')
+        acct_instance = self.cs.next_instance('account', **kwargs)
         acct_addr = acct_instance.get('addr')
         return acct_addr
 
-    def _refresh_endpoint(self, now=None):
+    def _refresh_endpoint(self, now=None, **kwargs):
         """Refresh account service endpoint."""
-        addr = self._get_account_addr()
+        addr = self._get_account_addr(**kwargs)
         self.endpoint = '/'. join(("http:/", addr, "v1.0/account"))
         if not now:
             now = time.time()
         self._last_refresh = now
 
-    def _maybe_refresh_endpoint(self):
+    def _maybe_refresh_endpoint(self, **kwargs):
         """Refresh account service endpoint if delay has been reached."""
         if self._refresh_delay >= 0.0 or not self.endpoint:
             now = time.time()
             if now - self._last_refresh > self._refresh_delay:
                 try:
-                    self._refresh_endpoint(now)
+                    self._refresh_endpoint(now, **kwargs)
                 except OioNetworkException as exc:
                     if not self.endpoint:
                         # Cannot use the previous one
@@ -80,7 +80,7 @@ class AccountClient(HttpApi):
 
     def account_request(self, account, method, action, params=None, **kwargs):
         """Make a request to the account service."""
-        self._maybe_refresh_endpoint()
+        self._maybe_refresh_endpoint(**kwargs)
         if not params:
             params = dict()
         if account:
@@ -94,7 +94,7 @@ class AccountClient(HttpApi):
                 self.logger.info(
                     "Refreshing account endpoint after error %s", exc)
                 try:
-                    self._refresh_endpoint()
+                    self._refresh_endpoint(**kwargs)
                 except Exception as exc:
                     self.logger.warn("%s", exc)
             raise exc_info[0], exc_info[1], exc_info[2]

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -29,7 +29,8 @@ from oio.api.replication import ReplicatedWriteHandler
 from oio.api.backblaze_http import BackblazeUtilsException, BackblazeUtils
 from oio.api.backblaze import BackblazeWriteHandler, \
     BackblazeChunkDownloadHandler
-from oio.common.utils import cid_from_name, GeneratorIO, monotonic_time
+from oio.common.utils import cid_from_name, GeneratorIO, monotonic_time, \
+    timeout_to_deadline
 from oio.common.easy_value import float_value, true_value
 from oio.common.logger import get_logger
 from oio.common.decorators import ensure_headers, ensure_request_id
@@ -42,16 +43,20 @@ from oio.common.storage_functions import _sort_chunks, fetch_stream, \
 from oio.common.fullpath import encode_fullpath
 
 
-# TODO(FVE): decorate more methods
 def patch_kwargs(fnc):
     """
     Patch keyword arguments with the ones passed to the class' constructor.
+    Compute a deadline if a timeout is provided and there is no deadline
+    already.
     """
     @wraps(fnc)
     def _patch_kwargs(self, *args, **kwargs):
         for argk, argv in self._global_kwargs.items():
             if argk not in kwargs:
                 kwargs[argk] = argv
+        to = kwargs.get('read_timeout')
+        if to and 'deadline' not in kwargs:
+            kwargs['deadline'] = timeout_to_deadline(to)
         return fnc(self, *args, **kwargs)
     return _patch_kwargs
 
@@ -108,6 +113,7 @@ class ObjectStorageApi(object):
         for key in self.__class__.EXTRA_KEYWORDS:
             if key in kwargs:
                 self._global_kwargs[key] = kwargs[key]
+        self.logger.debug("Global API parameters: %s", self._global_kwargs)
 
         from oio.account.client import AccountClient
         from oio.container.client import ContainerClient
@@ -152,6 +158,7 @@ class ObjectStorageApi(object):
                 logger=self.logger)
         return self._proxy_client
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_create(self, account, **kwargs):
@@ -165,6 +172,7 @@ class ObjectStorageApi(object):
         return self.account.account_create(account, **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_delete(self, account, **kwargs):
@@ -177,6 +185,7 @@ class ObjectStorageApi(object):
         self.account.account_delete(account, **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_show(self, account, **kwargs):
@@ -185,6 +194,7 @@ class ObjectStorageApi(object):
         """
         return self.account.account_show(account, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_list(self, **kwargs):
@@ -203,17 +213,20 @@ class ObjectStorageApi(object):
         self.account.account_update(account, metadata, to_delete, **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_set_properties(self, account, properties, **kwargs):
         self.account.account_update(account, properties, None, **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_del_properties(self, account, properties, **kwargs):
         self.account.account_update(account, None, properties, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_create(self, account, container, properties=None,
@@ -234,6 +247,7 @@ class ObjectStorageApi(object):
             account, container, properties=properties, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_touch(self, account, container, **kwargs):
@@ -247,6 +261,7 @@ class ObjectStorageApi(object):
         """
         self.container.container_touch(account, container, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_create_many(self, account, containers, properties=None,
@@ -265,6 +280,7 @@ class ObjectStorageApi(object):
             account, containers, properties=properties, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_delete(self, account, container, **kwargs):
@@ -279,6 +295,7 @@ class ObjectStorageApi(object):
         self.container.container_delete(account, container, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_flush(self, account, container, fast=False, **kwargs):
@@ -314,6 +331,7 @@ class ObjectStorageApi(object):
                     'None of the %d objects could be deleted' % len(deleted))
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_list(self, account, limit=None, marker=None,
@@ -346,6 +364,7 @@ class ObjectStorageApi(object):
         return resp["listing"]
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_show(self, account, container, **kwargs):
@@ -362,6 +381,7 @@ class ObjectStorageApi(object):
         return self.container.container_show(account, container, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_snapshot(self, account, container, dst_account,
@@ -423,6 +443,7 @@ class ObjectStorageApi(object):
             self.container.container_enable(account, container, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_get_properties(self, account, container, properties=None,
@@ -444,6 +465,7 @@ class ObjectStorageApi(object):
                                                        **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_set_properties(self, account, container, properties=None,
@@ -466,6 +488,7 @@ class ObjectStorageApi(object):
             clear=clear, **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_del_properties(self, account, container, properties,
@@ -493,6 +516,9 @@ class ObjectStorageApi(object):
                                **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
+    @ensure_headers
+    @ensure_request_id
     def container_purge(self, account, container, maxvers=None, **kwargs):
         if maxvers is None:
             props = self.container_get_properties(account, container, **kwargs)
@@ -653,6 +679,7 @@ class ObjectStorageApi(object):
                     properties=properties, policy=policy,
                     key_file=key_file, append=append, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_touch(self, account, container, obj,
@@ -670,6 +697,7 @@ class ObjectStorageApi(object):
         self.container.content_touch(account, container, obj,
                                      version=version, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_drain(self, account, container, obj,
@@ -687,6 +715,7 @@ class ObjectStorageApi(object):
                                      version=version, **kwargs)
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_delete(self, account, container, obj,
@@ -707,6 +736,7 @@ class ObjectStorageApi(object):
         return self.container.content_delete(account, container, obj,
                                              version=version, **kwargs)
 
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_delete_many(self, account, container, objs, **kwargs):
@@ -722,6 +752,7 @@ class ObjectStorageApi(object):
             account, container, objs, **kwargs)
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_truncate(self, account, container, obj,
@@ -769,6 +800,7 @@ class ObjectStorageApi(object):
                                                **kwargs)
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_list(self, account, container, limit=None, marker=None,
@@ -812,6 +844,7 @@ class ObjectStorageApi(object):
         return resp_body
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_locate(self, account, container, obj,
@@ -994,6 +1027,7 @@ class ObjectStorageApi(object):
         return meta, stream
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_get_properties(self, account, container, obj, **kwargs):
@@ -1025,6 +1059,7 @@ class ObjectStorageApi(object):
             account, container, obj, **kwargs)
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_show(self, account, container, obj, version=None, **kwargs):
@@ -1056,6 +1091,7 @@ class ObjectStorageApi(object):
                 account, container, obj, metadata, version=version, **kwargs)
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_set_properties(self, account, container, obj, properties,
@@ -1073,6 +1109,7 @@ class ObjectStorageApi(object):
             version=version, **kwargs)
 
     @handle_object_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def object_del_properties(self, account, container, obj, properties,
@@ -1237,6 +1274,7 @@ class ObjectStorageApi(object):
             current_offset += chunk_size
 
     @handle_container_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def container_refresh(self, account, container, attempts=3, **kwargs):
@@ -1259,6 +1297,7 @@ class ObjectStorageApi(object):
                                           **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_refresh(self, account=None, **kwargs):
@@ -1308,6 +1347,7 @@ class ObjectStorageApi(object):
         return self.account_refresh(None, **kwargs)
 
     @handle_account_not_found
+    @patch_kwargs
     @ensure_headers
     @ensure_request_id
     def account_flush(self, account, **kwargs):

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -339,3 +339,10 @@ def deadline_to_timeout(deadline, check=False):
     if check and dl_to <= 0.0:
         raise DeadlineReached()
     return dl_to
+
+
+def timeout_to_deadline(timeout, now=None):
+    """Convert a timeout (`float` seconds) to a deadline (`float` seconds)."""
+    if now is None:
+        now = monotonic_time()
+    return now + timeout

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,27 +25,27 @@ class LbClient(ProxyClient):
         super(LbClient, self).__init__(
             conf, request_prefix="/lb", **kwargs)
 
-    def next_instances(self, pool, **kwargs):
+    def next_instances(self, pool, size=None, **kwargs):
         """
         Get the next service instances from the specified pool.
 
         :keyword size: number of services to get
         :type size: `int`
-        :keyword slot: comma-separated list of slots to poll
-        :type slot: `str`
         """
         params = {'type': pool}
-        params.update(kwargs)
-        resp, body = self._request('GET', '/choose', params=params)
+        if size is not None:
+            params['size'] = size
+        resp, body = self._request('GET', '/choose', params=params, **kwargs)
         if resp.status == 200:
             return body
         else:
             raise OioException(
                 'ERROR while getting next instance %s' % pool)
 
-    def next_instance(self, pool):
+    def next_instance(self, pool, **kwargs):
         """Get the next service instance from the specified pool"""
-        return self.next_instances(pool, size=1)[0]
+        kwargs.pop('size', None)
+        return self.next_instances(pool, size=1, **kwargs)[0]
 
     def poll(self, pool, **kwargs):
         """
@@ -106,9 +106,9 @@ class ConscienceClient(ProxyClient):
         """
         return self.lb.next_instance(pool, **kwargs)
 
-    def next_instance(self, pool):
+    def next_instance(self, pool, **kwargs):
         """Get the next service instance from the specified pool"""
-        return self.lb.next_instance(pool)
+        return self.lb.next_instance(pool, **kwargs)
 
     def poll(self, pool, **kwargs):
         """

--- a/tests/unit/api/test_objectstorage.py
+++ b/tests/unit/api/test_objectstorage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -91,7 +91,8 @@ class ObjectStorageTest(unittest.TestCase):
                   "marker": marker, "end_marker": end_marker, "limit": limit}
         uri = "http://%s/v1.0/account/containers" % fake_endpoint
         self.api.account._direct_request.assert_called_once_with(
-            'GET', uri, params=params, headers=self.headers)
+            'GET', uri, params=params, headers=self.headers,
+            autocreate=True)
         self.assertEqual(len(containers), 1)
 
     def test_object_list(self):
@@ -118,7 +119,8 @@ class ObjectStorageTest(unittest.TestCase):
                   'end_marker': end_marker,
                   'properties': False}
         api.container._direct_request.assert_called_once_with(
-            'GET', uri, params=params, headers=self.headers)
+            'GET', uri, params=params, headers=self.headers,
+            autocreate=True)
         self.assertEqual(len(listing['objects']), 2)
 
     def test_container_show(self):
@@ -134,7 +136,8 @@ class ObjectStorageTest(unittest.TestCase):
         uri = "%s/container/show" % self.uri_base
         params = {'acct': self.account, 'ref': name}
         api.container._direct_request.assert_called_once_with(
-            'GET', uri, params=params, headers=self.headers)
+            'GET', uri, params=params, headers=self.headers,
+            autocreate=True)
         self.assertEqual(info, {})
 
     def test_container_show_not_found(self):
@@ -161,7 +164,7 @@ class ObjectStorageTest(unittest.TestCase):
         data = json.dumps({'properties': {}, 'system': {}})
         api.container._direct_request.assert_called_once_with(
             'POST', uri, params=params, data=data,
-            headers=self.headers)
+            headers=self.headers, autocreate=True)
 
     def test_container_create_exist(self):
         api = self.api
@@ -186,7 +189,8 @@ class ObjectStorageTest(unittest.TestCase):
         uri = "%s/container/destroy" % self.uri_base
         params = {'acct': self.account, 'ref': name}
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, params=params, headers=self.headers)
+            'POST', uri, params=params, headers=self.headers,
+            autocreate=True)
 
     def test_container_delete_not_empty(self):
         api = self.api
@@ -216,7 +220,8 @@ class ObjectStorageTest(unittest.TestCase):
         uri = "%s/container/set_properties" % self.uri_base
         params = {'acct': self.account, 'ref': name}
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, data=data, params=params, headers=self.headers)
+            'POST', uri, data=data, params=params, headers=self.headers,
+            autocreate=True)
 
     def test_object_show(self):
         api = self.api
@@ -238,7 +243,8 @@ class ObjectStorageTest(unittest.TestCase):
         params = {'acct': self.account, 'ref': self.container,
                   'path': name}
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, params=params, data=None, headers=self.headers)
+            'POST', uri, params=params, data=None, headers=self.headers,
+            autocreate=True)
         self.assertIsNotNone(obj)
 
     def test_object_create_no_data(self):
@@ -342,7 +348,8 @@ class ObjectStorageTest(unittest.TestCase):
         params = {'acct': self.account, 'ref': self.container,
                   'path': name}
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, data=data, params=params, headers=self.headers)
+            'POST', uri, data=data, params=params, headers=self.headers,
+            autocreate=True)
 
     def test_object_del_properties(self):
         resp = FakeApiResponse()
@@ -355,7 +362,7 @@ class ObjectStorageTest(unittest.TestCase):
                   'path': 'a', 'version': '17'}
         self.api.container._direct_request.assert_called_once_with(
             'POST', uri, data=json.dumps(['a']), params=params,
-            headers=self.headers)
+            headers=self.headers, autocreate=True)
 
     def test_object_delete(self):
         api = self.api
@@ -373,7 +380,8 @@ class ObjectStorageTest(unittest.TestCase):
         params = {'acct': self.account, 'ref': self.container,
                   'path': name}
         api.container._direct_request.assert_called_once_with(
-            'POST', uri, params=params, headers=self.headers)
+            'POST', uri, params=params, headers=self.headers,
+            autocreate=True)
 
     def test_object_delete_not_found(self):
         api = self.api
@@ -392,7 +400,8 @@ class ObjectStorageTest(unittest.TestCase):
         params = {'acct': self.account, 'ref': self.container,
                   'path': 'obj', 'version': '31'}
         self.api.container._direct_request.assert_called_once_with(
-            'POST', uri, params=params, headers=self.headers)
+            'POST', uri, params=params, headers=self.headers,
+            autocreate=True)
 
     def test_sort_chunks(self):
         raw_chunks = [


### PR DESCRIPTION
##### SUMMARY
The `patch_kwargs` functionality was used only on a few `ObjectStorageApi` methods, resulting in the `read_timeout` not being applied on all requeststo oio-proxy. This is now fixed.

Also, if a timeout is provided, a deadline is now computed for internal usage, and a timeout is computed accordingly for each subrequest.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.2.8.dev34
```


##### ADDITIONAL INFORMATION
This PR should fix an issue with oioswift, where `sds_read_timeout` was not applied on all requests.