### PR TITLE
Fix container snapshot feature

### DIFF
--- a/meta1v2/meta1_backend_services.c
+++ b/meta1v2/meta1_backend_services.c
@@ -974,7 +974,7 @@ meta1_backend_services_link (struct meta1_backend_s *m1,
 				g_prefix_error(&err, "Query error: ");
 		}
 		if (!(err = sqlx_transaction_end(repctx, err))) {
-			if (renewed)
+			if (renewed && !dryrun)
 				__notify_services_by_cid(m1, sq3, url);
 		}
 	}
@@ -1011,7 +1011,7 @@ meta1_backend_services_poll(struct meta1_backend_s *m1,
 				g_prefix_error(&err, "Query error: ");
 		}
 		if (!(err = sqlx_transaction_end(repctx, err)) && renewed) {
-			if (renewed)
+			if (renewed && !dryrun)
 				__notify_services_by_cid(m1, sq3, url);
 		}
 	}

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -439,6 +439,7 @@ class ObjectStorageApi(object):
                     target_beans, copy_beans,
                     dst_account, dst_container,
                     frozen=True, **kwargs)
+            self.container.container_touch(dst_account, dst_container)
         finally:
             self.container.container_enable(account, container, **kwargs)
 

--- a/oio/event/filters/dump.py
+++ b/oio/event/filters/dump.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from oio.common.json import json
+from oio.event.filters.base import Filter
+
+
+class DumpFilter(Filter):
+    """
+    Dump events to files in /tmp directory.
+    Each event will be named after its job ID (example: /tmp/event_3).
+    This filter is only intended to help debugging.
+    """
+
+    def __init__(self, app, conf, **kwargs):
+        super(DumpFilter, self).__init__(app, conf, **kwargs)
+
+    def process(self, env, cb):
+        with open("/tmp/event_%s" % env["job_id"], "w") as fp:
+            fp.write(json.dumps(env, indent=4))
+        return self.app(env, cb)
+
+
+def filter_factory(global_conf, **local_conf):
+    conf = global_conf.copy()
+    conf.update(local_conf)
+
+    def dump_filter(app):
+        return DumpFilter(app, conf)
+    return dump_filter

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1303,7 +1303,7 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 	GError *err = NULL;
 	gchar **urlv = NULL;
 	gchar **urlv_snapshot = NULL;
-	char type[LIMIT_LENGTH_SRVTYPE] = {};
+	char type[LIMIT_LENGTH_SRVTYPE] = {0};
 	_get_meta2_realtype(args, type, sizeof(type));
 	const char *target_account, *target_container;
 	char target_cid[65] = {};
@@ -1336,40 +1336,43 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 	const gchar *account = json_object_get_string(jaccount);
 	const gchar *container = json_object_get_string(jcontainer);
 	const gchar *seq_num = jseq_num? json_object_get_string(jseq_num): ".1";
