### PR TITLE
rawx: fix mispelled req-id header

### DIFF
--- a/rawx/rawx.go
+++ b/rawx/rawx.go
@@ -104,7 +104,7 @@ func (rawx *rawxService) ServeHTTP(rep http.ResponseWriter, req *http.Request) {
 	}
 
 	// Extract some common headers
-	rawxreq.reqid = req.Header.Get("X-oio-reqid")
+	rawxreq.reqid = req.Header.Get("X-oio-req-id")
 	if len(rawxreq.reqid) <= 0 {
 		rawxreq.reqid = req.Header.Get("X-trans-id")
 	}


### PR DESCRIPTION
##### SUMMARY

The header `X-oio-req-id` was mispelled `X-oio-reqid` and it was not possible to trace a full request on rawx level.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
go-rawx

##### SDS VERSION
```
openio 5.0.0.0a1.dev11
```
