### PR TITLE
Enrich performance data display

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -38,7 +38,8 @@ class AccountClient(HttpApi):
         account service endpoint (if not provided at instantiation)
         :type refresh_interval: `float` seconds
         """
-        super(AccountClient, self).__init__(endpoint=endpoint, **kwargs)
+        super(AccountClient, self).__init__(
+            endpoint=endpoint, service_type='account-service', **kwargs)
         self.logger = logger or get_logger(conf)
         self.cs = ConscienceClient(conf, endpoint=proxy_endpoint,
                                    logger=self.logger, **kwargs)

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -27,7 +27,7 @@ from oio.common.http import parse_content_type,\
     parse_content_range, ranges_from_http_header, http_header_from_ranges
 from oio.common.http_eventlet import http_connect
 from oio.common.utils import GeneratorIO, group_chunk_errors, \
-    deadline_to_timeout, set_deadline_from_read_timeout
+    deadline_to_timeout, monotonic_time, set_deadline_from_read_timeout
 from oio.common import green
 from oio.common.storage_method import STORAGE_METHODS
 
@@ -198,7 +198,7 @@ class ChunkReader(object):
 
     def __init__(self, chunk_iter, buf_size, headers,
                  connection_timeout=None, read_timeout=None,
-                 align=False, **_kwargs):
+                 align=False, perfdata=None, **_kwargs):
         """
         :param chunk_iter:
         :param buf_size: size of the read buffer
@@ -222,6 +222,7 @@ class ChunkReader(object):
         self.connection_timeout = connection_timeout or CONNECTION_TIMEOUT
         self.read_timeout = read_timeout or CHUNK_TIMEOUT
         self._resp_by_chunk = dict()
+        self.perfdata = perfdata
 
     @property
     def reqid(self):
@@ -282,8 +283,16 @@ class ChunkReader(object):
             with green.ConnectionTimeout(self.connection_timeout):
                 raw_url = chunk.get("real_url", chunk["url"])
                 parsed = urlparse(raw_url)
+                if self.perfdata is not None:
+                    connect_start = monotonic_time()
                 conn = http_connect(parsed.netloc, 'GET', parsed.path,
                                     self.request_headers)
+                if self.perfdata is not None:
+                    connect_end = monotonic_time()
+                    perfdata_rawx = self.perfdata.setdefault('rawx', dict())
+                    perfdata_rawx[chunk['url']] = \
+                        perfdata_rawx.get(chunk['url'], 0.0) \
+                        + connect_end - connect_start
             with green.OioTimeout(self.read_timeout):
                 source = conn.getresponse()
                 source.conn = conn
@@ -402,10 +411,20 @@ class ChunkReader(object):
         bytes_consumed = 0
         count = 0
         buf = ''
+        if self.perfdata is not None:
+            perfdata_rawx = self.perfdata.setdefault('rawx', dict())
+            url_chunk = chunk['url']
         while True:
             try:
                 with green.ChunkReadTimeout(self.read_timeout):
+                    if self.perfdata is not None:
+                        download_start = monotonic_time()
                     data = part.read(READ_CHUNK_SIZE)
+                    if self.perfdata is not None:
+                        download_end = monotonic_time()
+                        perfdata_rawx[url_chunk] = \
+                            perfdata_rawx.get(url_chunk, 0.0) \
+                            + download_end - download_start
                     count += 1
                     buf += data
             except (green.ChunkReadTimeout, IOError) as crto:
@@ -554,12 +573,13 @@ class MetachunkWriter(object):
     def __init__(self, storage_method=None, quorum=None,
                  chunk_checksum_algo='md5', reqid=None,
                  chunk_buffer_min=32768, chunk_buffer_max=262144,
-                 **_kwargs):
+                 perfdata=None, **_kwargs):
         self.storage_method = storage_method
         self._quorum = quorum
         if storage_method is None and quorum is None:
             raise ValueError('Missing storage_method or quorum')
         self.chunk_checksum_algo = chunk_checksum_algo
