### PR TITLE
sqliterepo: reset MASTER elections on ZOO_SESSION_EVENT

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -243,16 +243,25 @@ void oio_ext_set_reqid (const char *reqid) {
 		g_strlcpy(l->reqid, reqid, sizeof(l->reqid));
 }
 
-void oio_ext_set_random_reqid (void) {
+void oio_ext_set_random_reqid(void) {
+	oio_ext_set_prefixed_random_reqid(NULL);
+}
+
+void oio_ext_set_prefixed_random_reqid(const char *prefix) {
 	struct {
 		pid_t pid:16;
 		guint8 buf[14];
 	} bulk;
 	bulk.pid = getpid();
-	oio_buf_randomize(bulk.buf, sizeof(bulk.buf));
 
 	char hex[33];
-	oio_str_bin2hex((guint8*)&bulk, sizeof(bulk), hex, sizeof(hex));
+	size_t plen = 0;
+	if (prefix != NULL) {
+		plen = MIN(strlen(prefix), 16);
+		strncpy(hex, prefix, plen);
+	}
+	oio_buf_randomize(bulk.buf, sizeof(bulk.buf) - plen/2);
+	oio_str_bin2hex((guint8*)&bulk, sizeof(bulk), hex+plen, sizeof(hex) - plen);
 	oio_ext_set_reqid(hex);
 }
 

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -71,6 +71,10 @@ void oio_ext_set_reqid (const char *reqid);
 /** Calls oio_ext_set_reqid() with a randomly generated string */
 void oio_ext_set_random_reqid (void);
 
+/** Calls oio_ext_set_reqid() with a randomly generated string,
+ * with the specified prefix. */
+void oio_ext_set_prefixed_random_reqid(const char *prefix);
+
 /* DO NOT FREE ... In facts, DO NOT EVEN CONSIDER USING THIS FUNCTION!
  * Gets the PRNG associated to the local thread, and allocates on if none
  * already present. Returns THE pointer locally stored. Freeing it will break

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -555,6 +555,12 @@ sqlx_sync_awget_siblings (struct sqlx_sync_s *ss, const char *path,
 #endif
 }
 
+int
+sqlx_sync_uses_handle(struct sqlx_sync_s *ss, zhandle_t *zh)
+{
+	return ss? ss->zh == zh: FALSE;
+}
+
 /* -------------------------------------------------------------------------- */
 
 static void _direct_destroy (struct sqlx_peering_s *self);

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -105,6 +105,10 @@ void sqlx_sync_set_prefix(struct sqlx_sync_s *ss, const gchar *prefix);
 
 void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
 
+/** Tell if the current synchronizer handle is using the specified
+ * Zookeeper handle. */
+int sqlx_sync_uses_handle(struct sqlx_sync_s *ss, zhandle_t *zh);
+
 /* -------------------------------------------------------------------------- */
 
 struct sqlx_name_s;


### PR DESCRIPTION
##### SUMMARY
A long time ago, we used to reset all elections on such Zookeeper event. We stopped doing this when we started to use several connections to Zookeeper, because it seemed a bad idea to reset everything on a single connection failure. Unfortunately, this leads to elections staying forever in the same state
while their Zookeeper node has vanished.

Now, after getting an unbound (no path is provided) ZOO_SESSION_EVENT, we will reset all elections in the master state, to avoid any infamous "double master" situations.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- sqliterepo
- core

##### SDS VERSION
```
openio 4.4.4.dev5
```
