### PR TITLE
Rdir: Free error on missing options

### DIFF
--- a/rdir/rdir.c
+++ b/rdir/rdir.c
@@ -2620,6 +2620,8 @@ grid_main_configure(int argc, char **argv)
 	}
 
 	service_id = CFG("service_id");
+	if (err)
+		g_clear_error(&err);
 
 	gchar *cfg_ip = CFG("bind_addr");
 	STRING_STACKIFY(cfg_ip);
@@ -2636,6 +2638,8 @@ grid_main_configure(int argc, char **argv)
 	}
 
 	gchar *cfg_syslog = CFG("syslog_prefix");
+	if (err)
+		g_clear_error(&err);
 	STRING_STACKIFY(cfg_syslog);
 
 	g_key_file_free(gkf);


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since they are not mandatory we should just free the error.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->
 - rdir
##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 5.0.0.0a2.dev18
```