+        self.perfdata = perfdata
         self.reqid = reqid
         self._buffer_size_gen = exp_ramp_gen(chunk_buffer_min,
                                              chunk_buffer_max)
@@ -569,7 +589,8 @@ class MetachunkWriter(object):
         return {k: v for k, v in kwargs.items()
                 if k in ('chunk_checksum_algo',
                          'chunk_buffer_min',
-                         'chunk_buffer_max')}
+                         'chunk_buffer_max',
+                         'perfdata')}
 
     @property
     def quorum(self):

--- a/oio/api/replication.py
+++ b/oio/api/replication.py
@@ -20,10 +20,12 @@ import logging
 import hashlib
 from socket import error as SocketError
 from urlparse import urlparse
-from oio.common import exceptions as exc
-from oio.common.exceptions import SourceReadError
-from oio.common.http import headers_from_object_metadata
+
 from oio.api import io
+from oio.common.exceptions import OioTimeout, SourceReadError, \
+    SourceReadTimeout
+from oio.common.http import headers_from_object_metadata
+from oio.common.utils import monotonic_time
 from oio.common.constants import CHUNK_HEADERS
 from oio.common import green
 
@@ -58,7 +60,7 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
         self.read_timeout = read_timeout or io.CLIENT_TIMEOUT
         self.headers = headers or {}
 
-    def stream(self, source, size=None):
+    def stream(self, source, size):
         bytes_transferred = 0
         meta_chunk = self.meta_chunk
         if self.chunk_checksum_algo:
@@ -72,7 +74,7 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
         for chunk in meta_chunk:
             pile.spawn(self._connect_put, chunk)
 
-        for conn, chunk in [d for d in pile]:
+        for conn, chunk in pile:
             if not conn:
                 failed_chunks.append(chunk)
             else:
@@ -101,8 +103,8 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
                     with green.SourceReadTimeout(self.read_timeout):
                         try:
                             data = source.read(read_size)
-                        except (ValueError, IOError) as e:
-                            raise SourceReadError(str(e))
+                        except (ValueError, IOError) as err:
+                            raise SourceReadError(str(err))
                         if len(data) == 0:
                             for conn in current_conns:
                                 if not conn.failed:
@@ -129,13 +131,13 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
 
         except green.SourceReadTimeout as err:
             logger.warn('Source read timeout (reqid=%s): %s', self.reqid, err)
-            raise exc.SourceReadTimeout(err)
+            raise SourceReadTimeout(err)
         except SourceReadError as err:
             logger.warn('Source read error (reqid=%s): %s', self.reqid, err)
             raise
         except Timeout as to:
             logger.error('Timeout writing data (reqid=%s): %s', self.reqid, to)
-            raise exc.OioTimeout(to)
+            raise OioTimeout(to)
         except Exception:
             logger.exception('Exception writing data (reqid=%s)', self.reqid)
             raise
@@ -177,9 +179,17 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
             hdrs.update(self.headers)
 
             with green.ConnectionTimeout(self.connection_timeout):
+                if self.perfdata is not None:
+                    connect_start = monotonic_time()
                 conn = io.http_connect(
                     parsed.netloc, 'PUT', parsed.path, hdrs)
                 conn.set_cork(True)
+                if self.perfdata is not None:
+                    connect_end = monotonic_time()
+                    perfdata_rawx = self.perfdata.setdefault('rawx', dict())
+                    perfdata_rawx[chunk['url']] = \
+                        perfdata_rawx.get(chunk['url'], 0.0) \
+                        + connect_end - connect_start
                 conn.chunk = chunk
             return conn, chunk
         except (SocketError, Timeout) as err:
@@ -197,11 +207,15 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
         """
         Send data to an open connection, taking data blocks from `conn.queue`.
         """
+        conn.upload_start = None
         while True:
             data = conn.queue.get()
             if not conn.failed:
                 try:
                     with green.ChunkWriteTimeout(self.write_timeout):
+                        if self.perfdata is not None \
+                                and conn.upload_start is None:
+                            conn.upload_start = monotonic_time()
                         conn.send('%x\r\n' % len(data))
                         conn.send(data)
                         conn.send('\r\n')
