### PR TITLE
core: Explicit the value of public enums

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -232,10 +232,10 @@ extern time_hook_f oio_time_real;
 
 enum oio_header_case_e
 {
-	OIO_HDRCASE_NONE,
-	OIO_HDRCASE_LOW,
-	OIO_HDRCASE_1CAP,
-	OIO_HDRCASE_RANDOM,
+	OIO_HDRCASE_NONE = 0,
+	OIO_HDRCASE_LOW = 1,
+	OIO_HDRCASE_1CAP = 2,
+	OIO_HDRCASE_RANDOM = 3,
 };
 
 enum oio_header_case_e oio_header_case;

--- a/core/oio_sds.h
+++ b/core/oio_sds.h
@@ -47,23 +47,23 @@ enum oio_sds_config_e
 	OIOSDS_CFG_TIMEOUT_PROXY = 1,
 
 	/** expects an integer as a number of seconds */
-	OIOSDS_CFG_TIMEOUT_RAWX,
+	OIOSDS_CFG_TIMEOUT_RAWX = 2,
 
 	/** expects an integer used for its boolean value */
-	OIOSDS_CFG_FLAG_SYNCATDOWNLOAD,
+	OIOSDS_CFG_FLAG_SYNCATDOWNLOAD = 3,
 
 	/** expects an integer used for its boolean value */
-	OIOSDS_CFG_FLAG_ADMIN,
+	OIOSDS_CFG_FLAG_ADMIN = 4,
 
 	/** Disable the shuffling of chunks before reading,
 	 * and instead sort them by score.
 	 * Expects an integer used for its boolean value. */
-	OIOSDS_CFG_FLAG_NO_SHUFFLE,
+	OIOSDS_CFG_FLAG_NO_SHUFFLE = 5,
 
 	/** Defines the chunk size in bytes.
 	 *  Expects an <int64_t>.
 	 *  If 0, uses the default size. */
-	OIOSDS_CFG_FLAG_CHUNKSIZE,
+	OIOSDS_CFG_FLAG_CHUNKSIZE = 6,
 };
 
 /**
@@ -237,8 +237,8 @@ typedef int (*oio_sds_dl_hook_f) (void*, const unsigned char*, size_t);
 enum oio_sds_dl_dst_type_e
 {
 	OIO_DL_DST_HOOK_SEQUENTIAL = 1,
-	OIO_DL_DST_BUFFER,
-	OIO_DL_DST_FILE,
+	OIO_DL_DST_BUFFER = 2,
+	OIO_DL_DST_FILE = 3,
 };
 
 struct oio_sds_dl_dst_s

--- a/core/oiolog.h
+++ b/core/oiolog.h
@@ -124,10 +124,10 @@ guint16 oio_log_thread_id(GThread *thread);
 guint16 oio_log_current_thread_id(void);
 
 enum oio_log_level_e {
-	OIO_LOG_ERROR,
-	OIO_LOG_WARNING,
-	OIO_LOG_INFO,
-	OIO_LOG_DEBUG,
+	OIO_LOG_ERROR = 0,
+	OIO_LOG_WARNING = 1,
+	OIO_LOG_INFO = 2,
+	OIO_LOG_DEBUG = 3,
 };
 
 typedef void (*oio_log_handler_f) (enum oio_log_level_e lvl, const char *fmt, ...)

--- a/core/oiourl.h
+++ b/core/oiourl.h
@@ -37,19 +37,19 @@ extern "C" {
 enum oio_url_field_e
 {
 	OIOURL_NS=1,
-	OIOURL_ACCOUNT,
-	OIOURL_USER,
-	OIOURL_TYPE,
-	OIOURL_PATH,
+	OIOURL_ACCOUNT = 2,
+	OIOURL_USER = 3,
+	OIOURL_TYPE = 4,
+	OIOURL_PATH = 5,
 
-	OIOURL_VERSION,
+	OIOURL_VERSION = 6,
 
-	OIOURL_WHOLE, /* read-only */
+	OIOURL_WHOLE = 7,  /* read-only */
 
-	OIOURL_HEXID,     /* read-write */
-	OIOURL_CONTENTID, /* read-write */
+	OIOURL_HEXID = 8,  /* read-write */
+	OIOURL_CONTENTID = 9,  /* read-write */
 
-	OIOURL_FULLPATH
+	OIOURL_FULLPATH = 10
 };
 
 

--- a/core/oiovar.h
+++ b/core/oiovar.h
@@ -22,8 +22,8 @@ License along with this library.
 #include <core/oiocfg.h>
 
 enum oio_var_kind_e {
-	OIO_VARKIND_time,
-	OIO_VARKIND_size,
+	OIO_VARKIND_time = 0,
+	OIO_VARKIND_size = 1,
 };
 
 /**


### PR DESCRIPTION
##### SUMMARY
Ensure each publicly exported `enum` field has an explicit value. It helps avoiding ABI breaks.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`core`

##### SDS VERSION
`4.2.8.dev35`

##### ADDITIONAL INFORMATION
TODO(jfsmig): We should add a test that forbid the usage of enums without a value.