### PR TITLE
Meta2: Set `container_new` to the right tube

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -153,7 +153,7 @@ _init_notifiers(struct meta2_backend_s *m2, const char *ns)
 	STRING_STACKIFY(url);
 
 	GError *err = NULL;
-	INIT(m2->notifier_container_created, oio_meta2_tube_content_created);
+	INIT(m2->notifier_container_created, oio_meta2_tube_container_new);
 	INIT(m2->notifier_container_deleted, oio_meta2_tube_container_deleted);
 	INIT(m2->notifier_container_state, oio_meta2_tube_container_state);
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Set `container_new` to `oio_meta2_tube_container_new`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 5.0.0.0a2.dev18
```