@@ -222,6 +236,13 @@ class ReplicatedMetachunkWriter(io.MetachunkWriter):
         try:
             with green.ChunkWriteTimeout(self.write_timeout):
                 resp = conn.getresponse()
+                if self.perfdata is not None:
+                    upload_end = monotonic_time()
+                    perfdata_rawx = self.perfdata.setdefault('rawx', dict())
+                    url_chunk = conn.chunk['url']
+                    perfdata_rawx[url_chunk] = \
+                        perfdata_rawx.get(url_chunk, 0.0) \
+                        + upload_end - conn.upload_start
         except Timeout as err:
             resp = err
             logger.error('Failed to read response from %s (reqid=%s): %s',

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -63,8 +63,9 @@ def update_rawx_perfdata(func):
         res = func(self, *args, **kwargs)
         if perfdata is not None:
             req_end = utils.monotonic_time()
-            val = perfdata.get('rawx', 0.0) + req_end - req_start
-            perfdata['rawx'] = val
+            perfdata_rawx = perfdata.setdefault('rawx', dict())
+            total_rawx = perfdata_rawx.get('total', 0.0) + req_end - req_start
+            perfdata_rawx['total'] = total_rawx
         return res
     return _update_rawx_perfdata
 
@@ -98,7 +99,7 @@ class BlobClient(object):
                         else 'chunk_hash']
         writer = ReplicatedMetachunkWriter(
             meta, [chunk], FakeChecksum(checksum),
-            storage_method, quorum=1)
+            storage_method, quorum=1, perfdata=self.perfdata)
         writer.stream(data, None)
 
     @update_rawx_perfdata

--- a/oio/check_service/common.py
+++ b/oio/check_service/common.py
@@ -38,7 +38,7 @@ class CheckService(HttpApi):
         """
         Collect the list of hosts for a service type
         """
