### PR TITLE
Python API: enable TCP_CORK, avoid buffer copies

### DIFF
--- a/oio/common/http_eventlet.py
+++ b/oio/common/http_eventlet.py
@@ -78,6 +78,13 @@ class CustomHttpConnection(HTTPConnection):
         self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return conn
 
+    def set_cork(self, enabled=True):
+        """
+        Enable or disable TCP_CORK on the underlying socket.
+        """
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_CORK,
+                             1 if enabled else 0)
+
     def putrequest(self, method, url, skip_host=0, skip_accept_encoding=0):
         self._method = method
         self._path = url

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -27,6 +27,9 @@ def set_http_requests(cb):
             self.req = req
             self.resp = None
 
+        def set_cork(self, enabled=False):
+            pass
+
         def getresponse(self):
             self.resp = cb(self.req)
             return self.resp
@@ -120,6 +123,9 @@ def fake_http_connect(*status_iter, **kwargs):
         def send(self, data):
             if self.cb_body:
                 self.cb_body(self.conn_id, data)
+
+        def set_cork(self, enabled=False):
+            pass
 
         def close(self):
             self.closed = True


### PR DESCRIPTION
##### SUMMARY
- Enable TCP_CORK on sockets towards rawx services.
- Avoid CPU-consuming buffer copies during chunk upload.
- Implement profiling facilities in `openio` CLI.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.4.4.dev10
```
