### PR TITLE
CLI: implement 'openio-admin <service_type> decache' commands

### DIFF
--- a/oio/cli/admin/service_decache.py
+++ b/oio/cli/admin/service_decache.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cliff import lister
+
+
+class DecacheCommand(lister.Lister):
+    """
+    Base class for all decache commands.
+    """
+
+    columns = ('Id', 'Status')
+    service_type = None
+
+    @property
+    def admin(self):
+        """Get an instance of AdminClient."""
+        return self.app.client_manager.admin
+
+    @property
+    def cs(self):
+        """Get an instance of ConscienceClient."""
+        return self.app.client_manager.conscience
+
+    def get_parser(self, prog_name):
+        parser = super(DecacheCommand, self).get_parser(prog_name)
+        parser.add_argument(
+            'services',
+            metavar='<service_id>',
+            nargs='*',
+            help=("Service hosting the cache to empty. "
+                  "If no service is specified, flush them all."),
+        )
+        return parser
+
+    def get_services(self, parsed_args):
+        """
+        Yield IDs of services that must flush their cache.
+        """
+        if not parsed_args.services:
+            parsed_args.services = [
+                s['id'] for s in self.cs.all_services(self.service_type)]
+        for srv in parsed_args.services:
+            yield srv
+
+    def decache_services(self, services):
+        """Send a decache request to each specified service."""
+        raise NotImplementedError()
+
+    def take_action(self, parsed_args):
+        services = self.get_services(parsed_args)
+        return self.columns, self.decache_services(services)
+
+
+class ProxyDecache(DecacheCommand):
+    """Flush the cache of a proxy service."""
+
+    service_type = 'proxy'
+
+    def decache_services(self, services):
+        for srv in services:
+            try:
+                self.admin.proxy_flush_cache(proxy_netloc=srv)
+                yield srv, 'OK'
+            except Exception as err:
+                yield srv, err
+
+
+class SqliterepoDecacheCommand(DecacheCommand):
+    """Flush the cache of an sqliterepo-based service."""
+
+    def decache_services(self, services):
+        for srv in services:
+            try:
+                self.admin.service_flush_cache(srv)
+                yield srv, 'OK'
+            except Exception as err:
+                yield srv, err
+
+
+class Meta1Decache(SqliterepoDecacheCommand):
+    """Flush the cache of a meta1 service."""
+    service_type = 'meta1'
+
+
+class Meta2Decache(SqliterepoDecacheCommand):
+    """Flush the cache of a meta2 service."""
+    service_type = 'meta2'

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -129,8 +129,12 @@ class ConscienceClient(ProxyClient):
         :param type_: the type of services to get (ex: 'rawx')
         :type type_: `str`
         :param full: whether to get all metrics for each service
