### PR TITLE
tests: accelerate some shell scripts

### DIFF
--- a/oio/ecd/app.py
+++ b/oio/ecd/app.py
@@ -25,9 +25,9 @@ from oio.api.ec import EcMetachunkWriter, ECChunkDownloadHandler
 from oio.api.replication import ReplicatedMetachunkWriter
 from oio.api.backblaze import BackblazeChunkWriteHandler, \
     BackblazeChunkDownloadHandler
-from oio.api.backblaze_http import BackblazeUtils, BackblazeUtilsException
+from oio.api.backblaze_http import BackblazeUtils
 from oio.api.io import ChunkReader
-from oio.common.exceptions import OioException
+from oio.common.exceptions import OioException, ConfigurationException
 from oio.common.wsgi import WerkzeugApp
 
 SYS_PREFIX = 'x-oio-chunk-meta-'
@@ -134,7 +134,7 @@ class ECD(WerkzeugApp):
         key_file = self.conf.get('key_file')
         try:
             creds = BackblazeUtils.get_credentials(storage_method, key_file)
-        except BackblazeUtilsException as exc:
+        except ConfigurationException as exc:
             return Response(exc, 500)
         handler = BackblazeChunkWriteHandler(sysmeta, upload_chunk,
                                              meta_checksum, storage_method,
@@ -175,7 +175,7 @@ class ECD(WerkzeugApp):
         key_file = self.conf.get('key_file')
         try:
             creds = BackblazeUtils.get_credentials(storage_method, key_file)
-        except BackblazeUtilsException as exc:
+        except ConfigurationException as exc:
             return Response(exc, 500)
         if meta_start is not None:
             if meta_start < 0:

--- a/oio/event/filters/content_cleaner.py
+++ b/oio/event/filters/content_cleaner.py
@@ -19,8 +19,6 @@ from oio.common.constants import REQID_HEADER
 from oio.event.evob import Event, EventTypes
 from oio.event.filters.base import Filter
 from oio.common.exceptions import OioException
-from oio.api.backblaze import BackblazeDeleteHandler
-from oio.api.backblaze_http import BackblazeUtils
 from oio.common.storage_method import STORAGE_METHODS, guess_storage_method
 from oio.common.utils import request_id
 
@@ -55,6 +53,8 @@ class ContentReaperFilter(Filter):
                     resp.chunk.get('real_url', resp.chunk['url']), resp.status)
 
     def _handle_b2(self, url, chunks, headers, storage_method, reqid):
