### PR TITLE
CI: make curl silent when there is no error

### DIFF
--- a/tests/func/test_weird_chars.c
+++ b/tests/func/test_weird_chars.c
@@ -47,7 +47,7 @@ test_create_upload_delete_destroy(struct oio_url_s *url, const gchar *obj)
 	if (obj) {
 		oio_url_set(dst.url, OIOURL_PATH, obj);
 		g_assert_true(oio_url_check(dst.url, NULL, NULL));
-    }
+	}
 	err = oio_sds_upload_from_file(client, &dst, source_file, 0, -1);
 	g_assert_no_error((GError*)err);
 
@@ -93,13 +93,15 @@ static void
 test_create_upload_delete_destroy_objname(gconstpointer user_data)
 {
 	const char *obj_name = user_data;
+	char cname[LIMIT_LENGTH_USER] = {0};
+	g_snprintf(cname, LIMIT_LENGTH_USER, "container-%x", obj_name[0]);
 
 	struct oio_url_s *url = oio_url_empty();
 	g_assert_nonnull(url);
 
 	oio_url_set(url, OIOURL_NS, ns_name);
 	oio_url_set(url, OIOURL_ACCOUNT, account);
-	oio_url_set(url, OIOURL_USER, "container");
+	oio_url_set(url, OIOURL_USER, cname);
 	oio_url_set(url, OIOURL_PATH, obj_name);
 	g_assert_true(oio_url_check(url, ns_name, NULL));
 

--- a/tools/oio-test-mover.sh
+++ b/tools/oio-test-mover.sh
@@ -100,7 +100,7 @@ oio_meta2_mover()
   echo ""
 
   ALL_META2=$(${CLI} cluster list meta2 -c Addr -c "Service Id" -c Volume -f value)
-  META2_COPY=$(/usr/bin/curl -X POST \
+  META2_COPY=$(/usr/bin/curl -sS -X POST \
       "http://${PROXY}/v3.0/${NAMESPACE}/lb/poll?pool=meta2" 2> /dev/null \
       | /bin/grep -o "\"addr\":" | /usr/bin/wc -l)
   if [ "${META2_COPY}" -eq 0 ]; then

--- a/tools/oio-test-rebuilder.sh
+++ b/tools/oio-test-rebuilder.sh
@@ -58,7 +58,7 @@ update_timeout()
   for META_TYPE in meta0 meta1 meta2; do
     $CLI cluster list "${META_TYPE}" -f value -c Addr \
         | while read -r URL; do
-      curl -X POST -d "{\"resolver.cache.csm0.ttl.default\": ${TIMEOUT}, \"resolver.cache.srv.ttl.default\": ${TIMEOUT}}" \
+      curl -sS -X POST -d "{\"resolver.cache.csm0.ttl.default\": ${TIMEOUT}, \"resolver.cache.srv.ttl.default\": ${TIMEOUT}}" \
           "http://${PROXY}/v3.0/forward/config?id=${URL}"
     done
   done
@@ -69,7 +69,7 @@ check_and_remove_meta()
 {
   TYPE=$1
 
-  META_COPY=$(/usr/bin/curl -X POST \
+  META_COPY=$(/usr/bin/curl -sS -X POST \
       "http://${PROXY}/v3.0/${NAMESPACE}/lb/poll?pool=${TYPE}" 2> /dev/null \
       | /bin/grep -o "\"addr\":" | /usr/bin/wc -l)
   if [ "${META_COPY}" -le 0 ]; then

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -118,34 +118,34 @@ test_oio_file_tool () {
 test_proxy_forward () {
 	proxy=$(oio-test-config.py -t proxy -1)
 
-	curl -X GET "http://$proxy/v3.0/status" >/dev/null
-	curl -X GET "http://$proxy/v3.0/cache/status" >/dev/null
-	curl -X GET "http://$proxy/v3.0/config" >/dev/null
-	curl -X POST "http://$proxy/v3.0/cache/flush/local" >/dev/null
-	curl -X POST "http://$proxy/v3.0/cache/flush/high" >/dev/null
-	curl -X POST "http://$proxy/v3.0/cache/flush/low" >/dev/null
-	curl -X POST -d '{"socket.nodelay.enabled":"on"}' \
+	curl -sS  -X GET "http://$proxy/v3.0/status" >/dev/null
+	curl -sS  -X GET "http://$proxy/v3.0/cache/status" >/dev/null
+	curl -sS  -X GET "http://$proxy/v3.0/config" >/dev/null
+	curl -sS  -X POST "http://$proxy/v3.0/cache/flush/local" >/dev/null
+	curl -sS  -X POST "http://$proxy/v3.0/cache/flush/high" >/dev/null
+	curl -sS  -X POST "http://$proxy/v3.0/cache/flush/low" >/dev/null
+	curl -sS  -X POST -d '{"socket.nodelay.enabled":"on"}' \
 		"http://$proxy/v3.0/config" >/dev/null
 
 	for url in $(oio-test-config.py -t meta2 -t meta0 -t meta1) ; do
-		curl -X GET "http://$proxy/v3.0/forward/config?id=$url" >/dev/null
-		curl -X POST -d '{"socket.nodelay.enabled":"on"}' \
+		curl -sS  -X GET "http://$proxy/v3.0/forward/config?id=$url" >/dev/null
+		curl -sS  -X POST -d '{"socket.nodelay.enabled":"on"}' \
 			"http://$proxy/v3.0/forward/config?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/flush?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/reload?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/ping?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/lean-glib?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/lean-sqlx?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/version?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/handlers?id=$url" >/dev/null
-		curl -X POST "http://$proxy/v3.0/forward/info?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/flush?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/reload?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/ping?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/lean-glib?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/lean-sqlx?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/version?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/handlers?id=$url" >/dev/null
+		curl -sS  -X POST "http://$proxy/v3.0/forward/info?id=$url" >/dev/null
 	done
 }
 
 wait_proxy_cache() {
 	cnt=$(oio-test-config.py -t rawx | wc -l)
 	while true; do
-		rawx=$(curl -s http://$proxy/v3.0/cache/show | python -m json.tool | grep -c rawx | cat)
+		rawx=$(curl -sS  http://$proxy/v3.0/cache/show | python -m json.tool | grep -c rawx | cat)
 		if [ $cnt -eq $rawx ]; then
 			break
 		fi
@@ -154,7 +154,7 @@ wait_proxy_cache() {
 
 	cnt=$(oio-test-config.py -t meta2 | wc -l)
 	while true; do
-		meta2=$(curl -s http://$proxy/v3.0/cache/show | python -m json.tool | grep -c meta2 | cat)
+		meta2=$(curl -sS  http://$proxy/v3.0/cache/show | python -m json.tool | grep -c meta2 | cat)
 		if [ $cnt -eq $meta2 ]; then
 			break
 		fi


### PR DESCRIPTION
##### SUMMARY
We often reach the limit of 10000 log lines in our CI tool, and a lot of them are curl progress bars. We don't need them.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- CI

##### SDS VERSION
```
openio 5.0.0.0a2.dev1
```


##### ADDITIONAL INFORMATION
None.