-        :returns: the list of all services of the specified type
-        :rtype: `list` of `dict`
+        :returns: the list of all services of the specified type.
+        :rtype: `list` of `dict` objects, each containing at least
+            - 'addr' (`str`),
+            - 'id' (`str`),
+            - 'score' (`int`),
+            - 'tags' (`dict`).
         """
         params = {'type': type_}
         if full:

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -914,10 +914,16 @@ configure_request_handlers (void)
 	SET("/config/#POST", action_set_config);
 
 	SET("/forward/config/#POST", action_forward_set_config);
-
 	SET("/forward/config/#GET", action_forward_get_config);
+
+	/* Get the version of the service. */
 	SET("/forward/version/#GET", action_forward_get_version);
+
+	/* Get information about the (sqliterepo-based) service, like the number
+	 * of bases currently open, the number of managed elections. */
 	SET("/forward/info/#GET", action_forward_get_info);
+
+	/* Get request statistics for the specified service. */
 	SET("/forward/stats/#GET", action_forward_stats);
 
 	/* TODO(jfs): remove in a further release, present for the sake of backward
@@ -926,15 +932,33 @@ configure_request_handlers (void)
 
 	SET("/forward/ping/#GET", action_forward_get_ping);
 	SET("/forward/kill/#POST", action_forward_kill);
+
+	/* Reload the internal load balancer of the specified sqliterepo
+	 * service. */
 	SET("/forward/reload/#POST", action_forward_reload);
+
+	/* Flush the high and low caches of the specified sqliterepo service. */
 	SET("/forward/flush/#POST", action_forward_flush);
+
+	/* Ask a service to release memory to the system. */
 	SET("/forward/lean-glib/#POST", action_forward_lean_glib);
+	/* Ask sqlite3 to release memory. */
 	SET("/forward/lean-sqlx/#POST", action_forward_lean_sqlx);
 
+	/* Get a status of the high (conscience and meta0) and low (meta1)
+	 * cache, including the current number of entries. */
 	SET("/cache/status/#GET", action_cache_status);
+	/* Get the list of all services known to the internal load balancer,
+	 * with their ID and their network location. */
 	SET("/cache/show/#GET", action_cache_show);
+	/* Flush high and low caches and the internal load balancer.
+	 * DANGEROUS, LB requests will fail during the next few seconds! */
 	SET("/cache/flush/local/#POST", action_cache_flush_local);
+	/* Flush "high" cache, i.e. the list of all meta0 services
+	 * and the prefix/meta1 association (content of meta0 DB). */
 	SET("/cache/flush/high/#POST", action_cache_flush_high);
+	/* Flush "low" cache, i.e the reference/service association
+	 * (content of meta1 DB). */
 	SET("/cache/flush/low/#POST", action_cache_flush_low);
 
 	// New routes
@@ -1017,13 +1041,20 @@ configure_request_handlers (void)
 	/* Ask each peer if base exists ("DB_HAS"). */
 	SET("/$NS/admin/has/#POST", action_admin_has);
 
+	/* Get information about one of the services hosting the specified
+	 * container. Requires a CID and a service type.
+	 * Same as calling forward/info on the service hosting the CID. */
 	SET("/$NS/admin/info/#POST", action_admin_info);
 
 	/* Ask each peer for the status of the election.
 	 * 200 -> master, 303 -> slave. */
 	SET("/$NS/admin/status/#POST", action_admin_status);
 
+	/* Ask sqlite3 to release memory. Requires a CID and a service type.
+	 * Same as calling POST forward/lean-sqlx on the service
+	 * hosting the CID. */
 	SET("/$NS/admin/drop_cache/#POST", action_admin_drop_cache);
+
 	SET("/$NS/admin/sync/#POST", action_admin_sync);
 
 	/* Ask each peer to exit the election ("DB_LEAVE"). */

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,8 +150,11 @@ openio.admin =
     election_ping = oio.cli.election.election:ElectionPing
     election_status = oio.cli.election.election:ElectionStatus
     election_sync = oio.cli.election.election:ElectionSync
+    meta1_decache = oio.cli.admin.service_decache:Meta1Decache
+    meta2_decache = oio.cli.admin.service_decache:Meta2Decache
     object_check = oio.cli.admin.item_check:ObjectCheck
     object_locate = oio.cli.admin.item_locate:ObjectLocate
+    proxy_decache = oio.cli.admin.service_decache:ProxyDecache
 
 oio.conscience.checker =
     asn1 = oio.conscience.checker.asn1:Asn1PingChecker

--- a/tests/functional/cli/__init__.py
+++ b/tests/functional/cli/__init__.py
@@ -75,15 +75,27 @@ class CliTestCase(BaseTestCase):
         """Execute several commands in the same openio-admin CLI process."""
         return execute('openio-admin', stdin='\n'.join(commands), env=env)
 
+    # FIXME(FVE): deprecate this
     @classmethod
     def get_opts(cls, fields, format='value'):
+        return cls.get_format_opts(format_=format, fields=fields)
+
+    @classmethod
+    def get_format_opts(cls, format_='value', fields=[]):
+        """
+        Get formatting options for OpenIO CLIs,
+        to make them output the specified fields in the specified format.
+        """
         return ' -f {0} {1}'.format(
-            format, ' '.join(['-c ' + it for it in fields]))
+            format_, ' '.join(['-c ' + it for it in fields]))
 
     @classmethod
     def assertOutput(cls, expected, actual):
+        """
+        Compare command outputs, raise an exception if they are different.
+        """
         if expected != actual:
-            raise Exception(expected + ' != ' + actual)
+            raise Exception("'" + expected + "' != '" + actual + "'")
 
     def assert_show_fields(self, items, fields):
         for item in items:

--- a/tests/functional/cli/admin/test_service_decache.py
+++ b/tests/functional/cli/admin/test_service_decache.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+from oio.common.easy_value import true_value
+from oio.common.json import json
+
+from tests.utils import random_str
+from tests.functional.cli import CliTestCase
+
+
+class ServiceDecacheTest(CliTestCase):
+
+    def setUp(self):
+        super(ServiceDecacheTest, self).setUp()
+        self._containers = list()
+
+    def tearDown(self):
+        for acct, ct in self._containers:
+            try:
+                self.storage.container_delete(acct, ct)
+            except Exception:
+                pass
+        super(ServiceDecacheTest, self).tearDown()
+
+    def test_proxy_decache(self):
+        """
+        Check that a decache order actually empties proxy's cache.
+        """
+        if not true_value(self.conf['config'].get('proxy.cache.enabled')):
+            self.skipTest('Proxy cache disabled')
+        # Creating a container will put something in both high and low caches.
+        ct = 'test-decache-' + random_str(8)
+        self.storage.container_create(self.account, ct)
+        self._containers.append((self.account, ct))
+
+        status0 = self.admin.proxy_get_cache_status()
+        output = self.openio_admin('proxy decache' + self.get_format_opts())
+        # FIXME(FVE): this will fail when we will deploy several proxies
+        self.assertOutput('%s OK\n' % self.conf['proxy'], output)
+        status1 = self.admin.proxy_get_cache_status()
+        self.assertLess(status1['csm0']['count'], status0['csm0']['count'])
+        self.assertLess(status1['meta1']['count'], status0['meta1']['count'])
+
+    def _test_service_decache_all(self, type_):
+        all_svc = self.conscience.all_services(type_)
+        output = self.openio_admin('%s decache' % type_ +
+                                   self.get_format_opts('json'))
+        decached = {s['Id'] for s in json.loads(output)
+                    if s['Status'] == 'OK'}
+        expected = {s['id'] for s in all_svc}
+        self.assertEqual(expected, decached)
+
+    def _test_service_decache_one(self, type_):
+        all_svc = self.conscience.all_services(type_)
+        one = all_svc[0]
+        output = self.openio_admin('%s decache %s' % (type_, one['id']) +
+                                   self.get_format_opts('json'))
+        decached = {s['Id'] for s in json.loads(output)
+                    if s['Status'] == 'OK'}
+        expected = set([one['id']])
+        self.assertEqual(expected, decached)
+
+    def test_meta1_decache_all(self):
+        self._test_service_decache_all('meta1')
+
+    def test_meta1_decache_one(self):
+        self._test_service_decache_one('meta1')
+
+    def test_meta2_decache_all(self):
+        self._test_service_decache_all('meta2')
+
+    def test_meta2_decache_one(self):
+        self._test_service_decache_one('meta2')

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -257,7 +257,7 @@ class ObjectTest(CliTestCase):
             self.openio_batch(commands, env=env)
 
         # Default listing
-        opts = self.get_opts([], 'json')
+        opts = self.get_format_opts('json') + ' --attempts 3'
         output = self.openio('object list --auto --prefix ' +
                              prefix + ' ' + opts + ' ' + args,
                              env=env)
@@ -268,7 +268,6 @@ class ObjectTest(CliTestCase):
             self.assertEqual(4, len(obj))
 
         # Listing with properties
-        opts = self.get_opts([], 'json')
         output = self.openio('object list --auto --properties --prefix ' +
                              prefix + ' ' + opts + ' ' + args, env=env)
         listing = self.json_loads(output)
@@ -278,7 +277,6 @@ class ObjectTest(CliTestCase):
             self.assertEqual(9, len(obj))
 
         # Unpaged listing
-        opts = self.get_opts([], 'json')
         output = self.openio('object list --auto --no-paging --prefix ' +
                              prefix + ' ' + opts + ' ' + args, env=env)
         listing = self.json_loads(output)
@@ -289,7 +287,8 @@ class ObjectTest(CliTestCase):
             self.assertEqual(4, len(obj))
 
     def test_autocontainer_object_listing(self):
-        self._test_autocontainer_object_listing()
+        env = {"OIO_ACCOUNT": "ACT-%s" % uuid.uuid4().hex}
+        self._test_autocontainer_object_listing(env=env)
 
     def test_autocontainer_object_listing_other_flatns(self):
         env = {"OIO_ACCOUNT": "ACT-%s" % uuid.uuid4().hex}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -205,6 +205,7 @@ class CommonTestCase(testtools.TestCase):
         self._beanstalk = None
         self._conscience = None
         self._http_pool = None
+        self._storage_api = None
         # Namespace configuration, from "sds.conf"
         self._ns_conf = None
         # Namespace configuration as it was when the test started
@@ -250,6 +251,14 @@ class CommonTestCase(testtools.TestCase):
             from oio.event.beanstalk import Beanstalk
             self._beanstalk = Beanstalk.from_url(self.conf['queue_url'])
         return self._beanstalk
+
+    @property
+    def storage(self):
+        if self._storage_api is None:
+            from oio.api.object_storage import ObjectStorageApi
+            self._storage_api = ObjectStorageApi(self.ns,
+                                                 pool_manager=self.http_pool)
+        return self._storage_api
 
     @property
     def ns_conf(self):


### PR DESCRIPTION
##### SUMMARY
Implement the following commands:
- `openio-admin proxy decache`
- `openio-admin meta1 decache`
- `openio-admin meta2 decache`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- CLI
- Python API
- proxy

##### SDS VERSION
```
openio 4.4.2.dev14
```


##### ADDITIONAL INFORMATION
Some utility code was taken from #1712, and will probably conflict when merging.