### PR TITLE
sqliterepo/election: Fix an ugly but harmless memory management

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1204,7 +1204,7 @@ _LOCKED_init_member(struct election_manager_s *manager,
 		else {
 			const gsize len = strlen(key);
 			guint16 id = 0;
-			oio_str_hex2bin(key + len - 4, (guint8 *) &id, 4);
+			oio_str_hex2bin(key + len - 4, (guint8 *) &id, sizeof(id));
 			member->sync = manager->sync_tab[id % manager->sync_nb];
 		}
 


### PR DESCRIPTION
##### SUMMARY
The size of the buffer was wrong but hopefully, we did not write out of the `id` integer variable because the source hexadecimal string ends early enough.

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`sqliterepo`

##### SDS VERSION
`openio 4.4.0.0b1.dev75`