-	if(!strcmp(account, target_account) && !strcmp(container, target_container)) {
-		err = BADREQ("the snapshot should have a different account or reference");
+	if (!strcmp(account, target_account) &&
+			!strcmp(container, target_container)) {
+		err = BADREQ("The snapshot must either have a different name or "
+				"be placed in another account");
 		goto cleanup;
 	}
 
 	oio_url_set(args->url, OIOURL_ACCOUNT, account);
 	oio_url_set(args->url, OIOURL_USER, container);
 	oio_url_set(args->url, OIOURL_HEXID, NULL);
-	err = hc_resolve_reference_service (resolver, args->url,
+	err = hc_resolve_reference_service(resolver, args->url,
 			NAME_SRVTYPE_META2, &urlv_snapshot, oio_ext_get_deadline());
 	if (!err) {
 		err = BADREQ("Container already exists");
 		goto cleanup;
-	}else {
+	} else {
 		g_error_free(err);
 		err = NULL;
 	}
 
-	GError *hook_dir (const char *m1) {
-		GError *e = meta1v2_remote_link_service (
-				m1, args->url, type, FALSE, TRUE, &urlv_snapshot,
+	GError *hook_dir(const char *m1) {
+		/* Whether replication is enabled or not,
+		 * keep only one service to host the snapshot. */
+		GError *err2 = meta1v2_remote_link_service(
+				m1, args->url, type, TRUE, TRUE, &urlv_snapshot,
 				oio_ext_get_deadline());
-		if (!e && urlv_snapshot && *urlv_snapshot) {
-			e = meta1v2_remote_force_reference_service(
+		if (!err2 && urlv_snapshot && *urlv_snapshot) {
+			err2 = meta1v2_remote_force_reference_service(
 				m1, args->url, urlv_snapshot[0], FALSE, TRUE,
 				oio_ext_get_deadline());
 		}
 		if (urlv_snapshot) {
-			g_strfreev (urlv_snapshot);
+			g_strfreev(urlv_snapshot);
 			urlv_snapshot = NULL;
 		}
-		return e;
+		return err2;
 	}
-
 	err = _m1_locate_and_action(args->url, hook_dir);
 	if (err)
 		goto cleanup;
@@ -1377,18 +1380,29 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 	meta1_urlv_shift_addr(urlv);
 	CLIENT_CTX(ctx, args, type, 1);
 	gchar *url = _resolve_service_id(urlv[0]);
-	GByteArray * _pack(const struct sqlx_name_s *n) {
+	GByteArray * _pack_snapshot(const struct sqlx_name_s *n) {
 		return sqlx_pack_SNAPSHOT(n, url, target_cid, seq_num, DL());
 	}
-
-	err = _resolve_meta2(args, CLIENT_PREFER_MASTER, _pack, NULL, NULL);
+	err = _resolve_meta2(args, CLIENT_PREFER_MASTER,
+			_pack_snapshot, NULL, NULL);
 	g_free(url);
-	if(err)
-		goto cleanup;
+
+	/* Give the snapshot its name. */
+	if (!err) {
+		gchar *props[5] = {
+			SQLX_ADMIN_ACCOUNT, (gchar*)account,
+			SQLX_ADMIN_USERNAME, (gchar*)container,
+			NULL
+		};
+		GByteArray * _pack_propset(const struct sqlx_name_s *n) {
+			return sqlx_pack_PROPSET_tab(n, FALSE, props, DL());
+		}
+		err = _resolve_meta2(args, CLIENT_PREFER_MASTER,
+				_pack_propset, NULL, NULL);
+	}
 
 cleanup:
-
-	if(urlv_snapshot)
+	if (urlv_snapshot)
 		g_strfreev(urlv_snapshot);
 	if (urlv)
 		g_strfreev(urlv);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1676,8 +1676,12 @@ static GError * _list_loop (struct req_args_s *args,
 //    }
 //
 // Take a snapshot of a container. Create a separate database containing all
-// information about the contents from the original database, but with copies of
-// the chunks at the time of the snapshot. This new database is not replicated.
+// information about the contents from the original database.
+//
+// WARNING: this command is not intended to be used as-is as source and destination
+// containers will share same chunks.
+//
+// Please use `openio container snapshot` command.
 //
 // .. code-block:: http
 //

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,6 +147,7 @@ oio.event.filter_factory =
     noop = oio.event.filters.noop:filter_factory
     logger = oio.event.filters.logger:filter_factory
     bury = oio.event.filters.bury:filter_factory
+    dump = oio.event.filters.dump:filter_factory
 
 [wheel]
 universal = 1

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -1087,6 +1087,11 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         # Non existing snapshot should work
         self.api.container_snapshot(self.account, container, self.account,
                                     snapshot)
+        # Check sys.user.name is correct
+        ret = self.api.container_get_properties(self.account, snapshot)
+        self.assertEqual(snapshot, ret['system']['sys.user.name'])
+        self.assertEqual(self.account, ret['system']['sys.account'])
+
         # Already taken snapshot name should failed
         self.assertRaises(exc.ClientException,
                           self.api.container_snapshot,

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -823,14 +823,17 @@ use = egg:oio#notify
 tube = oio-repli
 queue_url = ${QUEUE_URL}
 
+[filter:bury]
+use = egg:oio#bury
+
+[filter:dump]
+use = egg:oio#dump
+
 [filter:noop]
 use = egg:oio#noop
 
 [filter:logger]
 use = egg:oio#logger
-
-[filter:bury]
-use = egg:oio#bury
 """
 
 template_conscience_agent = """


### PR DESCRIPTION
##### SUMMARY

The snapshot operation did not show the created container in account service:
- the `sys.user.name` and `sys.account` was not updated
- a manual `openio container touch` was not possible due to these erroneous values

Fixes OS-350

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
CLI

##### SDS VERSION
```
openio 4.2.9.dev10
```
