### PR TITLE
Python API: do not use the legacy 'meta1_digits' parameter

### DIFF
--- a/oio/rebuilder/meta1_rebuilder.py
+++ b/oio/rebuilder/meta1_rebuilder.py
@@ -28,7 +28,8 @@ class Meta1Rebuilder(MetaRebuilder):
         super(Meta1Rebuilder, self).__init__(conf, logger, **kwargs)
         self.conscience = ConscienceClient(self.conf, logger=self.logger)
         sds_conf = load_namespace_conf(self.conf['namespace']) or {}
-        self.meta1_digits = int(sds_conf.get('meta1_digits', 4))
+        self.meta1_digits = int(sds_conf.get('ns.meta1_digits',
+                                             sds_conf.get('meta1_digits', 4)))
 
     def _create_worker(self, **kwargs):
         return Meta1RebuilderWorker(self.conf, self.logger, **kwargs)


### PR DESCRIPTION
##### SUMMARY

The variable meta1_digits was renamed ns.meta1_digits in 4.1.22.
If new variable is missing, we try to load old value

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio-meta1-rebuilder

##### SDS VERSION
```
openio 4.4.2.dev27
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
