### PR TITLE
Prevent installation of urllib3 1.25

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -9,6 +9,6 @@ PyYAML>=3.10,<4.0
 redis>=2.10.3,<4.0.0
 requests!=2.13.0,<3.0.0
 simplejson>=2.0.9,<4.0.0
-urllib3>=1.13.1,<2.0.0
+urllib3>=1.13.1,<1.25.0
 werkzeug>=0.9.1,<1.0.0
 zkpython<1.0.0


### PR DESCRIPTION
##### SUMMARY

Prevent urllib3 1.25 because some test environments are slower with this version.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.2.9.dev14
```