### PR TITLE
Improve storage.content.update events

### DIFF
--- a/meta2v2/generic.c
+++ b/meta2v2/generic.c
@@ -64,8 +64,12 @@ _gba_randomize(GByteArray *gba)
 static GByteArray *
 _gba_assign(GByteArray *base, GByteArray *gba)
 {
-	if (!base)
+	if (!base && gba) {
 		base = g_byte_array_sized_new(gba ? gba->len : 8);
+	} else if (base && !gba) {
+		g_byte_array_free(base, TRUE);
+		base = NULL;
+	}
 	if (base != gba) {
 		g_byte_array_set_size(base, 0);
 		g_byte_array_append(base, gba->data, gba->len);

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1580,7 +1580,7 @@ meta2_backend_get_properties(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_del_properties(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gchar **propv, struct bean_ALIASES_s **out)
+		struct oio_url_s *url, gchar **propv, GSList **out)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -1604,7 +1604,7 @@ meta2_backend_del_properties(struct meta2_backend_s *m2b,
 
 GError*
 meta2_backend_set_properties(struct meta2_backend_s *m2b, struct oio_url_s *url,
-		gboolean flush, GSList *beans, struct bean_ALIASES_s **out)
+		gboolean flush, GSList *beans, GSList **out)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;

--- a/meta2v2/meta2_backend.h
+++ b/meta2v2/meta2_backend.h
@@ -177,13 +177,19 @@ GError* meta2_backend_get_properties(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, guint32 flags,
 		m2_onbean_cb cb, gpointer u0);
 
+/** Delete the specified properties, or all properties if "propv" is empty.
+ * After success, "out" will contain an alias bean and the property beans
+ * that have been deleted (with null values). The caller is responsible for
+ * cleaning the list. */
 GError* meta2_backend_del_properties(struct meta2_backend_s *m2b,
-		struct oio_url_s *url, gchar **propv, struct bean_ALIASES_s **out);
+		struct oio_url_s *url, gchar **propv, GSList **out);
 
-/** Helper for testing purpose */
+/** Insert the specified properties, delete the ones with no value.
+ * After success, "out" will contain an alias bean and the property beans
+ * that have been modified. The caller is responsible for cleaning the list. */
 GError* meta2_backend_set_properties(struct meta2_backend_s *m2b,
 		struct oio_url_s *url, gboolean flush, GSList *beans,
-		struct bean_ALIASES_s **out);
+		GSList **out);
 
 /* Back-Links listing ------------------------------------------------------- */
 

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -161,11 +161,18 @@ GError* m2db_list_aliases(struct sqlx_sqlite3_s *sq3, struct list_params_s *lp,
 GError* m2db_get_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 		m2_onbean_cb cb, gpointer u);
 
+/* Delete the specified properties, or all properties if "namev" is empty.
+ * After success, "out" will contain an alias bean and the property beans
+ * that have been deleted (will null values). The caller is responsible for
+ * cleaning the list. */
 GError* m2db_del_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
-		gchar **namev, struct bean_ALIASES_s **out);
+		gchar **namev, GSList **out);
 
+/* Insert the specified properties, delete the ones with no value.
+ * After success, "out" will contain an alias bean and the property beans
+ * that have been modified. The caller is responsible for cleaning the list. */
 GError* m2db_set_properties(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
-		gboolean flush, GSList *beans, struct bean_ALIASES_s **out);
+		gboolean flush, GSList *beans, GSList **out);
 
 GError* m2db_drain_content(struct sqlx_sqlite3_s *sq3, struct oio_url_s *url,
 		m2_onbean_cb cb, gpointer u0);

--- a/meta2v2/meta2_utils_json_out.c
+++ b/meta2v2/meta2_utils_json_out.c
@@ -80,7 +80,11 @@ encode_property(GString *g, gpointer bean)
 	OIO_JSON_append_gstr(g, "key", PROPERTIES_get_key(bean));
 	g_string_append_c(g, ',');
 	GByteArray *property = PROPERTIES_get_value(bean);
-	OIO_JSON_append_blob(g, "value", (gchar*)property->data, property->len);
+	if (property != NULL) {
+		OIO_JSON_append_blob(g, "value", (gchar*)property->data, property->len);
+	} else {
+		OIO_JSON_append_str(g, "value", NULL);
+	}
 }
 
 void