-        super(CheckService, self).__init__(**kwargs)
+        super(CheckService, self).__init__(service_type=service_type, **kwargs)
         self.ns = namespace
         self.service_type = service_type
         self.all_services = ConscienceClient(

--- a/oio/cli/common/shell.py
+++ b/oio/cli/common/shell.py
@@ -24,7 +24,9 @@ from cliff.app import App
 from oio import __version__ as oio_version
 from oio.cli.common.commandmanager import CommandManager
 from oio.cli.common.clientmanager import ClientManager, get_plugin_module
+from oio.common.json import json
 
+json.encoder.FLOAT_REPR = lambda o: format(o, '.6f')
 LOG = logging.getLogger(__name__)
 
 GROUP_LIST = ["account", "container", "object", "reference", "volume",
@@ -81,9 +83,10 @@ class OpenIOShell(App):
     def run(self, argv):
         try:
             res = super(OpenIOShell, self).run(argv)
-            pdata = self.client_manager.cli_conf().get('perfdata')
-            if pdata:
-                LOG.warn("Performance data: %s", pdata)
+            perfdata = self.client_manager.cli_conf().get('perfdata')
+            if perfdata:
+                LOG.warn("Performance data: %s",
+                         json.dumps(perfdata, sort_keys=True, indent=4))
             return res
         except Exception as e:
             LOG.error('Exception raised: ' + str(e))

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -76,8 +76,8 @@ class ProxyClient(HttpApi):
 
         self._request_attempts = request_attempts
 
-        super(ProxyClient, self).__init__(endpoint='/'.join(ep_parts),
-                                          **kwargs)
+        super(ProxyClient, self).__init__(
+            endpoint='/'.join(ep_parts), service_type='proxy', **kwargs)
 
     def _direct_request(self, method, url, headers=None, request_attempts=None,
                         **kwargs):

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -322,7 +322,7 @@ class RdirClient(HttpApi):
     }
 
     def __init__(self, conf, **kwargs):
-        super(RdirClient, self).__init__(**kwargs)
+        super(RdirClient, self).__init__(service_type='rdir', **kwargs)
         self.directory = DirectoryClient(conf, **kwargs)
         self.ns = conf['namespace']
         self._addr_cache = dict()


### PR DESCRIPTION
##### SUMMARY

Enrich perfdata when:
- requesting a service
- reading and writing an object

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- Python API
- CLI

##### SDS VERSION

```
openio 4.4.4.dev19
```

##### ADDITIONAL INFORMATION

```
$ openio object create toto /etc/magic --dump-perfdata
+-------+------+----------------------------------+--------+
| Name  | Size | Hash                             | Status |
+-------+------+----------------------------------+--------+
| magic |  111 | 272913026300E7AE9B5E2D51F138E674 | Ok     |
+-------+------+----------------------------------+--------+
Performance data: {
    "proxy": {
        "meta2": 0.007457,
        "resolve": 0.007463,
        "total": 0.049264
    },
    "rawx": {
        "ec": 0.000075,
        "http://127.0.0.1:6010/DE0E43B2C423D9FF1335B155A818F5E8A18FDAAEDAEBD71366906C148866526B": 0.008854,
        "http://127.0.0.1:6011/FE4C3DEBE825832BE78F3B8700DE5511A4BE4610FC88D9FC5B59A68B3641A994": 0.008322,
        "http://127.0.0.1:6012/0D5F2575F999695EC3C48E49057CF9E90C323DC46CDDF9C33713DD66AD7365B1": 0.008967,
        "http://127.0.0.1:6013/C59503C2A9664011018E8326E69C6E116CA657B333BE3B3A26AF58C22ECFB608": 0.006861,
        "http://127.0.0.1:6015/9A800AE389D9DC720C8A37FA5CAAA899B70ED883587DFB52BCA07FAA16255A23": 0.010464,
        "http://127.0.0.1:6018/5FA2C42BB211E528241786037A4391C9C5E8FC55825C009D265C2735BF211BE8": 0.006750,
        "http://127.0.0.1:6019/6BECBCA594319B5247CAE199F348946E6F7F0B5725D2836DDE68C03A00EEC3B3": 0.007201,
        "http://127.0.0.1:6020/A9D5B1B5344CA8350A98DE6CFD28A4800280DACA4AF6896DED669E6E7829DB13": 0.008090,
        "http://127.0.0.1:6021/DCE37B6A05CE586FE462B0C511BFE4FCD77442575A943E6DF657F895F4986B3E": 0.011369,
        "total": 0.017745
    }
}
$ openio object save toto magic --dump-perfdata
Performance data: {
    "proxy": {
        "meta2": 0.000607,
        "resolve": 0.001472,
        "total": 0.003384
    },
    "rawx": {
        "ec": 0.000002,
        "http://127.0.0.1:6010/DE0E43B2C423D9FF1335B155A818F5E8A18FDAAEDAEBD71366906C148866526B": 0.000234,
        "http://127.0.0.1:6011/FE4C3DEBE825832BE78F3B8700DE5511A4BE4610FC88D9FC5B59A68B3641A994": 0.001408,
        "http://127.0.0.1:6012/0D5F2575F999695EC3C48E49057CF9E90C323DC46CDDF9C33713DD66AD7365B1": 0.000677,
        "http://127.0.0.1:6018/5FA2C42BB211E528241786037A4391C9C5E8FC55825C009D265C2735BF211BE8": 0.001244,
        "http://127.0.0.1:6019/6BECBCA594319B5247CAE199F348946E6F7F0B5725D2836DDE68C03A00EEC3B3": 0.001747,
        "http://127.0.0.1:6020/A9D5B1B5344CA8350A98DE6CFD28A4800280DACA4AF6896DED669E6E7829DB13": 0.001055,
        "total": 0.004671
    },
    "ttfb": 0.008856,
    "ttlb": 0.009006
}
$ openio object delete toto magic --dump-perfdata
+-------+---------+
| Name  | Deleted |
+-------+---------+
| magic | True    |
+-------+---------+
Performance data: {
    "proxy": {
        "meta2": 0.003108,
        "resolve": 0.001374,
        "total": 0.005626
    }
}
```