### PR TITLE
Persist service locks after conscience restart

### DIFF
--- a/metautils/lib/metatype_srvinfo.h
+++ b/metautils/lib/metatype_srvinfo.h
@@ -26,6 +26,9 @@ void service_info_clean(struct service_info_s *si);
 
 void service_info_cleanv(struct service_info_s **siv, gboolean content_only);
 
+/* Clean the tags array from the service_info_s object. */
+void service_info_clean_tags(struct service_info_s *si);
+
 void service_info_gclean(gpointer si, gpointer unused);
 
 struct service_info_s *service_info_dup(const struct service_info_s *si);

--- a/metautils/lib/metautils_macros.h
+++ b/metautils/lib/metautils_macros.h
@@ -40,6 +40,7 @@ License along with this library.
 # define NAME_TAGNAME_RAWX_UP "tag.up"
 # define NAME_TAGNAME_RAWX_FIRST "tag.1"
 # define NAME_TAGNAME_RAWX_LOC "tag.loc"
+# define NAME_TAGNAME_LOCK "tag.lock"
 # define NAME_TAGNAME_SLOTS "tag.slots"
 
 # define NAME_TAGNAME_USER_IS_SERVICE "user_is_a_service"

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -235,23 +235,26 @@ service_tag_to_string(const struct service_tag_s *tag, gchar * dst, gsize dst_si
 	return 0;
 }
 
-void
-service_info_clean(struct service_info_s *si)
+void service_info_clean_tags(struct service_info_s *si)
 {
-	if (!si)
-		return;
 	if (si->tags) {
 		GPtrArray *pa = si->tags;
-
 		while (pa->len > 0) {
 			struct service_tag_s *tag;
-
 			tag = g_ptr_array_index(pa, 0);
 			g_ptr_array_remove_index_fast(pa, 0);
 			service_tag_destroy(tag);
 		}
 		g_ptr_array_free(pa, TRUE);
 	}
+}
+
+void
+service_info_clean(struct service_info_s *si)
+{
+	if (!si)
+		return;
+	service_info_clean_tags(si);
 	g_free(si);
 }
 

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -686,7 +686,7 @@ group=${NS},localhost,conscience,${IP}:${PORT}
 on_die=cry
 enabled=true
 start_at_boot=true
-command=oio-daemon -s OIO,${NS},cs,${SRVNUM} ${CFGDIR}/${NS}-conscience-${SRVNUM}.conf
+command=oio-daemon -O PersistencePath=${DATADIR}/${NS}-conscience-${SRVNUM}/conscience.dat -O PersistencePeriod=15 -s OIO,${NS},cs,${SRVNUM} ${CFGDIR}/${NS}-conscience-${SRVNUM}.conf
 """
 
 template_gridinit_meta = """


### PR DESCRIPTION
##### SUMMARY
Create a new `tag.lock` tag telling is the service has been locked by an administrator. This tag is saved (with all other tags) in the conscience persistence file. After a restart, this file is loaded, and the services are locked (or unlocked) again.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- conscience
- CLI

##### SDS VERSION
```
openio 4.4.2.dev19
```