### PR TITLE
Fix get_poolmanager parameters

### DIFF
--- a/oio/common/http_urllib3.py
+++ b/oio/common/http_urllib3.py
@@ -31,9 +31,14 @@ DEFAULT_BACKOFF = 0
 URLLIB3_REQUESTS_KWARGS = ('fields', 'headers', 'body', 'retries', 'redirect',
                            'assert_same_host', 'timeout', 'pool_timeout',
                            'release_conn', 'chunked')
-URLLIB3_POOLMANAGER_KWARGS = ('pool_connections', 'pool_maxsize',
-                              'max_retries', 'backoff_factor',
-                              'socket_options', 'source_address')
+URLLIB3_POOLMANAGER_KWARGS = (
+    # Integers
+    'pool_connections', 'pool_maxsize', 'max_retries', 'backoff_factor',
+    # List or tuple
+    'socket_options',
+    # Tuple
+    'source_address'
+)
 
 
 class SafePoolManager(urllib3.PoolManager):
@@ -74,10 +79,12 @@ def get_pool_manager(pool_connections=DEFAULT_POOLSIZE,
     if max_retries == DEFAULT_RETRIES:
         max_retries = urllib3.Retry(0, read=False)
     else:
-        max_retries = urllib3.Retry(total=max_retries,
-                                    backoff_factor=backoff_factor)
+        max_retries = urllib3.Retry(total=int(max_retries),
+                                    backoff_factor=int(backoff_factor))
     kw = {k: v for k, v in kwargs.items()
           if k in URLLIB3_POOLMANAGER_KWARGS[4:]}
+    pool_connections = int(pool_connections)
+    pool_maxsize = int(pool_maxsize)
     return SafePoolManager(num_pools=pool_connections,
                            maxsize=pool_maxsize, retries=max_retries,
                            block=False, **kw)

--- a/tests/unit/api/test_utils.py
+++ b/tests/unit/api/test_utils.py
@@ -16,6 +16,7 @@
 import unittest
 from oio.common.exceptions import DeadlineReached
 from oio.common.storage_functions import obj_range_to_meta_chunk_range
+from oio.common.http_urllib3 import get_pool_manager
 from oio.common.utils import deadline_to_timeout, \
     set_deadline_from_read_timeout, monotonic_time
 
@@ -165,3 +166,23 @@ class TestUtils(unittest.TestCase):
         # deadline is recomputed
         self.assertIn('deadline', kwargs)
         self.assertNotEqual(prev_deadline, kwargs['deadline'])
+
+    def test_pool_manager_parameters(self):
+        get_pool_manager(pool_connections=5)
+        get_pool_manager(pool_connections='5')
+        self.assertRaises(ValueError,
+                          get_pool_manager, pool_connections='cinq')
+        get_pool_manager(pool_maxsize=5)
+        get_pool_manager(pool_maxsize='5')
+        self.assertRaises(ValueError,
+                          get_pool_manager, pool_maxsize='cinq')
+        get_pool_manager(max_retries=5)
+        get_pool_manager(max_retries='5')
+        self.assertRaises(ValueError,
+                          get_pool_manager, max_retries='cinq')
+        get_pool_manager(backoff_factor=5, max_retries=5)
+        get_pool_manager(backoff_factor='5', max_retries=5)
+        self.assertRaises(ValueError,
+                          get_pool_manager,
+                          backoff_factor='cinq', max_retries=5)
+        get_pool_manager(ignored='ignored')


### PR DESCRIPTION
##### SUMMARY
When using oioswift, some configuration parameters come as strings instead of integers. Unfortunately, the magic cast has disappeared during a refactoring. This PR restores it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.5.0.0b1.dev7
```
