### PR TITLE
Few fixes around x-oio-req-id

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -146,7 +146,7 @@ class HttpApi(object):
 
         # Look for a request ID
         if 'reqid' in kwargs:
-            out_headers['X-oio-req-id'] = str(kwargs['reqid'])
+            out_headers[REQID_HEADER] = str(kwargs['reqid'])
 
         if len(out_headers.get(REQID_HEADER, '')) > STRLEN_REQID:
             out_headers[REQID_HEADER] = \

--- a/rawx/rawx.go
+++ b/rawx/rawx.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	HeaderNameOioReqId = "X-oio-req-id"
+	HeaderLenOioReqId  = 63
 	HeaderNameTransId  = "X-trans-id"
 	HeaderNameError    = "X-Error"
 )
@@ -111,7 +112,10 @@ func (rawx *rawxService) ServeHTTP(rep http.ResponseWriter, req *http.Request) {
 		rawxreq.reqid = req.Header.Get(HeaderNameTransId)
 	}
 	if len(rawxreq.reqid) > 0 {
-		rep.Header().Set(HeaderNameTransId, rawxreq.reqid)
+		if len(rawxreq.reqid) > HeaderLenOioReqId {
+			rawxreq.reqid = rawxreq.reqid[0:HeaderLenOioReqId]
+		}
+		rep.Header().Set(HeaderNameOioReqId, rawxreq.reqid)
 	} else {
 		// patch the reqid for pretty access log
 		rawxreq.reqid = "-"


### PR DESCRIPTION
##### SUMMARY

Our Python API was duplicating `x-oio-req-id` header when sending a request
The GO Rawx was not limited length of `req-id` to 63 chars and response was replying with deprecated `x-trans-id`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio
rawx

##### SDS VERSION
```
5.0.0.0a2.dev36
```
