### PR TITLE
Configure event-agent connection pool

### DIFF
--- a/etc/event-handlers.conf-sample
+++ b/etc/event-handlers.conf-sample
@@ -50,6 +50,13 @@ pipeline = account_update volume_index
 
 [filter:content_cleaner]
 use = egg:oio#content_cleaner
+# Allowed parameters:
+# - backoff_factor (float, 0),
+# - concurrency (int, 3)
+# - max_retries (int, 0),
+# - pool_connections (int, 32),
+# - pool_maxsize (int, 32),
+# - timeout (float, 5.0)
 
 [filter:account_update]
 use = egg:oio#account_update

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -112,7 +112,9 @@ class BlobClient(object):
         return resp
 
     @ensure_request_id
-    def chunk_delete_many(self, chunks, cid=None, **kwargs):
+    def chunk_delete_many(self, chunks, cid=None,
+                          concurrency=PARALLEL_CHUNKS_DELETE,
+                          **kwargs):
         """
         :rtype: `list` of either `urllib3.response.HTTPResponse`
             or `urllib3.exceptions.HTTPError`, with an extra "chunk"
@@ -137,7 +139,7 @@ class BlobClient(object):
                 ex.chunk = chunk_
                 return ex
 
-        pile = GreenPile(PARALLEL_CHUNKS_DELETE)
+        pile = GreenPile(concurrency)
         for chunk in chunks:
             pile.spawn(__delete_chunk, chunk)
         resps = [resp for resp in pile if resp]

--- a/oio/common/http_urllib3.py
+++ b/oio/common/http_urllib3.py
@@ -80,7 +80,7 @@ def get_pool_manager(pool_connections=DEFAULT_POOLSIZE,
         max_retries = urllib3.Retry(0, read=False)
     else:
         max_retries = urllib3.Retry(total=int(max_retries),
-                                    backoff_factor=int(backoff_factor))
+                                    backoff_factor=float(backoff_factor))
     kw = {k: v for k, v in kwargs.items()
           if k in URLLIB3_POOLMANAGER_KWARGS[4:]}
     pool_connections = int(pool_connections)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -861,6 +861,13 @@ pipeline = account_update volume_index ${PRESERVE}
 use = egg:oio#content_cleaner
 key_file = ${KEY_FILE}
 
+# These values are changed only for testing purposes.
+# The default values are good for most use cases.
+concurrency = 4
+pool_connections = 16
+pool_maxsize = 16
+timeout = 4.5
+
 [filter:content_improve]
 use = egg:oio#notify
 tube = oio-improve
@@ -873,6 +880,8 @@ queue_url = ${QUEUE_URL}
 
 [filter:account_update]
 use = egg:oio#account_update
+connection_timeout=1.0
+read_timeout=15.0
 
 [filter:volume_index]
 use = egg:oio#volume_index


### PR DESCRIPTION
##### SUMMARY
Allow to configure the connection pool of the `content_cleaner` filter. This will help reducing the number of persistent connections to one service, while keeping at least one persistent connection to each service. If you see too many persistent connections, set:
- `pool_connections`: high value (ideally one per rawx service);
- `pool_maxsize`: low value (one per coroutine, `concurrency` in the main configuration file).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- event-agent

##### SDS VERSION
```
openio 4.5.2.dev6
```