### PR TITLE
Revert "Admin CLI: Set the default verbose level to INFO"

### DIFF
--- a/oio/cli/admin/__init__.py
+++ b/oio/cli/admin/__init__.py
@@ -25,8 +25,6 @@ from oio.common.utils import request_id
 
 class OpenioAdminApp(CommonShell):
 
-    DEFAULT_VERBOSE_LEVEL = 2
-
     def __init__(self):
         super(OpenioAdminApp, self).__init__('openio.admin')
 


### PR DESCRIPTION
##### SUMMARY

Revert commit a896febd0e49ea78c2fdcbf8a2dc09dbeda4847a because the `openio-admin` commands are too verbose.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Admin CLI

##### SDS VERSION

```
openio 5.0.0.0b2.dev1
```