### PR TITLE
Python API: recompute deadline after data upload success

### DIFF
--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -280,6 +280,7 @@ class ClusterWait(lister.Lister):
         min_score = parsed_args.score
         delay = parsed_args.delay
         deadline = now() + delay
+        descr = []
         exc_msg = ("Timeout ({0}s) while waiting for the services to get a "
                    "score >= {1}, still {2} are not.")
 
@@ -290,7 +291,13 @@ class ClusterWait(lister.Lister):
 
         def check_deadline():
             if now() > deadline:
-                raise Exception(exc_msg.format(delay, min_score, ko))
+                msg = exc_msg.format(delay, min_score, ko)
+                for srv in descr:
+                    if srv['score'] < min_score:
+                        self.log.warn(
+                            "%s %s %s",
+                            srv['type'], srv['id'], srv['score'])
+                raise Exception(msg)
 
         while True:
             descr = []

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -352,3 +352,13 @@ def timeout_to_deadline(timeout, now=None):
     if now is None:
         now = monotonic_time()
     return now + timeout
+
+
+def set_deadline_from_read_timeout(kwargs, force=False):
+    """
+    Compute a deadline from a read timeout, and set it in a keyword
+    argument dictionary if there is none (or `force` is set).
+    """
+    to = kwargs.get('read_timeout')
+    if to is not None and (force or 'deadline' not in kwargs):
+        kwargs['deadline'] = timeout_to_deadline(to)


### PR DESCRIPTION
##### SUMMARY
At some point in the upload process, we know that the metadata server is fine (it provided us with chunk addresses) and the client is still listening (he just uploaded all data). It seems a good idea to postpone the deadline (because it is computed from the client-provided timeout).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 5.0.0.0b1.dev7
```


##### ADDITIONAL INFORMATION
This modification will allow slow uploads to take longer than `read_timeout`, provided the client is still sending data from time to time.