### PR TITLE
CI: enhance wait_for_event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       env: TEST_SUITE=worm
     - stage: Functional tests
       script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=single
+      env: TEST_SUITE=single,webhook
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=repli,go-rawx
     - script: ./tools/oio-travis-suites.sh
@@ -102,8 +102,6 @@ jobs:
       env: TEST_SUITE=multi-beanstalk
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=mover,with-service-id
-    - script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=webhook
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f /tmp/cmake_coverage.output

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -418,7 +418,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
 
         self._create(name)
         for i in range(10):
-            reqid = 'content' + str(i)
+            reqid = 'content' + name + str(i)
             self.api.object_create(
                 self.account, name, obj_name=reqid, data='data',
                 reqid=reqid)
@@ -432,7 +432,8 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.wait_for_event(
             'oio-preserved', reqid=reqid, type_=EventTypes.CONTENT_NEW)
         self.wait_for_event(
-            'oio-preserved', type_=EventTypes.CONTAINER_STATE)
+            'oio-preserved', fields={'user': name},
+            type_=EventTypes.CONTAINER_STATE)
         containers = self.api.container_list(self.account)
         for container in containers:
             if container[0] == name:
@@ -449,7 +450,8 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         reqid = request_id()
         self.api.container_touch(self.account, name, reqid=reqid)
         self.wait_for_event(
-            'oio-preserved', type_=EventTypes.CONTAINER_STATE)
+            'oio-preserved', fields={'user': name},
+            type_=EventTypes.CONTAINER_STATE)
         containers = self.api.container_list(self.account)
         self.assertEqual(1, len(containers))
         self.assertListEqual(
@@ -461,7 +463,8 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
 
         self.api.container_touch(self.account, name, recompute=True)
         self.wait_for_event(
-            'oio-preserved', type_=EventTypes.CONTAINER_STATE)
+            'oio-preserved', fields={'user': name},
+            type_=EventTypes.CONTAINER_STATE)
         meta = self.api.container_get_properties(self.account, name)
         self.assertEqual(objects, meta['system']['sys.m2.objects'])
         self.assertEqual(usage, meta['system']['sys.m2.usage'])
@@ -840,10 +843,14 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
 
         name = random_str(32)
         self.api.object_create(account, name, data="data", obj_name=name)
-        self.wait_for_event('oio-preserved', type_=EventTypes.CONTAINER_STATE)
+        self.wait_for_event('oio-preserved',
+                            fields={'account': account},
+                            type_=EventTypes.CONTAINER_STATE)
         self.beanstalkd0.drain_tube('oio-preserved')
         self.api.account_refresh(account)
-        self.wait_for_event('oio-preserved', type_=EventTypes.CONTAINER_STATE)
+        self.wait_for_event('oio-preserved',
+                            fields={'account': account},
+                            type_=EventTypes.CONTAINER_STATE)
         res = self.api.account_show(account)
         self.assertEqual(res["bytes"], 4)
         self.assertEqual(res["objects"], 1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -480,11 +480,11 @@ class BaseTestCase(CommonTestCase):
                      score_threshold, timeout)
 
     def wait_for_event(self, tube, reqid=None, type_=None,
-                       timeout=30.0):
+                       fields=None, timeout=30.0):
         """
         Wait for an event in the specified tube.
-        If reqid and/or type_ are specified, drain events until the specified
-        event is found.
+        If reqid, type_ and/or fields are specified, drain events until the
+        specified event is found.
         """
         self.beanstalkd0.wait_for_ready_job(tube, timeout=timeout)
         self.beanstalkd0.watch(tube)
@@ -497,10 +497,19 @@ class BaseTestCase(CommonTestCase):
                 job_id, data = self.beanstalkd0.reserve(timeout=to)
                 edata = jsonlib.loads(data)
                 self.beanstalkd0.delete(job_id)
-                if not type_ or edata['event'] == type_:
-                    if not reqid or edata.get('request_id') == reqid:
-                        return edata
                 now = time.time()
+                if type_ and edata['event'] != type_:
+                    logging.debug("ignore event %s (event mismatch)", data)
+                    continue
+                if reqid and edata.get('request_id') != reqid:
+                    logging.info("ignore event %s (request_id mismatch)", data)
+                    continue
+                if fields and any(fields[k] != edata.get('url', {}).get(k)
+                                  for k in fields):
+                    logging.info("ignore event %s (filter mismatch)", data)
+                    continue
+                logging.info("event %s", data)
+                return edata
         except ResponseError as err:
             logging.info('%s', err)
         return None

--- a/tools/oio-test-suites.sh
+++ b/tools/oio-test-suites.sh
@@ -176,6 +176,9 @@ func_tests () {
 	if is_running_test_suite "fsync"; then
 		args="${args} -f "${SRCDIR}/etc/bootstrap-option-rawx-fsync.yml""
 	fi
+	if is_running_test_suite "webhook"; then
+		args="${args} -f "${SRCDIR}/etc/bootstrap-option-webhook.yml""
+	fi
 	$OIO_RESET ${args} -N $OIO_NS $@
 
 	test_proxy_forward
@@ -381,12 +384,6 @@ if is_running_test_suite "multi-beanstalk" ; then
 	func_tests \
 		-f "${SRCDIR}/etc/bootstrap-preset-SINGLE.yml" \
 		-f "${SRCDIR}/etc/bootstrap-option-3beanstalkd.yml"
-fi
-
-if is_running_test_suite "webhook" ; then
-	echo -e "\n### with webhooks"
-	func_tests -f "${SRCDIR}/etc/bootstrap-preset-SINGLE.yml" \
-		-f "${SRCDIR}/etc/bootstrap-option-webhook.yml"
 fi
 
 func_tests_rebuilder_mover () {


### PR DESCRIPTION
##### SUMMARY

During test on Travis, some tests were waiting specific events but previous events were used.
We can now add more filter to wait the wanted event.

The single and webhook testsuite was merged

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests

##### SDS VERSION
```
5.0.0.0a2.dev17
```