### PR TITLE
Integrity crawler improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ jobs:
       env: TEST_SUITE=worm
     - stage: Functional tests
       script: ./tools/oio-travis-suites.sh
+      env: TEST_SUITE=rebuilder,with-service-id
+    - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=single,webhook
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=repli,go-rawx
@@ -96,8 +98,6 @@ jobs:
       env: TEST_SUITE=3copies,with-service-id
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=ec,with-random-service-id
-    - script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=rebuilder,with-service-id
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=multi-beanstalk
     - script: ./tools/oio-travis-suites.sh

--- a/oio/cli/admin/item_check.py
+++ b/oio/cli/admin/item_check.py
@@ -18,7 +18,7 @@ from cliff import lister
 
 from oio.cli.admin.common import AccountCommandMixin, ContainerCommandMixin, \
     ObjectCommandMixin
-from oio.crawler.integrity import Checker, Target
+from oio.crawler.integrity import Checker, Target, DEFAULT_DEPTH
 
 
 class ItemCheckCommand(lister.Lister):
@@ -89,11 +89,11 @@ class RecursiveCheckCommand(ItemCheckCommand):
         parser.add_argument(
             '--depth', '--max-depth',
             type=int,
-            default=5,
+            default=DEFAULT_DEPTH,
             help=("How deep to recurse. 0 means do not recurse. "
                   "N > 0 means recurse N levels below the specified item type "
                   "(namespace -> account -> container -> object -> chunk, "
-                  "default: 5).")
+                  "default: %d)." % DEFAULT_DEPTH)
         )
         return parser
 

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -92,9 +92,17 @@ class ConscienceClient(ProxyClient):
     def __init__(self, conf, **kwargs):
         super(ConscienceClient, self).__init__(
             conf, request_prefix="/conscience", **kwargs)
-        lb_kwargs = dict(kwargs)
-        lb_kwargs.pop("pool_manager", None)
-        self.lb = LbClient(conf, pool_manager=self.pool_manager, **lb_kwargs)
+        self._lb_kwargs = dict(kwargs)
+        self._lb_kwargs.pop("pool_manager", None)
+        self._lb = None
+
+    @property
+    def lb(self):
+        """Get an instance of LbClient."""
+        if self._lb is None:
+            self._lb = LbClient(self.conf, pool_manager=self.pool_manager,
+                                **self._lb_kwargs)
+        return self._lb
 
     def next_instances(self, pool, **kwargs):
         """

--- a/tools/oio-test-rebuilder.sh
+++ b/tools/oio-test-rebuilder.sh
@@ -48,6 +48,7 @@ FAIL=false
 TMP_VOLUME="${TMPDIR:-/tmp}/openio_volume_before"
 TMP_FILE_BEFORE="${TMPDIR:-/tmp}/openio_file_before"
 TMP_FILE_AFTER="${TMPDIR:-/tmp}/openio_file_after"
+INTEGRITY_LOG="${TMPDIR:-/tmp}/integrity.log"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -325,6 +326,7 @@ remove_rawx()
 
 openioadmin_rawx_rebuild()
 {
+  rm -f "$INTEGRITY_LOG"
   set -e
 
   echo ""
@@ -424,7 +426,7 @@ openioadmin_rawx_rebuild()
         continue
       fi
       if ! $INTEGRITY "$NAMESPACE" "${ACCOUNT}" \
-          "${CONTAINER}" "${CONTENT}" "${CHUNK_URL}" &> /dev/null; then
+          "${CONTAINER}" "${CONTENT}" "${CHUNK_URL}" &>> "$INTEGRITY_LOG"; then
         echo >&2 "${CHUNK}: (${CHUNK_URL}) oio-crawler-integrity failed for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue


### PR DESCRIPTION
##### SUMMARY
Bring various improvements to `oio-crawler-integrity`, required to make it a daemon later.
- Allow it to check all accounts.
- Fix concurrency issues.
- Load `LbClient` from `ConscienceClient` only when necessary.
- Refactor `Tool` class a little.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API
- CLI
- oio-crawler-integrity

##### SDS VERSION
```
openio 5.0.0.0a2.dev24
```