### PR TITLE
CLI: implement 'openio-admin container touch' command

### DIFF
--- a/oio/cli/admin/item_touch.py
+++ b/oio/cli/admin/item_touch.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from cliff import lister
+
+from oio.cli.admin.common import ContainerCommandMixin
+
+
+class ItemTouchCommand(lister.Lister):
+    """
+    Various parameters that apply to all check commands.
+    """
+
+    columns = ('Container', 'Status')
+
+    def get_parser(self, prog_name):
+        parser = super(ItemTouchCommand, self).get_parser(prog_name)
+        parser.add_argument(
+            '--recompute',
+            dest='recompute',
+            default=False,
+            help='Recompute the statistics of the specified container',
+            action="store_true"
+        )
+        return parser
+
+
+class ContainerTouch(ContainerCommandMixin, ItemTouchCommand):
+    """
+    Touch an object container, triggers asynchronous treatments on it.
+    """
+
+    def get_parser(self, prog_name):
+        parser = super(ContainerTouch, self).get_parser(prog_name)
+        self.patch_parser(parser)
+        return parser
+
+    def touch(self, container, is_cid, recompute):
+        kwargs = {'cid': container if is_cid else None,
+                  'recompute': recompute}
+        self.app.client_manager.storage.container_touch(
+            self.app.client_manager.account,
+            container if not is_cid else None,
+            **kwargs)
+
+    def do(self, parsed_args):
+        for container in parsed_args.containers:
+            try:
+                self.touch(container, parsed_args.is_cid,
+                           parsed_args.recompute)
+                yield (container, "ok")
+            except Exception as err:
+                yield (container, str(err))
+
+    def take_action(self, parsed_args):
+        super(ContainerTouch, self).take_action(parsed_args)
+        return self.columns, self.do(parsed_args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,7 @@ openio.admin =
     container_check = oio.cli.admin.item_check:ContainerCheck
     container_locate = oio.cli.admin.item_locate:ContainerLocate
     container_move = oio.cli.admin.item_move:ContainerMove
+    container_touch = oio.cli.admin.item_touch:ContainerTouch
     election_debug = oio.cli.election.election:ElectionDebug
     election_leave = oio.cli.election.election:ElectionLeave
     election_ping = oio.cli.election.election:ElectionPing


### PR DESCRIPTION
##### SUMMARY

Implement `container touch` in admin CLI

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Admin CLI

##### SDS VERSION
```
openio 4.4.2.dev12
```

##### ADDITIONAL INFORMATION

Output has been added and will consume all containers instead of stopping at first error


```
$ openio container touch d1 d2
Directory error: no such user (HTTP 403) (STATUS 406)

$ openio-admin container touch d1 d2
+-----------+-------------------------------------------------------+
| Container | Status                                                |
+-----------+-------------------------------------------------------+
| d1        | ok                                                    |
| d2        | Directory error: no such user (HTTP 403) (STATUS 406) |
+-----------+-------------------------------------------------------+
```