--- a/proxy/cs_actions.c
+++ b/proxy/cs_actions.c
@@ -559,10 +559,10 @@ action_conscience_resolve_service_id (struct req_args_s *args)
 }
 
 // CS{{
-// POST /v3.0/{NS}/conscience/flush?type=<services_type>
+// POST /v3.0/{NS}/conscience/flush?type=<service_type>
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
-// Deregister all services with given type
+// Deregister all services with the given type.
 //
 // .. code-block:: http
 //

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -101,6 +101,9 @@ _reply_m2_error (struct req_args_s *args, GError * err)
 		return _reply_conflict_error (args, err);
 	if (err->code == CODE_CONTENT_DRAINED)
 		return _reply_gone_error(args, err);
+	// For NULL properties
+	if (err->code == SQLITE_CONSTRAINT)
+		return _reply_format_error(args, err);
 	return _reply_common_error (args, err);
 }
 

--- a/tests/functional/cli/__init__.py
+++ b/tests/functional/cli/__init__.py
@@ -66,14 +66,36 @@ class CliTestCase(BaseTestCase):
         return execute('openio', stdin='\n'.join(commands), env=env)
 
     @classmethod
+    def openio_admin(cls, cmd, env=None):
+        """Executes openio-admin CLI command."""
+        return execute('openio-admin ' + cmd, env=env)
+
+    @classmethod
+    def openio_admin_batch(cls, commands, env=None):
+        """Execute several commands in the same openio-admin CLI process."""
+        return execute('openio-admin', stdin='\n'.join(commands), env=env)
+
+    # FIXME(FVE): deprecate this
+    @classmethod
     def get_opts(cls, fields, format='value'):
+        return cls.get_format_opts(format_=format, fields=fields)
+
+    @classmethod
+    def get_format_opts(cls, format_='value', fields=[]):
+        """
+        Get formatting options for OpenIO CLIs,
+        to make them output the specified fields in the specified format.
+        """
         return ' -f {0} {1}'.format(
-            format, ' '.join(['-c ' + it for it in fields]))
+            format_, ' '.join(['-c ' + it for it in fields]))
 
     @classmethod
     def assertOutput(cls, expected, actual):
+        """
+        Compare command outputs, raise an exception if they are different.
+        """
         if expected != actual:
-            raise Exception(expected + ' != ' + actual)
+            raise Exception("'" + expected + "' != '" + actual + "'")
 
     def assert_show_fields(self, items, fields):
         for item in items:

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -255,7 +255,7 @@ class ObjectTest(CliTestCase):
             self.openio_batch(commands, env=env)
 
         # Default listing
-        opts = self.get_opts([], 'json')
+        opts = self.get_format_opts('json') + ' --attempts 3'
         output = self.openio('object list --auto --prefix ' +
                              prefix + ' ' + opts + ' ' + args,
                              env=env)
@@ -266,7 +266,6 @@ class ObjectTest(CliTestCase):
             self.assertEqual(4, len(obj))
 
         # Listing with properties
-        opts = self.get_opts([], 'json')
         output = self.openio('object list --auto --properties --prefix ' +
                              prefix + ' ' + opts + ' ' + args, env=env)
         listing = self.json_loads(output)
@@ -276,7 +275,6 @@ class ObjectTest(CliTestCase):
             self.assertEqual(9, len(obj))
 
         # Unpaged listing
-        opts = self.get_opts([], 'json')
         output = self.openio('object list --auto --no-paging --prefix ' +
                              prefix + ' ' + opts + ' ' + args, env=env)
         listing = self.json_loads(output)
@@ -286,7 +284,8 @@ class ObjectTest(CliTestCase):
             self.assertEqual(4, len(obj))
 
     def test_autocontainer_object_listing(self):
-        self._test_autocontainer_object_listing()
+        env = {"OIO_ACCOUNT": "ACT-%s" % uuid.uuid4().hex}
+        self._test_autocontainer_object_listing(env=env)
 
     def test_autocontainer_object_listing_other_flatns(self):
         env = {"OIO_ACCOUNT": "ACT-%s" % uuid.uuid4().hex}

