### PR TITLE
rawx: More FD-based syscalls, Less buffer copies

### DIFF
--- a/rawx/chunkrepo.go
+++ b/rawx/chunkrepo.go
@@ -29,17 +29,16 @@ type chunkRepository struct {
 	sub fileRepository
 }
 
-func (chunkrepo *chunkRepository) lock(ns, url string) error {
-	return chunkrepo.sub.lock(ns, url)
+func (cr *chunkRepository) getAttr(name, key string, value []byte) (int, error) {
+	return cr.sub.getAttr(name, key, value)
 }
 
-func (chunkrepo *chunkRepository) has(name string) (bool, error) {
-	v, _ := chunkrepo.sub.has(name)
-	return v, nil
+func (cr *chunkRepository) lock(ns, url string) error {
+	return cr.sub.lock(ns, url)
 }
 
-func (chunkrepo *chunkRepository) del(name string) error {
-	err := chunkrepo.sub.del(name)
+func (cr *chunkRepository) del(name string) error {
+	err := cr.sub.del(name)
 	if err == nil {
 		return nil
 	} else if err != os.ErrNotExist && !os.IsNotExist(err) {
@@ -49,8 +48,8 @@ func (chunkrepo *chunkRepository) del(name string) error {
 	}
 }
 
-func (chunkrepo *chunkRepository) get(name string) (fileReader, error) {
-	r, err := chunkrepo.sub.get(name)
+func (cr *chunkRepository) get(name string) (fileReader, error) {
+	r, err := cr.sub.get(name)
 	if err == nil {
 		return r, nil
 	} else if err != os.ErrNotExist && !os.IsNotExist(err) {
@@ -60,11 +59,10 @@ func (chunkrepo *chunkRepository) get(name string) (fileReader, error) {
 	}
 }
 
-func (chunkrepo *chunkRepository) put(name string) (fileWriter, error) {
-	return chunkrepo.sub.put(name)
+func (cr *chunkRepository) put(name string) (fileWriter, error) {
+	return cr.sub.put(name)
 }
 
-func (chunkrepo *chunkRepository) link(fromName,
-	toName string) (fileWriter, error) {
-	return chunkrepo.sub.link(fromName, toName)
+func (cr *chunkRepository) link(fromName, toName string) (linkOperation, error) {
+	return cr.sub.link(fromName, toName)
 }

--- a/rawx/repo.go
+++ b/rawx/repo.go
@@ -23,11 +23,15 @@ some <key,value> properties.
 
 type repository interface {
 	lock(ns, url string) error
-	has(name string) (bool, error)
 	get(name string) (fileReader, error)
 	put(name string) (fileWriter, error)
-	link(fromName, toName string) (fileWriter, error)
+	link(fromName, toName string) (linkOperation, error)
 	del(name string) error
+	getAttr(name, key string, value []byte) (int, error)
+}
+
+type decorable interface {
+	setAttr(n string, v []byte) error
 }
 
 type fileReader interface {
@@ -35,13 +39,19 @@ type fileReader interface {
 	Close() error
 	size() int64
 	seek(int64) error
-	getAttr(n string) ([]byte, error)
+	getAttr(key string, value []byte) (int, error)
 }
 
 type fileWriter interface {
+	decorable
 	Write([]byte) (int, error)
 	seek(int64) error
 	commit() error
 	abort() error
-	setAttr(n string, v []byte) error
+}
+
+type linkOperation interface {
+	decorable
+	commit() error
+	rollback() error
 }


### PR DESCRIPTION
##### SUMMARY
* Fixes a bug in the logic of the `PUT` operation: the check on the final chun must happen *after* the atomic creation of the temporary `.pending` file
* Rewrites the logic of the `COPY` operation: only 3 atomic syscalls and no risk lose a content
* Optimizes the DELETE of chunks: less attributes are read, just the necessary syscalls are done
* Makes a better use of syscalls when it is possible with the Golang standard library
* Tries to reduce the number of memory copies and allocations

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`rawx`

##### SDS VERSION
`openio 4.4.2.dev42`

##### COMMENTS
* `PUT` and `DELETE` now seem faster than the *httpd* equivalents
* `GET` still appears slower, seemingly due to a sequence of `getattr` always interrupted by the golang scheduler between each call and operating of paths instead of file descriptors.