### PR TITLE
Python API: close all EC writers, whatever happens

### DIFF
--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -60,6 +60,11 @@ class ChunkReadTimeout(OioTimeout):
     msg_prefix = 'Chunk read '
 
 
+def eventlet_yield():
+    """Swith to another eventlet coroutine."""
+    sleep(0)
+
+
 def get_hub():
     return 'poll'
 


### PR DESCRIPTION
##### SUMMARY
EC writers used to leak open connections after `SourceReadError` or `SourceReadTimeout` exceptions (when the client unexpectedly closes the connection).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.5.1.dev1
```
