### PR TITLE
account: fix filtering when more than 1000 containers

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -161,7 +161,7 @@ class AccountClient(HttpApi):
         :keyword end_marker:
         :keyword prefix:
         :keyword delimiter:
-        :keyword s3_buckets_only: only listing s3 buckets
+        :keyword s3_buckets_only: list only S3 buckets.
         :type s3_buckets_only: `bool`
         :rtype: `dict` with 'ctime' (`float`), 'bytes' (`int`),
             'objects' (`int`), 'containers' (`int`), 'id' (`str`),

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -395,7 +395,7 @@ class ObjectStorageApi(object):
         :keyword end_marker:
         :keyword prefix:
         :keyword delimiter:
-        :keyword s3_buckets_only: only listing s3 buckets
+        :keyword s3_buckets_only: list only S3 buckets.
         :type s3_buckets_only: `bool`
         :type marker: `bool`
         :return: the list of containers of an account


### PR DESCRIPTION
##### SUMMARY
Refactor the container filtering method so it is more readable
and less error-prone.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- account

##### SDS VERSION
```
openio 4.4.0
```


##### ADDITIONAL INFORMATION
Bug has been discovered when trying to integrate https://github.com/open-io/oio-swift/pull/162