### PR TITLE
blob-indexer: do not warn on pending or just deleted chunks

### DIFF
--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -16,6 +16,7 @@
 
 from oio.common.green import ratelimit, time
 
+import errno
 from datetime import datetime
 from random import random
 from string import hexdigits
@@ -27,7 +28,7 @@ from oio.common import exceptions as exc
 from oio.common.utils import paths_gen, request_id
 from oio.common.easy_value import int_value, true_value
 from oio.common.logger import get_logger
-from oio.common.constants import STRLEN_CHUNKID
+from oio.common.constants import STRLEN_CHUNKID, CHUNK_SUFFIX_PENDING
 from oio.blob.converter import BlobConverter
 
 
@@ -67,7 +68,10 @@ class BlobIndexer(Daemon):
     def safe_update_index(self, path):
         chunk_id = path.rsplit('/', 1)[-1]
         if len(chunk_id) != STRLEN_CHUNKID:
-            self.logger.warn('WARN Not a chunk %s', path)
+            if chunk_id.endswith(CHUNK_SUFFIX_PENDING):
+                self.logger.info('Skipping pending chunk %s', path)
+            else:
+                self.logger.warn('WARN Not a chunk %s', path)
             return
         for char in chunk_id:
             if char not in hexdigits:
@@ -102,9 +106,15 @@ class BlobIndexer(Daemon):
             else:
                 self.errors += 1
                 self.logger.error('ERROR while updating %s: %s', path, err)
-        except Exception:
-            self.errors += 1
-            self.logger.exception('ERROR while updating %s', path)
+        except Exception as err:
+            # We cannot compare errno in the 'except' line.
+            # pylint: disable=no-member
+            if isinstance(err, IOError) and err.errno == errno.ENOENT:
+                self.logger.debug('Chunk %s disappeared before indexing', path)
+                # Neither an error nor a success, do not touch counters.
+            else:
+                self.errors += 1
+                self.logger.exception('ERROR while updating %s', path)
         self.total_since_last_reported += 1
 
     def report(self, tag, start_time):

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -31,6 +31,7 @@ READ_TIMEOUT = 30.0
 
 STRLEN_CHUNKID = 64
 
+# Version of the format of chunk extended attributes
 OIO_VERSION = '4.2'
 
 OIO_DB_ENABLED = 0
@@ -80,8 +81,6 @@ CHUNK_HEADERS = {
     "full_path": "%sfull-path" % CHUNK_METADATA_PREFIX,
     "oio_version": "%soio-version" % CHUNK_METADATA_PREFIX,
 }
-# TODO(FVE): remove from versions >= 4.2.0
-chunk_headers = CHUNK_HEADERS
 
 chunk_xattr_keys = {
     'chunk_hash': 'grid.chunk.hash',
@@ -115,3 +114,8 @@ volume_xattr_keys = {
     'namespace': 'server.ns',
     'type': 'server.type',
     'id': 'server.id'}
+
+# Suffix of chunk file names that have been declared corrupt
+CHUNK_SUFFIX_CORRUPT = '.corrupt'
+# Suffix of chunk file names that are not finished being uploaded
+CHUNK_SUFFIX_PENDING = '.pending'

--- a/tests/functional/blob/test_indexer.py
+++ b/tests/functional/blob/test_indexer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -111,8 +111,7 @@ class TestBlobIndexer(BaseTestCase):
         _, _, expected_cid, _, _, expected_content_id, expected_chunk_id = \
             self._put_chunk()
 
-        chunks = self.rdir_client.chunk_fetch(self.rawx_id)
-        chunks = list(chunks)
+        chunks = list(self.rdir_client.chunk_fetch(self.rawx_id))
         self.assertEqual(1, len(chunks))
         cid, content_id, chunk_id, _ = chunks[0]
         self.assertEqual(expected_cid, cid)
@@ -137,8 +136,7 @@ class TestBlobIndexer(BaseTestCase):
             expected_content_path, expected_content_version, \
             expected_content_id, expected_chunk_id = self._put_chunk()
 
-        chunks = self.rdir_client.chunk_fetch(self.rawx_id)
-        chunks = list(chunks)
+        chunks = list(self.rdir_client.chunk_fetch(self.rawx_id))
         self.assertEqual(1, len(chunks))
         cid, content_id, chunk_id, _ = chunks[0]
         self.assertEqual(expected_cid, cid)


### PR DESCRIPTION
##### SUMMARY
* Do not pollute `oio-blob-indexer` logs with dirty messages like:
```
ERROR while updating /mnt/sdi/OPENIO/rawx-7/3A1/3A1810D5BA7EBB77D146E6258923694AEE060DCD0E6CAD9517744139D37D1E15#012Traceback (most recent call last):#012  File "/usr/lib/python2.7/site-packages/oio/blob/indexer.py", line 73, in safe_update_index#012    self.update_index(path, chunk_id)#012  File "/usr/lib/python2.7/site-packages/oio/blob/indexer.py", line 137, in update_index#012    with open(path) as f:#012IOError: [Errno 2] No such file or directory: '/mnt/sdi/OPENIO/rawx-7/3A1/3A1810D5BA7EBB77D146E6258923694AEE060DCD0E6CAD9517744139D37D1E15'
```
They were due to files seen by the crawler but deleted just before the worker could handle them.

* Do not pollute logs with messages like:
```
WARN Not a chunk /mnt/sdi/OPENIO/rawx-7/CCC/CCCF8C85934932F15F0AF3DBE026AF87A0DBA01B672A57E47CE8F0D51B13CEFA.pending
```
Pending chunks are valid (mostly).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- `oio-blob-indexer`

##### SDS VERSION
```
openio 4.2.8
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
