### PR TITLE
Python API: Replace Queue with LightQueue when sending data

### DIFF
--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -25,7 +25,7 @@ from eventlet import Queue, Timeout, GreenPile, GreenPool # noqa
 from eventlet.green import threading, socket # noqa
 from eventlet.green.httplib import HTTPConnection, HTTPResponse, _UNKNOWN # noqa
 from eventlet.event import Event # noqa
-from eventlet.queue import Empty, LifoQueue # noqa
+from eventlet.queue import Empty, LifoQueue, LightQueue # noqa
 
 eventlet.monkey_patch(os=False)
 


### PR DESCRIPTION
##### SUMMARY

Replace `eventlet.Queue` with `eventlet.queue.LightQueue` when sending data

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.4.4.dev17
```