### PR TITLE
event-agent: configure timeouts to the account service

### DIFF
--- a/etc/event-handlers.conf-sample
+++ b/etc/event-handlers.conf-sample
@@ -53,6 +53,9 @@ use = egg:oio#content_cleaner
 
 [filter:account_update]
 use = egg:oio#account_update
+# Timeouts to the account service, in seconds
+#connection_timeout=2.0
+#read_timeout=30.0
 
 [filter:volume_index]
 use = egg:oio#volume_index


### PR DESCRIPTION
##### SUMMARY
Allow to configure timeouts from the event-agent to the account service.
Also review how we handle errors occurring while removing a container from the account service: the event was dropped, it is now replayed later.

Jira: OS-355

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- event-agent

##### SDS VERSION
```
openio 4.4.2.dev19
```