### PR TITLE
rawx: fix log format

### DIFF
--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -369,6 +369,11 @@ func (rr *rawxRequest) serveChunk() {
 	case "PUT":
 		rr.uploadChunk()
 		spent = IncrementStatReqPut(rr)
+		LogHttp(
+			rr.rawx.url, rr.req.RemoteAddr, rr.req.Method,
+			rr.status, spent, rr.bytesIn, rr.chunk.ContainerID,
+			rr.reqid, rr.req.URL.Path)
+		return
 	case "DELETE":
 		rr.removeChunk()
 		spent = IncrementStatReqDel(rr)
@@ -383,8 +388,8 @@ func (rr *rawxRequest) serveChunk() {
 		spent = IncrementStatReqOther(rr)
 	}
 
-	LogIncoming(
+	LogHttp(
 		rr.rawx.url, rr.req.RemoteAddr, rr.req.Method,
-		rr.status, spent, rr.bytesOut,
+		rr.status, spent, rr.bytesOut, rr.chunk.ContainerID,
 		rr.reqid, rr.req.URL.Path)
 }

--- a/rawx/logger.go
+++ b/rawx/logger.go
@@ -105,7 +105,7 @@ func LogDebug(format string, v ...interface{}) {
 	writeLogFmt(syslog.LOG_DEBUG, format, v...)
 }
 
-func LogIncoming(url, peer, method string, status int, spent, bytes uint64, id, path string) {
+func LogHttp(url, peer, method string, status int, spent, bytes uint64, containerID, id, path string) {
 	sb := strings.Builder{}
 	sb.Grow(128 + len(path))
 	// Preamble
@@ -124,24 +124,16 @@ func LogIncoming(url, peer, method string, status int, spent, bytes uint64, id, 
 	sb.WriteRune(' ')
 	sb.WriteString(utoa(bytes))
 	sb.WriteRune(' ')
+	if len(containerID) > 0 {
+		sb.WriteString(containerID)
+	} else {
+		sb.WriteRune('-')
+	}
+	sb.WriteRune(' ')
 	sb.WriteString(id)
 	sb.WriteRune(' ')
 	sb.WriteString(path)
 	logger.write(syslog.LOG_LOCAL1|syslog.LOG_INFO, sb.String())
-}
-
-func LogOutgoing(format string, v ...interface{}) {
-	if !severityAllowed(syslog.LOG_DEBUG) {
-		return
-	}
-	sb := strings.Builder{}
-	sb.Grow(256)
-	// Preamble
-	sb.WriteString(strconv.Itoa(os.Getpid()))
-	sb.WriteString(" out INF - ")
-	// Payload
-	sb.WriteString(fmt.Sprintf(format, v...))
-	logger.write(syslog.LOG_LOCAL2|syslog.LOG_INFO, sb.String())
 }
 
 type NoopLogger struct {


### PR DESCRIPTION
##### SUMMARY

The log emitted by the rawx was not compliant with our documentation:

    The ContainerID was missing in emitted log.
    The LogOIncoming was not correct, it is now used by PUT operation.

Fixes OS-356

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rawx

##### SDS VERSION
```
openio 4.4.2.dev27
```


##### ADDITIONAL INFORMATION

Please note that an update is still required on monitoring stack.