### PR TITLE
Python API: use reqid instead of req_id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,22 @@ zealous and modify more lines than expected.
 
 The code must comply with [PEP8](https://www.python.org/dev/peps/pep-0008/).
 Running ``tox -e pep8`` will tell what is wrong.
+
+
+## Abbreviations
+
+When using abbreviations, try to be consistent. Here is a list of
+abbreviation commonly used in the existing code base.
+
+- acct: account
+- cid: container ID
+- cs: conscience
+- err: error
+- exc: exception
+- m0: meta0
+- m1: meta1
+- m2: meta2
+- ns: namespace
+- req: request
+- reqid: request ID
+- resp: response

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -138,8 +138,8 @@ class HttpApi(object):
             out_headers[TIMEOUT_HEADER] = int(to * 1000000.0)
 
         # Look for a request ID
-        if 'req_id' in kwargs:
-            out_headers['X-oio-req-id'] = str(kwargs['req_id'])
+        if 'reqid' in kwargs:
+            out_headers['X-oio-req-id'] = str(kwargs['reqid'])
 
         # Convert json and add Content-Type
         if json:

--- a/oio/common/decorators.py
+++ b/oio/common/decorators.py
@@ -32,8 +32,8 @@ def ensure_request_id(func):
     def ensure_request_id_wrapper(*args, **kwargs):
         headers = kwargs.get('headers', dict())
         if 'X-oio-req-id' not in headers:
-            if 'req_id' in kwargs:
-                headers['X-oio-req-id'] = kwargs.pop('req_id')
+            if 'reqid' in kwargs:
+                headers['X-oio-req-id'] = kwargs.pop('reqid')
             else:
                 headers['X-oio-req-id'] = request_id()
             kwargs['headers'] = headers

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -330,13 +330,13 @@ class RdirClient(HttpApi):
     def _clear_cache(self, volume_id):
         self._addr_cache.pop(volume_id, None)
 
-    def _get_rdir_addr(self, volume_id, req_id=None):
+    def _get_rdir_addr(self, volume_id, reqid=None):
         # Initial lookup in the cache
         if volume_id in self._addr_cache:
             return self._addr_cache[volume_id]
         # Not cached, try a direct lookup
         try:
-            headers = {'X-oio-req-id': req_id or request_id()}
+            headers = {'X-oio-req-id': reqid or request_id()}
             resp = self.directory.list(RDIR_ACCT, volume_id,
                                        service_type='rdir',
                                        headers=headers)
@@ -347,8 +347,8 @@ class RdirClient(HttpApi):
         except NotFound:
             raise VolumeException('No rdir assigned to volume %s' % volume_id)
 
-    def _make_uri(self, action, volume_id, req_id=None, service_type='rawx'):
-        rdir_host = self._get_rdir_addr(volume_id, req_id)
+    def _make_uri(self, action, volume_id, reqid=None, service_type='rawx'):
+        rdir_host = self._get_rdir_addr(volume_id, reqid)
         return 'http://%s/v1/%s/%s' % (rdir_host,
                                        self.__class__.base_url[service_type],
                                        action)
@@ -363,7 +363,7 @@ class RdirClient(HttpApi):
         if create:
             params['create'] = '1'
         uri = self._make_uri(action, volume,
-                             req_id=kwargs['headers']['X-oio-req-id'],
+                             reqid=kwargs['headers']['X-oio-req-id'],
                              service_type=service_type)
         try:
             resp, body = self._direct_request(method, uri, params=params,

--- a/tests/functional/content/test_content_perfectible.py
+++ b/tests/functional/content/test_content_perfectible.py
@@ -241,7 +241,7 @@ class TestPerfectibleContent(BaseTestCase):
         reqid = request_id('perfectible-')
         chunks, _, _ = self.api.object_create(
             self.account, container, obj_name='perfectible',
-            data='whatever', policy='THREECOPIES', req_id=reqid)
+            data='whatever', policy='THREECOPIES', reqid=reqid)
 
         # Wait for the "perfectible" event to be emitted,
         # but do not consume it.


### PR DESCRIPTION
##### SUMMARY
Try to be consistent when using abbreviations. We choose reqid over req_id since it was more common in the existing code base, especially in log messages.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.4.0.0b2.dev18
```