### PR TITLE
Fix error messages, document proxy API

### DIFF
--- a/server/network_server.c
+++ b/server/network_server.c
@@ -1136,7 +1136,7 @@ _cb_tcp_worker(struct network_client_s *clt, struct network_server_s *srv)
 					"Too many simultaneous requests? (server.pool.max_tcp=%d)",
 					clt->peer_name, clt->fd,
 					(now - clt->time.evt_in) / G_TIME_SPAN_MILLISECOND,
-					server_queue_max_delay / G_TIME_SPAN_MILLISECOND,
+					server_queue_warn_delay / G_TIME_SPAN_MILLISECOND,
 					server_threadpool_max_tcp);
 		}
 	}


### PR DESCRIPTION
##### SUMMARY
- Fix oio-proxy API documentation.
- Fix the variable used in a warning message from TCP server base.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- oio-proxy
- TCP server base

##### SDS VERSION
```
openio 4.4.0.0b2.dev15
```