### PR TITLE
CLI: return 1 when rdir bootstrap fails

### DIFF
--- a/oio/cli/rdir/rdir.py
+++ b/oio/cli/rdir/rdir.py
@@ -75,7 +75,8 @@ class RdirBootstrap(lister.Lister):
                           parsed_args.service_type, exc)
             self.error = exc
             all_services, _ = dispatcher.get_assignments(
-                "meta2", connection_timeout=30.0, read_timeout=90.0)
+                parsed_args.service_type, connection_timeout=30.0,
+                read_timeout=90.0)
         return _format_assignments(all_services,
                                    parsed_args.service_type.capitalize())
 

--- a/oio/cli/rdir/rdir.py
+++ b/oio/cli/rdir/rdir.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -79,6 +79,11 @@ class RdirBootstrap(lister.Lister):
                 read_timeout=90.0)
         return _format_assignments(all_services,
                                    parsed_args.service_type.capitalize())
+
+    def run(self, parsed_args):
+        super(RdirBootstrap, self).run(parsed_args)
+        if self.error:
+            return 1
 
 
 class RdirAssignments(lister.Lister):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Rdir bootstrap returned 0 when there was a partial success.
Deployment needs to be able to check if everything was ok.
So now even on partial success we return 1 but still printing the partial success.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->
CLI
##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.4.0.0b2.dev13
```



<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->


