### PR TITLE
oio-blob-converter: restore fullpath if grid.content.path or  oio:HASH are missing

### DIFF
--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -374,7 +374,9 @@ class BlobConverter(object):
 
     def is_fullpath_error(self, err):
         if (isinstance(err, MissingAttribute) and
-                err.attribute.startswith(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX)):
+            (err.attribute.startswith(CHUNK_XATTR_CONTENT_FULLPATH_PREFIX)
+             or err.attribute == chunk_xattr_keys['content_path']
+             or err.attribute.startswith(XATTR_OLD_FULLPATH))):
             return True
         elif isinstance(err, FaultyChunk):
             return any(self.is_fullpath_error(x) for x in err.args)

--- a/tests/functional/blob/__init__.py
+++ b/tests/functional/blob/__init__.py
@@ -67,6 +67,14 @@ def remove_fullpath_xattr(chunk_path):
             print 'Failed to remove fullpath: %s' % err
 
 
+def remove_xattr(chunk_path, key):
+    with open(chunk_path, 'w') as fd:
+        try:
+            xattr.removexattr(fd, key)
+        except IOError as err:
+            print 'Failed to remove fullpath: %s' % err
+
+
 def random_buffer(dictionary, n):
     slot = 512
     pattern = ''.join(random.choice(dictionary) for _ in range(slot))

--- a/tests/functional/blob/test_converter.py
+++ b/tests/functional/blob/test_converter.py
@@ -30,7 +30,8 @@ from oio.blob.utils import read_chunk_metadata
 from oio.crawler.integrity import Checker, Target
 from oio.rdir.client import RdirClient
 from tests.utils import BaseTestCase, random_str
-from tests.functional.blob import convert_to_old_chunk, remove_fullpath_xattr
+from tests.functional.blob import convert_to_old_chunk, \
+    remove_fullpath_xattr, remove_xattr
 
 
 class TestBlobConverter(BaseTestCase):
@@ -531,6 +532,37 @@ class TestBlobConverter(BaseTestCase):
                 as recover:
             self._convert_and_check(chunk_volume, path, {}, expected_errors=1)
             recover.assert_not_called()
+
+    def test_recover_missing_old_fullpath(self):
+        for c in self.chunks:
+            convert_to_old_chunk(
+                self._chunk_path(c), self.account, self.container, self.path,
+                self.version, self.content_id)
+
+        victim = random.choice(self.chunks)
+        self._test_converter_single_chunk(victim)
+
+    def test_recover_missing_content_path(self):
+        for c in self.chunks:
+            convert_to_old_chunk(
+                self._chunk_path(c), self.account, self.container, self.path,
+                self.version, self.content_id, add_old_fullpath=True)
+
+        victim = random.choice(self.chunks)
+        path = self._chunk_path(victim)
+        remove_xattr(path, chunk_xattr_keys['content_path'])
+        self._test_converter_single_chunk(victim)
+
+    def test_recover_missing_old_fullpath_and_content_path(self):
+        for c in self.chunks:
+            convert_to_old_chunk(
+                self._chunk_path(c), self.account, self.container, self.path,
+                self.version, self.content_id)
+
+        victim = random.choice(self.chunks)
+        path = self._chunk_path(victim)
+        remove_xattr(path, chunk_xattr_keys['content_path'])
+        self._test_converter_single_chunk(victim)
 
     def test_recover_missing_fullpath(self):
         """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Recreate fullpath  when xattrs 'grid.contant.path' and 'oio:$HASH' are also missing
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
oio-blob-converter

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.2.8.dev36
```
