### PR TITLE
Replicate container snapshots

### DIFF
--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1456,16 +1456,11 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 	}
 
 	GError *hook_dir(const char *m1) {
-		/* Whether replication is enabled or not,
-		 * keep only one service to host the snapshot. */
 		GError *err2 = meta1v2_remote_link_service(
-				m1, args->url, NAME_SRVTYPE_META2, TRUE, TRUE, &urlv_snapshot,
+				m1, args->url, NAME_SRVTYPE_META2, FALSE, TRUE, &urlv_snapshot,
 				oio_ext_get_deadline());
-		if (!err2 && urlv_snapshot && *urlv_snapshot) {
-			err2 = meta1v2_remote_force_reference_service(
-				m1, args->url, urlv_snapshot[0], FALSE, TRUE,
-				oio_ext_get_deadline());
-		}
+		/* TODO(FVE): send this list along with the snapshot request.
+		 * This will prevent the meta2 from looking up in the meta1. */
 		if (urlv_snapshot) {
 			g_strfreev(urlv_snapshot);
 			urlv_snapshot = NULL;

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1160,7 +1160,8 @@ sqlx_repository_timed_open_and_lock(sqlx_repository_t *repo,
 				mode = SQLX_OPEN_DISABLED;
 
 			if (!(mode & expected_status)) {
-				err = NEWERROR(CODE_CONTAINER_FROZEN, "Invalid status");
+				err = NEWERROR(CODE_CONTAINER_FROZEN,
+						"Invalid status: %s", sqlx_admin_status2str(flags));
 				sqlx_repository_unlock_and_close_noerror(*result);
 			}
 		}

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -310,6 +310,21 @@ sqlx_admin_get_status(struct sqlx_sqlite3_s *sq3)
 			(gint64)ADMIN_STATUS_ENABLED);
 }
 
+const gchar*
+sqlx_admin_status2str(gint64 status)
+{
+	switch (status) {
+		case ADMIN_STATUS_FROZEN:
+			return "frozen";
+		case ADMIN_STATUS_DISABLED:
+			return "disabled";
+		case ADMIN_STATUS_ENABLED:
+			return "enabled";
+		default:
+			return "unknown";
+	}
+}
+
 gchar**
 sqlx_admin_get_keys(struct sqlx_sqlite3_s *sq3)
 {

--- a/sqliterepo/sqlite_utils.c
+++ b/sqliterepo/sqlite_utils.c
@@ -159,7 +159,8 @@ sqlx_admin_del_all_user(struct sqlx_sqlite3_s *sq3)
 int
 sqlx_admin_has(struct sqlx_sqlite3_s *sq3, const gchar *k)
 {
-	return NULL != g_tree_lookup(sq3->admin, k);
+	struct _cache_entry_s *v = g_tree_lookup(sq3->admin, k);
+	return v != NULL && !v->flag_deleted;
 }
 
 gchar*

--- a/sqliterepo/sqlite_utils.h
+++ b/sqliterepo/sqlite_utils.h
@@ -179,6 +179,9 @@ guint sqlx_admin_save_lazy_tnx (struct sqlx_sqlite3_s *sq3);
 void sqlx_admin_set_status(struct sqlx_sqlite3_s *sq3, gint64 status);
 gint64 sqlx_admin_get_status(struct sqlx_sqlite3_s *sq3);
 
+/* Get a (static) string representing the status of the database. */
+const gchar* sqlx_admin_status2str(gint64 status);
+
 void sqlx_alert_dirty_base(struct sqlx_sqlite3_s *sq3, const char *msg);
 
 #endif /*OIO_SDS__sqliterepo__sqlite_utils_h*/


### PR DESCRIPTION
##### SUMMARY
Container snapshots are now real containers, frozen by default. They can be unfrozen with `openio container set --status enabled`.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API
- oio-proxy
- sqliterepo

##### SDS VERSION
```
openio 5.0.0.0a1.dev8
```