### PR TITLE
[WIP] oio: Allow to defer the EC computation to a thread pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,8 @@ set(ZK_INCLUDE_DIRS "${DEFAULT_INCLUDE_DIRS}/zookeeper")
 pkg_search_module(JSONC json json-c)
 pkg_check_modules(GLIB2 REQUIRED glib-2.0 gthread-2.0 gmodule-2.0)
 pkg_check_modules(CURL curl libcurl)
+pkg_check_modules(PYTHON REQUIRED python)
+pkg_check_modules(EC REQUIRED erasurecode-1)
 
 if (NOT SDK_ONLY)
 pkg_check_modules(APR REQUIRED apr-1)
@@ -417,6 +419,7 @@ link_directories(${GLIB2_LIBRARY_DIRS})
 
 add_subdirectory(./core)
 add_subdirectory(./tests/unit)
+add_subdirectory(./ecp)
 
 if (NOT SDK_ONLY)
 add_subdirectory(./metautils/lib)

--- a/ecp/CMakeLists.txt
+++ b/ecp/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_definitions(-DG_LOG_DOMAIN="oio.ecp")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+
+include_directories(BEFORE
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${CMAKE_SOURCE_DIR}
+	${CMAKE_CURRENT_BINARY_DIR}
+	${CMAKE_BINARY_DIR})
+
+include_directories(AFTER
+		${GLIB2_INCLUDE_DIRS}
+		${CURL_INCLUDE_DIRS}
+		${JSONC_INCLUDE_DIRS})
+
+link_directories(
+		${GLIB2_LIBRARY_DIRS}
+		${CURL_LIBRARY_DIRS}
+		${JSONC_LIBRARY_DIRS})
+
+add_library(oioecp SHARED ecp.c)
+
+set_target_properties(oioecp PROPERTIES PUBLIC_HEADER "oio_core.h" VERSION 0.0.0 SOVERSION 0)
+target_link_libraries(oioecp
+		${JSONC_LIBRARIES} ${GLIB2_LIBRARIES}
+		${EC_LIBRARIES} ${PYTHON_LIBRARIES})
+
+
+install(TARGETS oioecp
+		LIBRARY DESTINATION ${LD_LIBDIR}
+		PUBLIC_HEADER DESTINATION include)
+

