### PR TITLE
proxy: Fix the location comparison

### DIFF
--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -223,7 +223,7 @@ static oio_weight_t
 _patch_score(const oio_weight_t score,
 		const oio_location_t location, const oio_location_t reference)
 {
-	if (score <= 0 || !location)
+	if (score <= 0 || !location || !reference)
 		return score;
 	switch (oio_location_proximity(location, reference)) {
 		case OIO_LOC_PROX_VOLUME:


### PR DESCRIPTION
##### SUMMARY
Only perform the location comparison when both the proxy and the service have a location.

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`oio-proxy`

##### SDS VERSION
`openio 4.5.1.dev1`
