### PR TITLE
Register proxy and beanstalkd into conscience

### DIFF
--- a/oio/conscience/checker/beanstalk.py
+++ b/oio/conscience/checker/beanstalk.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from oio.common import exceptions as exc
+from oio.event.beanstalk import Beanstalk, ConnectionError
+from oio.conscience.checker.base import BaseChecker
+
+
+class BeanstalkChecker(BaseChecker):
+    name = 'beanstalkd'
+
+    def configure(self):
+        for k in ('host', 'port'):
+            if k not in self.checker_conf:
+                raise exc.ConfigurationException(
+                    'Missing field "%s" in configuration' % k)
+        self.__beanstalk = None
+        self.host = self.checker_conf['host']
+        self.port = int(self.checker_conf['port'])
+
+    @property
+    def beanstalk(self):
+        if self.__beanstalk is None:
+            self.__beanstalk = Beanstalk(self.host, self.port)
+        return self.__beanstalk
+
+    def check(self):
+        result = False
+        try:
+            self.beanstalk.stats()
+            result = True
+        except ConnectionError as e:
+            self.logger.warn(
+                'ERROR connection lost to beanstalk (%s:%d) %s',
+                self.host, self.port, e)
+            self.__beanstalk = None
+        except Exception as e:
+            self.logger.warn('ERROR performing beanstalk check (%s:%s): %s',
+                             self.host, self.port, e)
+        finally:
+            return result

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -396,6 +396,7 @@ class Beanstalk(object):
         'peek-ready': parse_body,
         'reserve': parse_body,
         'reserve-with-timeout': parse_body,
+        'stats': parse_yaml,
         'stats-tube': parse_yaml
     })
     EXPECTED_OK = dict_merge({
@@ -411,6 +412,7 @@ class Beanstalk(object):
         'release': ['RELEASED'],
         'reserve': ['RESERVED'],
         'reserve-with-timeout': ['RESERVED'],
+        'stats': ['OK'],
         'stats-tube': ['OK'],
         'use': ['USING'],
         'watch': ['WATCHING'],
@@ -428,6 +430,7 @@ class Beanstalk(object):
         'reserve': ['DEADLINE_SOON', 'TIMED_OUT'],
         'reserve-with-timeout': ['DEADLINE_SOON', 'TIMED_OUT'],
         'release': ['BURIED', 'NOT_FOUND', 'OUT_OF_MEMORY'],
+        'stats': [],
         'stats-tube': ['NOT_FOUND'],
         'use': [],
         'watch': [],
@@ -605,6 +608,9 @@ class Beanstalk(object):
             time.sleep(poll_interval)
             job_id, _ = self.peek_ready()
         return job_id
+
+    def stats(self):
+        return self.execute_command('stats')
 
     def stats_tube(self, tube):
         return self.execute_command('stats-tube', tube)

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -390,6 +390,7 @@ def parse_body(connection, response, **kwargs):
 
 class Beanstalk(object):
     RESPONSE_CALLBACKS = dict_merge({
+        'list-tubes': parse_yaml,
         'peek': parse_body,
         'peek-buried': parse_body,
         'peek-delayed': parse_body,
@@ -402,6 +403,7 @@ class Beanstalk(object):
     EXPECTED_OK = dict_merge({
         'bury': ['BURIED'],
         'delete': ['DELETED'],
+        'list-tubes': ['OK'],
         'kick': ['KICKED'],
         'kick-job': ['KICKED'],
         'peek': ['FOUND'],
@@ -420,6 +422,7 @@ class Beanstalk(object):
     EXPECTED_ERR = dict_merge({
         'bury': ['NOT_FOUND', 'OUT_OF_MEMORY'],
         'delete': ['NOT_FOUND'],
+        'list-tubes': [],
         'kick': ['OUT_OF_MEMORY'],
         'kick-job': ['NOT_FOUND', 'OUT_OF_MEMORY'],
         'peek': ['NOT_FOUND'],
@@ -614,6 +617,9 @@ class Beanstalk(object):
 
     def stats_tube(self, tube):
         return self.execute_command('stats-tube', tube)
+
+    def tubes(self):
+        return self.execute_command('list-tubes')
 
     def close(self):
         if self._connection:

--- a/setup.cfg
+++ b/setup.cfg
@@ -152,6 +152,7 @@ oio.conscience.checker =
     asn1 = oio.conscience.checker.asn1:Asn1PingChecker
     http = oio.conscience.checker.http:HttpChecker
     tcp = oio.conscience.checker.tcp:TcpChecker
+    beanstalkd = oio.conscience.checker.beanstalk:BeanstalkChecker
 oio.conscience.stats =
     http = oio.conscience.stats.http:HttpStat
     rawx = oio.conscience.stats.rawx:RawxStat


### PR DESCRIPTION
##### SUMMARY
Register `proxy` and `beanstalkd` into `conscience`, it will allow us to launch commands on all cluster.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
conscience-agent

##### SDS VERSION
```
master
```
