### PR TITLE
CLI: display nicer KeyError messages

### DIFF
--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -406,11 +406,9 @@ class LocalNSConf(show.ShowOne):
         return parser
 
     def take_action(self, parsed_args):
-        from oio.common.configuration import load_namespace_conf
-
         self.log.debug('take_action(%s)', parsed_args)
         namespace = self.app.client_manager.cluster.conf['namespace']
-        sds_conf = load_namespace_conf(namespace)
+        sds_conf = self.app.client_manager.sds_conf
         output = list()
         for k in sds_conf:
             output.append(("%s/%s" % (namespace, k), sds_conf[k]))

--- a/oio/cli/common/clientmanager.py
+++ b/oio/cli/common/clientmanager.py
@@ -56,7 +56,7 @@ class ClientManager(object):
     @property
     def client_conf(self):
         """Dict to be passed as first parameter to all *Client classes."""
-        if not self._sds_conf:
+        if not self._client_conf:
             self._client_conf = {'namespace': self.namespace,
                                  'proxyd_url': self.get_endpoint()}
         return self._client_conf

--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -18,7 +18,6 @@ from oio.common.green import Queue, GreenPile, sleep
 
 from logging import getLogger, INFO
 from cliff.command import Command
-from oio.common.configuration import load_namespace_conf
 from oio.common.exceptions import \
         ClientException, ConfigurationException, PreconditionFailed
 from oio.common import green
@@ -306,7 +305,7 @@ class DirectoryWarmup(DirectoryCmd):
         if parsed_args.proxy:
             conf.update({'proxyd_url': parsed_args.proxy})
         else:
-            ns_conf = load_namespace_conf(conf['namespace'])
+            ns_conf = self.app.client_manager.sds_conf
             proxy = ns_conf.get('proxy')
             conf.update({'proxyd_url': proxy})
 
@@ -317,7 +316,8 @@ class DirectoryWarmup(DirectoryCmd):
 
             # Prepare some workers
             for _ in range(workers_count):
-                worker = WarmupWorker(conf, self.log)
+                worker = WarmupWorker(self.app.client_manager.client_conf,
+                                      self.log)
                 workers.append(worker)
                 pile.spawn(worker.run, prefix_queue)
 

--- a/oio/cli/zk/set.py
+++ b/oio/cli/zk/set.py
@@ -16,7 +16,6 @@
 import zookeeper
 from logging import getLogger
 from cliff import lister, command
-from oio.common.configuration import load_namespace_conf
 from oio.zk.client import \
         get_connected_handles, \
         generate_namespace_tree as _run, \
@@ -38,7 +37,7 @@ class ElectionCmdMixin(object):
 
     def get_params(self, parsed_args):
         ns = self.app.client_manager.zk['ns']
-        cnxstr = load_namespace_conf(ns)['zookeeper']
+        cnxstr = self.app.client_manager.sds_conf['zookeeper']
         return ns, cnxstr
 
     def iterate_groups(self, parsed_args, non_leaf=False):

--- a/oio/common/configuration.py
+++ b/oio/common/configuration.py
@@ -101,6 +101,21 @@ def config_paths():
 NS_CONF_CACHE = dict()
 
 
+class NamespaceConfiguration(dict):
+    """
+    Dictionary subclass that holds namespace configuration.
+    Displays a nice message if a key is missing.
+    """
+
+    def __init__(self, files, *args, **kwargs):
+        super(NamespaceConfiguration, self).__init__(*args, **kwargs)
+        self.files = files
+
+    def __missing__(self, key):
+        raise Exception("'%s' not found in configuration files:\n%s" % (
+            key, '\n'.join(self.files)))
+
+
 def load_namespace_conf(namespace, failsafe=False, fresh=False):
     """
     Load configuration for the namespace from the local configuration files.
@@ -114,10 +129,10 @@ def load_namespace_conf(namespace, failsafe=False, fresh=False):
     if not fresh and namespace in NS_CONF_CACHE:
         return NS_CONF_CACHE[namespace]
 
-    conf = {'namespace': namespace}
     parser = SafeConfigParser({})
     success = False
     loaded_files = parser.read(config_paths())
+    conf = NamespaceConfiguration(loaded_files, namespace=namespace)
     if not loaded_files:
         print('Unable to read namespace config')
     else:


### PR DESCRIPTION
##### SUMMARY
When some parameters are missing from configuration files, and are requested by the CLI, a nice message will be displayed, telling in which file the parameter is supposed to be.
```
> openio zk stat meta2
'zookeeper' not found in configuration files:
/etc/oio/sds.conf.d/NS
/home/fvennetier/.oio/sds.conf
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 5.0.0.0a1.dev8
```