### PR TITLE
Python API: fix import of eventlet.Semaphore

### DIFF
--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -27,6 +27,7 @@ from eventlet.green import threading, socket # noqa
 from eventlet.green.httplib import HTTPConnection, HTTPResponse, _UNKNOWN # noqa
 from eventlet.event import Event # noqa
 from eventlet.queue import Empty, LifoQueue, LightQueue # noqa
+from eventlet.semaphore import Semaphore # noqa
 
 eventlet.monkey_patch(os=False)
 

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -19,7 +19,7 @@ Recursively check account, container, content and chunk integrity.
 
 
 from __future__ import print_function
-from oio.common.green import eventlet, Event, GreenPool, Queue, sleep
+from oio.common.green import Event, GreenPool, Queue, sleep, Semaphore
 
 import os
 import csv
@@ -171,7 +171,7 @@ class Checker(object):
 
         self.list_cache = {}
         self.running = {}
-        self.running_lock = eventlet.Semaphore(1)
+        self.running_lock = Semaphore(1)
         self.result_queue = Queue()
 
     def complete_target_from_chunk_metadata(self, target, xattr_meta):


### PR DESCRIPTION
##### SUMMARY

eventlet.Semaphore exists since version 0.20.1: https://github.com/eventlet/eventlet/commit/79292bd16a6a1384d8c3d11bcefa40eb53bbeae4#diff-e8a149cf9a6b76be0526ba05331438c5R42.
But Centos 7 uses version 0.18.4.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API
- CLI

##### SDS VERSION

```
openio 5.0.0.0b2.dev1
```