+        from oio.api.backblaze import BackblazeDeleteHandler
+        from oio.api.backblaze_http import BackblazeUtils
         meta = {'container_id': url['id']}
         key_file = self.conf.get('key_file')
         b2_creds = BackblazeUtils.get_credentials(

--- a/tools/oio-test-mover.sh
+++ b/tools/oio-test-mover.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-NAMESPACE=$($(which oio-test-config.py) -n)
-META1_DIGITS=$($(which oio-test-config.py) -v meta1_digits)
-CLI=$(which openio)
+NAMESPACE=$($(command -v oio-test-config.py) -n)
+META1_DIGITS=$($(command -v oio-test-config.py) -v meta1_digits)
+CLI=$(command -v openio)
+M2_MOVER="$(command -v oio-meta2-mover)"
 
 SVCID_ENABLED=$(openio cluster list rawx -c 'Service Id' -f value | grep -v 'n/a')
 
@@ -38,7 +39,7 @@ while getopts ":n:d:" opt; do
   esac
 done
 
-PROXY=$($(which oio-test-config.py) -t proxy -1)
+PROXY=$($(command -v oio-test-config.py) -t proxy -1)
 
 FAIL=false
 
@@ -73,7 +74,7 @@ oio_meta2_mover()
     fi
     OLD_IFS=$IFS
     IFS=' '
-    for TABLE in $(echo "${TABLES_1}"); do
+    for TABLE in ${TABLES_1}; do
       if ! TABLE_1=$(/usr/bin/sqlite3 "${1}" "SELECT * FROM ${TABLE}" \
           2> /dev/null); then
         IFS=$OLD_IFS
@@ -178,7 +179,7 @@ oio_meta2_mover()
       POSSIBLE_DESTS=$ALL_META2
       OLD_IFS=$IFS
       IFS=$'\n'
-      for PEER_ID in $(echo "${PEERS_BEFORE}"); do
+      for PEER_ID in ${PEERS_BEFORE}; do
         POSSIBLE_DESTS=$(echo "${POSSIBLE_DESTS}" | /bin/sed "/${PEER_ID}/d")
       done
       IFS=$OLD_IFS
@@ -199,7 +200,7 @@ oio_meta2_mover()
 
     if [ -z "${DEST_ID}" ]; then
       echo "oio-meta2-mover ${NAMESPACE} ${BASE}.${SEQ} ${META2_ID}"
-      if ! $(which oio-meta2-mover) "${NAMESPACE}" "${BASE}" \
+      if ! $M2_MOVER "${NAMESPACE}" "${BASE}" \
           "${META2_ID}" &> /dev/null; then
         echo "${META2}: oio-meta2-mover failed"
         FAIL=true
@@ -207,7 +208,7 @@ oio_meta2_mover()
     else
       echo "oio-meta2-mover ${NAMESPACE} ${BASE}.${SEQ} ${META2_ID}" \
           "${DEST_ID}"
-      if ! $(which oio-meta2-mover) "${NAMESPACE}" "${BASE}" \
+      if ! $M2_MOVER "${NAMESPACE}" "${BASE}" \
           "${META2_ID}" "${DEST_ID}" &> /dev/null; then
         echo "${META2}: oio-meta2-mover failed"
         FAIL=true
@@ -231,7 +232,7 @@ oio_meta2_mover()
     unset REAL_DEST_ID
     OLD_IFS=$IFS
     IFS=$'\n'
-    for META1_ID in $(echo "${META1_PEERS_ID}"); do
+    for META1_ID in ${META1_PEERS_ID}; do
       META1_LOC=$(echo "${ALL_META1}" | /bin/grep "${META1_ID}" \
           | /usr/bin/cut -d' ' -f3)
       META1=$(/bin/ls "${META1_LOC}/"*"/${BASE:0:${META1_DIGITS}}${EMPTY_META1_PREFIX:0:4-${META1_DIGITS}}.meta1")
@@ -250,7 +251,7 @@ oio_meta2_mover()
       PEERS_AFTER_COPY=$PEERS_AFTER
       OLD_IFS=$IFS
       IFS=$'\n'
-      for PEER_ID in $(echo "${PEERS_TO_KEEP}"); do
+      for PEER_ID in ${PEERS_TO_KEEP}; do
         if ! echo "${PEERS_AFTER_COPY}" | /bin/grep -q "${PEER_ID}" ; then
           echo "${META2}: Missing IP (${PEER_ID}) for the meta1 ${META1_ID}"
           FAIL=true
@@ -288,7 +289,7 @@ oio_meta2_mover()
     unset VERSION_AFTER
     OLD_IFS=$IFS
     IFS=$'\n'
-    for PEER_ID in $(echo "${PEERS_AFTER}"); do
+    for PEER_ID in ${PEERS_AFTER}; do
       PEER_LOC=$(echo "${ALL_META2}" | /bin/grep "${PEER_ID}" \
           | /usr/bin/cut -d' ' -f3)
       META2_AFTER=$(/bin/ls "${PEER_LOC}/"*"/${FILE}")
@@ -306,7 +307,7 @@ oio_meta2_mover()
       fi
       OLD_IFS=$IFS
       IFS=$'\n'
-      for PEER_ID_BIS in $(echo "${PEERS_AFTER}"); do
+      for PEER_ID_BIS in ${PEERS_AFTER}; do
         if ! echo "${PEERS_AFTER_BIS}" | /bin/grep -q "${PEER_ID_BIS}"; then
           echo "${META2}: Missing ID (${PEER_ID_BIS}) for the meta2 ${PEER_ID}"
           FAIL=true
@@ -380,7 +381,7 @@ oio_meta2_mover()
 
     OLD_IFS=$IFS
     IFS=$'\n'
-    for PEER_ID in $(echo "${PEERS_AFTER}"); do
+    for PEER_ID in ${PEERS_AFTER}; do
       if ! echo "${PEERS_AFTER_BIS}" | /bin/grep -q "${PEER_ID}"; then
         echo "${META2}: Missing ID (${PEER_ID}) for the 'container locate'"
         FAIL=true

--- a/tools/oio-test-rebuilder.sh
+++ b/tools/oio-test-rebuilder.sh
@@ -263,6 +263,7 @@ openioadmin_meta_rebuild()
       FAIL=true
       continue
     fi
+    echo -n '.'
   done
 
   if [ "${FAIL}" = true ]; then
@@ -273,10 +274,17 @@ openioadmin_meta_rebuild()
   fi
 }
 
+declare -A -x ID_TO_NETLOC
+
 resolve_chunk()
 {
   ID=$(echo "$1" | sed -E -n -e 's,http://([^/]+)/.*,\1,p')
-  NETLOC=$($CLI cluster resolve -f value rawx "$ID")
+  NETLOC="${ID_TO_NETLOC[$ID]}"
+  if [ -z "$NETLOC" ]
+  then
+    NETLOC=$($CLI cluster resolve -f value rawx "$ID")
+    ID_TO_NETLOC[$ID]="$NETLOC"
+  fi
   echo "${1/$ID/$NETLOC}"
 }
 


### PR DESCRIPTION
##### SUMMARY
Try to find why the rebuilder tests are so slow, and fix what is fixable.

- Use a bash associative array to cache results of `openio cluster resolve` (which is rather slow).
- Use variables for commands we use often.
- Call `command -v` instead of `which`.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
- tests

##### SDS VERSION
```
openio 5.0.0.0a1
```