### PR TITLE
CLI: fix invalid service type in bootstrap message

### DIFF
--- a/oio/cli/rdir/rdir.py
+++ b/oio/cli/rdir/rdir.py
@@ -75,7 +75,8 @@ class RdirBootstrap(lister.Lister):
                           parsed_args.service_type, exc)
             self.error = exc
             all_services, _ = dispatcher.get_assignments(
-                "meta2", connection_timeout=30.0, read_timeout=90.0)
+                parsed_args.service_type, connection_timeout=30.0,
+                read_timeout=90.0)
         return _format_assignments(all_services,
                                    parsed_args.service_type.capitalize())
 


### PR DESCRIPTION
##### SUMMARY

If anything go wrong in `openio rdir bootstrap rawx`,
the behavior is to display current assignments but
invalid refactoring has left `meta2` instead of current
services.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
CLI

##### SDS VERSION
```
4.4.0.0b2.dev19
```