--- a/tests/unit/test_meta2_backend.c
+++ b/tests/unit/test_meta2_backend.c
@@ -994,7 +994,7 @@ test_content_put_prop_get(void)
 {
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GSList *beans;
-		struct bean_ALIASES_s *alias = NULL;
+		GSList *modified = NULL;
 		guint expected;
 		GPtrArray *tmp;
 		GError *err;
@@ -1016,10 +1016,10 @@ test_content_put_prop_get(void)
 
 		/* set some properties */
 		beans = _props_generate(u, 1, 10);
-		err = meta2_backend_set_properties(m2, u, TRUE, beans, &alias);
+		err = meta2_backend_set_properties(m2, u, TRUE, beans, &modified);
 		g_assert_no_error(err);
 		_bean_cleanl2(beans);
-		_bean_clean(alias);
+		_bean_cleanl2(modified);
 
 		/* versioned or not, a container doesn't generate a new version of the
 		 * content when a property is set on it. */
@@ -1431,7 +1431,7 @@ test_props_gotchas()
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GError *err;
 		GSList *beans;
-		struct bean_ALIASES_s *alias = NULL;
+		GSList *modified = NULL;
 		(void) maxver;
 
 		err = meta2_backend_get_properties(m2, u, 0, NULL, NULL);
@@ -1439,11 +1439,11 @@ test_props_gotchas()
 		g_clear_error(&err);
 
 		beans = _props_generate(u, 1, 10);
-		err = meta2_backend_set_properties(m2, u, FALSE, beans, &alias);
+		err = meta2_backend_set_properties(m2, u, FALSE, beans, &modified);
 		g_assert_error(err, GQ(), CODE_CONTENT_NOTFOUND);
 		g_clear_error(&err);
 		_bean_cleanl2(beans);
-		_bean_clean(alias);
+		_bean_cleanl2(modified);
 	}
 	_container_wraper_allversions("NS", test);
 }
@@ -1454,7 +1454,7 @@ test_props_set_simple()
 	void test(struct meta2_backend_s *m2, struct oio_url_s *u, gint64 maxver) {
 		GError *err;
 		GSList *beans;
-		struct bean_ALIASES_s *alias = NULL;
+		GSList *modified = NULL;
 		(void) maxver;
 
 		CLOCK_START = CLOCK = oio_ext_rand_int();
@@ -1473,11 +1473,11 @@ test_props_set_simple()
 		/* set it properties */
 		beans = _props_generate(u, 1, 10);
 		CLOCK ++;
-		err = meta2_backend_set_properties(m2, u, FALSE, beans, &alias);
+		err = meta2_backend_set_properties(m2, u, FALSE, beans, &modified);
 		CLOCK ++;
 		g_assert_no_error(err);
 		_bean_cleanl2(beans);
-		_bean_clean(alias);
+		_bean_cleanl2(modified);
 
 		CHECK_ALIAS_VERSION(m2,u,CLOCK_START);
 	}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -204,6 +204,7 @@ class CommonTestCase(testtools.TestCase):
         self._beanstalk = None
         self._conscience = None
         self._http_pool = None
+        self._storage_api = None
         # Namespace configuration, from "sds.conf"
         self._ns_conf = None
         # Namespace configuration as it was when the test started
@@ -249,6 +250,14 @@ class CommonTestCase(testtools.TestCase):
             from oio.event.beanstalk import Beanstalk
             self._beanstalk = Beanstalk.from_url(self.conf['queue_url'])
         return self._beanstalk
+
+    @property
+    def storage(self):
+        if self._storage_api is None:
+            from oio.api.object_storage import ObjectStorageApi
+            self._storage_api = ObjectStorageApi(self.ns,
+                                                 pool_manager=self.http_pool)
+        return self._storage_api
 
     @property
     def ns_conf(self):


### PR DESCRIPTION
##### SUMMARY
Improve `storage.content.update` events, in regards to object properties.
- Send keys and values of properties that have just been set.
- Send keys of properties that have been deleted (with a null value).

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- meta2

##### SDS VERSION
```
openio 4.4.2.dev1
```