### PR TITLE
Python API: ramp up upload buffer size

### DIFF
--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -75,7 +75,8 @@ class ObjectStorageApi(object):
         - `write_timeout`: `float`
     """
     TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
-    EXTRA_KEYWORDS = ('chunk_checksum_algo', 'autocreate')
+    EXTRA_KEYWORDS = ('chunk_checksum_algo', 'autocreate',
+                      'chunk_buffer_min', 'chunk_buffer_max')
 
     def __init__(self, namespace, logger=None, **kwargs):
         """


### PR DESCRIPTION
##### SUMMARY
Start small to minimize initial dead time and parallelize early,
then grow to avoid too much context switches.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.4.4.dev16
```


##### ADDITIONAL INFORMATION
Minimum and maximum of the ramp are configurable with `chunk_buffer_min` and `chunk_buffer_max`.