--- a/ecp/CMakeLists.txt
+++ b/ecp/CMakeLists.txt
@@ -19,7 +19,7 @@ link_directories(
 
 add_library(oioecp SHARED ecp.c)
 
-set_target_properties(oioecp PROPERTIES PUBLIC_HEADER "oio_core.h" VERSION 0.0.0 SOVERSION 0)
+set_target_properties(oioecp PROPERTIES VERSION 0.0.0 SOVERSION 0)
 target_link_libraries(oioecp
 		${JSONC_LIBRARIES} ${GLIB2_LIBRARIES}
 		${EC_LIBRARIES} ${PYTHON_LIBRARIES})

--- a/ecp/ecp.c
+++ b/ecp/ecp.c
@@ -1,0 +1,302 @@
+/*
+OpenIO SDS core library
+Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+#include <sys/uio.h>
+#include <sys/eventfd.h>
+
+#include <glib.h>
+#include <liberasurecode/erasurecode.h>
+#include <python2.7/Python.h>
+
+#include "ecp.h"
+
+#define MAXBLOCKS 24
+
+const int algo_JERASURE_RS_VAND = EC_BACKEND_JERASURE_RS_VAND;
+const int algo_JERASURE_RS_CAUCHY = EC_BACKEND_JERASURE_RS_CAUCHY;
+const int algo_ISA_L_RS_VAND = EC_BACKEND_ISA_L_RS_VAND;
+const int algo_ISA_L_RS_CAUCHY = EC_BACKEND_ISA_L_RS_CAUCHY;
+const int algo_SHSS = EC_BACKEND_SHSS;
+const int algo_LIBERASURECODE_RS_VAND = EC_BACKEND_LIBERASURECODE_RS_VAND;
+const int algo_LIBPHAZR = EC_BACKEND_LIBPHAZR;
+
+struct ec_handle_s {
+	ec_backend_id_t backend;
+	int k;
+	int m;
+	int instance;
+};
+
+struct ecp_ctx_s {
+	/* Cache of open liberasurecode handles */
+	GArray *array_ec_handles;
+	GMutex lock_ec_handles;
+};
+
+enum ecp_action_e {
+	THP_NOTSET = 0,
+	THP_ENCODE = 1,
+	THP_DECODE = 2
+};
+
+struct ecp_job_s {
+	struct iovec original;
+	struct iovec encoded[24];
+
+	int algo;
+	int k;
+	int m;
+	int status;
+
+	int fd_wakeup;
+
+	guint64 fragment_size;
+	enum ecp_action_e action;
+};
+
+static struct ecp_ctx_s ecp_ctx = {};
+
+static GThreadPool *thp = NULL;
+
+static void __attribute__((constructor)) ecp_init(void);
+
+static void __attribute__((destructor)) ecp_fini(void);
+
+static void _action_common(struct ecp_job_s *job, struct ecp_ctx_s *ctx);
+
+
+static void ecp_init(void) {
+	thp = g_thread_pool_new((GFunc)_action_common, &ecp_ctx, 1, TRUE, NULL);
+	g_assert_nonnull(thp);
+
+	g_mutex_init(&ecp_ctx.lock_ec_handles);
+	ecp_ctx.array_ec_handles =
+		g_array_sized_new(FALSE, FALSE, sizeof(struct ec_handle_s), 16);
+}
+
+static void ecp_fini(void) {
+	g_thread_pool_free(thp, FALSE, FALSE);
+	thp = NULL;
+
+	g_mutex_lock(&ecp_ctx.lock_ec_handles);
+	g_mutex_unlock(&ecp_ctx.lock_ec_handles);
+	g_mutex_clear(&ecp_ctx.lock_ec_handles);
+
+	while (ecp_ctx.array_ec_handles->len > 0) {
+		const guint last_idx = ecp_ctx.array_ec_handles->len - 1;
+		struct ec_handle_s *last = &g_array_index(
+				ecp_ctx.array_ec_handles, struct ec_handle_s, last_idx);
+		int rc = liberasurecode_instance_destroy(last->instance);
+		g_assert_cmpint(rc, ==, 0);
+		g_array_remove_index_fast(ecp_ctx.array_ec_handles, last_idx);
+	}
+}
+
+static void _job_ping(struct ecp_job_s *job) {
+	int64_t evt = 1;
+	(void) write(job->fd_wakeup, &evt, 8);
+}
+
+static int _get_instance(struct ecp_job_s *job, struct ecp_ctx_s *ctx) {
+	g_mutex_lock(&ctx->lock_ec_handles);
+	for (guint i=0; i<ctx->array_ec_handles->len ;i++) {
+		struct ec_handle_s *h = &g_array_index(
+				ctx->array_ec_handles, struct ec_handle_s, i);
+		int b = (int) h->backend;
+		if (b == job->algo && h->k == job->k && h->m == job->m) {
+			g_mutex_unlock(&ctx->lock_ec_handles);
+			return h->instance;
+		}
+	}
+
+	struct ec_args ea = {
+		.k = job->k, .m = job->m,
+		.w = 8, .hd = job->m,
+		.ct = CHKSUM_CRC32
+	};
+	int instance = liberasurecode_instance_create(job->algo, &ea);
+
+	if (instance >= 0) {
+		struct ec_handle_s h = {};
+		h.backend = job->algo;
+		h.k = ea.k;
+		h.m = ea.m;
+		h.instance = instance;
+		g_array_append_vals(ctx->array_ec_handles, &h, 1);
+	}
+
+	g_mutex_unlock(&ctx->lock_ec_handles);
+	return instance;
+}
+
+static void _action_encode(struct ecp_job_s *job, struct ecp_ctx_s *ctx) {
+	char **data = NULL, **parity = NULL;
+	int instance = _get_instance(job, ctx);
+
+	int rc = liberasurecode_encode(instance,
+			job->original.iov_base, job->original.iov_len,
+			&data, &parity, &job->fragment_size);
+	job->status = rc;
+
+	if (rc == 0) {
+		int i = 0;
+		for (int j=0; j<job->k ;j++,i++) {
+			job->encoded[i].iov_base = data[j];
+			job->encoded[i].iov_len = job->fragment_size;
+			data[j] = NULL;
+		}
+		for (int j=0; j<job->m ;j++,i++) {
+			job->encoded[i].iov_base = parity[j];
+			job->encoded[i].iov_len = job->fragment_size;
+			parity[j] = NULL;
+		}
+		rc = liberasurecode_encode_cleanup(instance, data, parity);
+		g_assert_cmpint(rc, ==, 0);
+	}
+
+	return _job_ping(job);
+}
+
+static void _action_decode(struct ecp_job_s *job, struct ecp_ctx_s *ctx) {
+	int instance = _get_instance(job, ctx);
+	(void) instance;
+	job->status = -1;
+	return _job_ping(job);
+}
+
+static void _action_common(struct ecp_job_s *job, struct ecp_ctx_s *ctx) {
+	g_assert_nonnull(job);
+	g_assert_nonnull(ctx);
+	switch (job->action) {
+		case THP_ENCODE:
+			return _action_encode(job, ctx);
+		case THP_DECODE:
+			return _action_decode(job, ctx);
+		default:
+			job->status = G_MININT;
+			return _job_ping(job);
+	}
+}
+
+static gboolean _job_check(struct ecp_job_s *job) {
+	switch (job->algo) {
+		case EC_BACKEND_JERASURE_RS_VAND:
+		case EC_BACKEND_JERASURE_RS_CAUCHY:
+		case EC_BACKEND_FLAT_XOR_HD:
+		case EC_BACKEND_ISA_L_RS_VAND:
+		case EC_BACKEND_SHSS:
+		case EC_BACKEND_LIBERASURECODE_RS_VAND:
+		case EC_BACKEND_ISA_L_RS_CAUCHY:
+		case EC_BACKEND_LIBPHAZR:
+			break;
+		default:
+			return FALSE;
+	}
+
+	if (job->k <= 0 || job->m <= 0)
+		return FALSE;
+	if (job->k + job->m > MAXBLOCKS)
+		return FALSE;
+	if (job->m > 6)
+		return FALSE;
+
+	if (job->action == THP_ENCODE) {
+		if (!job->original.iov_base || !job->original.iov_len)
+			return FALSE;
+	} else if (job->action == THP_DECODE) {
+		/* No check yet on the number of blocs.
+		 * Some algorithms accept to decode with less than K */
+	} else {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+struct ecp_job_s * ecp_job_init(int algo, int k, int m) {
+	struct ecp_job_s *h = g_malloc0(sizeof(*h));
+	h->algo = algo;
+	h->k = k;
+	h->m = m;
+	h->status = -1;
+	h->fd_wakeup = eventfd(0, EFD_SEMAPHORE);
+	return h;
+}
+
+int ecp_job_status(struct ecp_job_s *job) {
+	g_assert_nonnull(job);
+	return job->status;
+}
+
+int ecp_job_fd(struct ecp_job_s *job) {
+	g_assert_nonnull(job);
+	return job->fd_wakeup;
+}
+
+void ecp_job_close(struct ecp_job_s *job) {
+	if (!job)
+		return;
+
+	if (job->fd_wakeup >= 0) {
+		close(job->fd_wakeup);
+		job->fd_wakeup = -1;
+	}
+
+	/* TODO(jfs): memory cleanup */
+
+	g_free(job);
+}
+
+static void _submit(struct ecp_job_s *job, enum ecp_action_e action) {
+	g_assert_nonnull(job);
+	job->action = action;
+	if (_job_check(job)) {
+		g_thread_pool_push(thp, job, NULL);
+	} else {
+		job->status = EINVAL;
+		return _job_ping(job);
+	}
+}
+
+void ecp_job_encode(struct ecp_job_s *job) {
+	return _submit(job, THP_ENCODE);
+}
+
+void ecp_job_decode(struct ecp_job_s *job) {
+	return _submit(job, THP_DECODE);
+}
+
+
+void ecp_job_set_original(struct ecp_job_s *job, void *base, int len) {
+	g_assert_nonnull(job);
+	job->original.iov_base = base;
+	job->original.iov_len = len;
+}
+
+PyObject* ecp_job_get_fragments(struct ecp_job_s *job) {
+	g_assert_nonnull(job);
+	g_assert_cmpint(job->action, ==, THP_ENCODE);
+	const int max = job->k + job->m;
+	PyObject *out = PyTuple_New(max);
+	for (int i=0; i<max ;i++) {
+		PyObject *buf = PyBuffer_FromMemory(
+				job->encoded[i].iov_base, job->encoded[i].iov_len);
+		PyTuple_SetItem(out, i, buf);
+	}
+	return out;
+}

--- a/ecp/ecp.h
+++ b/ecp/ecp.h
@@ -1,0 +1,62 @@
+/*
+OpenIO SDS core library
+Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library.
+*/
+
+/**
+ * Deferred EC computations.
+ *
+ * This API is for people who know what they are doing.
+ */
+
+#ifndef OIO_SDS__core__oioecp_h
+# define OIO_SDS__core__oioecp_h 1
+
+extern const int algo_JERASURE_RS_VAND;
+extern const int algo_JERASURE_RS_CAUCHY;
+extern const int algo_ISA_L_RS_VAND;
+extern const int algo_ISA_L_RS_CAUCHY;
+extern const int algo_SHSS;
+extern const int algo_LIBERASURECODE_RS_VAND;
+extern const int algo_LIBPHAZR;
+
+struct ecp_job_s;
+
+/* Allocate and prepare a job structure */
+struct ecp_job_s * ecp_job_init(int algo, int k, int m);
+
+void ecp_job_set_original(struct ecp_job_s *job, void *base, int len);
+
+PyObject* ecp_job_get_fragments(struct ecp_job_s *job);
+
+/* Return a file descriptor you just have to read on to wait for the
+ * job's completion. */
+int ecp_job_fd(struct ecp_job_s *job);
+
+/* Return the status of the defered liberasurecode call */
+int ecp_job_status(struct ecp_job_s *job);
+
+/* Free the job structure and its internal resources.
+ * The just must be terminated. */
+void ecp_job_close(struct ecp_job_s *job);
+
+/* Submit an encoding job */
+void ecp_job_encode(struct ecp_job_s *job);
+
+/* Submit a decoding job */
+void ecp_job_decode(struct ecp_job_s *job);
+
+#endif  /* OIO_SDS__core__oioecp_h */

--- a/ecp/ecp.h
+++ b/ecp/ecp.h
@@ -25,14 +25,6 @@ License along with this library.
 #ifndef OIO_SDS__core__oioecp_h
 # define OIO_SDS__core__oioecp_h 1
 
-extern const int algo_JERASURE_RS_VAND;
-extern const int algo_JERASURE_RS_CAUCHY;
-extern const int algo_ISA_L_RS_VAND;
-extern const int algo_ISA_L_RS_CAUCHY;
-extern const int algo_SHSS;
-extern const int algo_LIBERASURECODE_RS_VAND;
-extern const int algo_LIBPHAZR;
-
 struct ecp_job_s;
 
 /* Allocate and prepare a job structure */

--- a/oio/common/storage_method.py
+++ b/oio/common/storage_method.py
@@ -15,6 +15,7 @@
 
 import sys
 from oio.common import exceptions
+from oio.ecp import OioEcDriver
 
 try:
     from pyeclib.ec_iface import ECDriver, ECDriverError
@@ -23,11 +24,6 @@ except ImportError as err:
 
     class ECDriverError(RuntimeError):
         pass
-
-    class ECDriver(object):
-        """Dummy wrapper for ECDriver, when erasure-coding is not available."""
-        def __init__(self, *_args, **_kwargs):
-            raise ECDriverError(EC_MSG)
 
 
 EC_SEGMENT_SIZE = 1048576
@@ -168,8 +164,10 @@ class ECStorageMethod(StorageMethod):
         self._ec_type = ec_type
 
         try:
-            self.driver = ECDriver(k=ec_nb_data, m=ec_nb_parity,
-                                   ec_type=ec_type)
+            self.driver = OioEcDriver(k=ec_nb_data, m=ec_nb_parity,
+                                      ec_type=ec_type)
+            #self.driver = ECDriver(k=ec_nb_data, m=ec_nb_parity,
+            #                       ec_type=ec_type)
         except ECDriverError as exc:
             msg = "'%s' (%s: %s) Check erasure code packages." % (
                 ec_type, exc.__class__.__name__, exc)

--- a/oio/common/storage_method.py
+++ b/oio/common/storage_method.py
@@ -28,6 +28,9 @@ except ImportError as err:
 
 EC_SEGMENT_SIZE = 1048576
 
+# Set to True to use a thread pool (oio.ecp) to compute the EC strips
+EC_SYNC = True
+
 
 def parse_chunk_method(chunk_method):
     param_list = dict()
@@ -164,10 +167,12 @@ class ECStorageMethod(StorageMethod):
         self._ec_type = ec_type
 
         try:
-            self.driver = OioEcDriver(k=ec_nb_data, m=ec_nb_parity,
-                                      ec_type=ec_type)
-            #self.driver = ECDriver(k=ec_nb_data, m=ec_nb_parity,
-            #                       ec_type=ec_type)
+            if EC_SYNC:
+                self.driver = ECDriver(k=ec_nb_data, m=ec_nb_parity,
+                                       ec_type=ec_type)
+            else:
+                self.driver = OioEcDriver(k=ec_nb_data, m=ec_nb_parity,
+                                          ec_type=ec_type)
         except ECDriverError as exc:
             msg = "'%s' (%s: %s) Check erasure code packages." % (
                 ec_type, exc.__class__.__name__, exc)

--- a/oio/ecp/__init__.py
+++ b/oio/ecp/__init__.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+from os import read
+from ctypes import CDLL, c_int, c_void_p, py_object
+
+
+__author__ = "jfsmig"
+
+
+# Prepare the env
+_lib = CDLL('liboioecp.so.0')
+_lib.ecp_job_init.argtypes = (c_int, c_int, c_int)
+_lib.ecp_job_init.restype = c_void_p
+_lib.ecp_job_fd.argtypes = (c_void_p,)
+_lib.ecp_job_fd.restype = c_int
+_lib.ecp_job_status.argtypes = (c_void_p,)
+_lib.ecp_job_status.restype = c_int
+_lib.ecp_job_encode.argtypes = (c_void_p,)
+_lib.ecp_job_decode.argtypes = (c_void_p,)
+_lib.ecp_job_close.argtypes = (c_void_p,)
+_lib.ecp_job_set_original.argtypes = (c_void_p, c_void_p, c_int)
+_lib.ecp_job_get_fragments.argtypes = (c_void_p, )
+_lib.ecp_job_get_fragments.restype = py_object
+
+
+# Export one variable per algorithm
+algo_LIBERASURECODE_RS_VAND = c_int.in_dll(_lib, "algo_LIBERASURECODE_RS_VAND")
+algo_JERASURE_RS_VAND = c_int.in_dll(_lib, "algo_JERASURE_RS_VAND")
+algo_JERASURE_RS_CAUCHY = c_int.in_dll(_lib, "algo_JERASURE_RS_CAUCHY")
+algo_ISA_L_RS_VAND = c_int.in_dll(_lib, "algo_ISA_L_RS_VAND")
+algo_ISA_L_RS_CAUCHY = c_int.in_dll(_lib, "algo_ISA_L_RS_CAUCHY")
+algo_SHSS = c_int.in_dll(_lib, "algo_SHSS")
+algo_LIBPHAZR = c_int.in_dll(_lib, "algo_LIBPHAZR")
+
+
+def encode(algo, k, m, data):
+    """
+    Apply the given EC algorithm and return the fragments.
+    """
+    job = _lib.ecp_job_init(algo, k, m)
+    _lib.ecp_job_set_original(job, data, len(data))
+    try:
+        _lib.ecp_job_encode(job)
+        fd = _lib.ecp_job_fd(job)
+        read(fd, 8)
+        if 0 == _lib.ecp_job_status(job):
+            return _lib.ecp_job_get_fragments(job)
+        raise Exception("EC encode failure")
+    finally:
+        _lib.ecp_job_close(job)
+
+
+class ECDriver(object):
+    """Mimic the pyeclib driver interface"""
+
+    def __init__(self, k=1, m=1, ec_type=None):
+        self.k = k
+        self.m = m
+        self.algo = ec_type
+
+    def min_parity_fragments_needed(self):
+        return 0
+
+    def get_segment_info(self, size, _ignored):
+        # return {"fragment_size": 0}
+        raise Exception("NYI")
+
+    def encode(self, data):
+        return encode(self.algo, k, m, data)
+
+    def decode(self, fragments):
+        raise Exception("NYI")
+
+    def reconstruct(self, fragments, missing):
+        raise Exception("NYI")

--- a/oio/ecp/__init__.py
+++ b/oio/ecp/__init__.py
@@ -64,7 +64,6 @@ def encode(algo, k, m, data):
         _lib.ecp_job_encode(job)
         fd = _lib.ecp_job_fd(job)
         done = False
-        a = 0
         # Loop until the non-blocking FD, loop until we have errno=EAGAIN
         while not done:
             # create a listener on fd and swithc to another greenlet
@@ -92,4 +91,3 @@ class OioEcDriver(ECDriver):
 
     def encode(self, data):
         return encode(self.ec_type.value, self.k, self.m, data)
-

--- a/tools/ecp-tool.py
+++ b/tools/ecp-tool.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python
 
-from oio import ecp
+import eventlet
+import traceback
+from oio.ecp import ECDriver
+
+def _concurrent_test():
+    for i in range(10):
+        print "concurent_function"
+
+def print_result(fn, data):
+        try:
+            fragments = fn(data)
+            #print "OK", len(fragments)
+        except Exception as ex:
+            traceback.print_exc()
 
 def main():
-    for algo in (ecp.algo_LIBERASURECODE_RS_VAND,
-                 ecp.algo_JERASURE_RS_VAND,
-                 ecp.algo_JERASURE_RS_CAUCHY,
-                 ecp.algo_ISA_L_RS_VAND,
-                 ecp.algo_ISA_L_RS_CAUCHY,
-                 ecp.algo_SHSS,
-                 ecp.algo_LIBPHAZR):
-        try:
-            f = ecp.encode(algo, 6, 3, "plop")
-            print "OK", repr(f)
-        except Exception as ex:
-            print "ERROR", repr(ex)
+    driver = ECDriver(ec_type="liberasurecode_rs_vand", k=6, m=3)
+    pool = eventlet.GreenPool()
+    data = "0" * 1024 * 1024
+    for i in range(1024):
+        pool.spawn(print_result, driver.encode, data)
+    pool.waitall()
 
 if __name__ == '__main__':
     main()

--- a/tools/ecp-tool.py
+++ b/tools/ecp-tool.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+from oio import ecp
+
+def main():
+    for algo in (ecp.algo_LIBERASURECODE_RS_VAND,
+                 ecp.algo_JERASURE_RS_VAND,
+                 ecp.algo_JERASURE_RS_CAUCHY,
+                 ecp.algo_ISA_L_RS_VAND,
+                 ecp.algo_ISA_L_RS_CAUCHY,
+                 ecp.algo_SHSS,
+                 ecp.algo_LIBPHAZR):
+        try:
+            f = ecp.encode(algo, 6, 3, "plop")
+            print "OK", repr(f)
+        except Exception as ex:
+            print "ERROR", repr(ex)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Avoid mixing the I/O intensive workloads of the greenlet-based main thread of python, with the CPU intensive tasks of the EC computation. A GLib-2.0 GThreadPool is used and (linux specific) eventfd synchronization used between them.

This is useful when more than one upload operation happens in the main python thread, that is why the feature has to be explicitly turned on (set `oio.api.storage_method.EC_SYNC` to `False`).

**TODO**: removed the explicit coroutine switching that will happen in #1787 that becomes superfluous (if not counter-productive).
**TODO**: manage errors with adequate exceptions

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`oio`, `ecp`

##### SDS VERSION
`openio 4.4.4.dev14`
