### PR TITLE
Update max_versions of container from header (part 2)

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -1050,11 +1050,16 @@ meta2_backend_delete_alias(struct meta2_backend_s *m2b,
 	err = m2b_open(m2b, url, M2V2_OPEN_MASTERONLY|M2V2_OPEN_ENABLED, &sq3);
 	if (!err) {
 		struct sqlx_repctx_s *repctx = NULL;
-		const gint64 max_versions = _maxvers(sq3);
+		gint64 max_versions = _maxvers(sq3);
 		GSList *deleted_beans = NULL;
 		GSList *deleted_objects = NULL;
 
 		if (!(err = _transaction_begin(sq3, url, &repctx))) {
+			if (oio_ext_get_force_versioning()) {
+				GRID_DEBUG("Updating max_version: %s", oio_ext_get_force_versioning());
+				max_versions = atoi(oio_ext_get_force_versioning());
+				m2db_set_max_versions(sq3, max_versions);
+			}
 			if (!(err = m2db_delete_alias(sq3, max_versions, url,
 					_bean_list_cb, &deleted_beans))) {
 				if (deleted_beans) {

--- a/meta2v2/meta2_gridd_dispatcher.c
+++ b/meta2v2/meta2_gridd_dispatcher.c
@@ -370,6 +370,7 @@ static gridd_filter M2V2_DELETE_FILTERS[] =
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_localflag,
 	meta2_filter_extract_header_flags32,
+	meta2_filter_extract_header_optional_force_versioning,
 	meta2_filter_extract_admin,
 	meta2_filter_extract_user_agent,
 	meta2_filter_fill_subject,

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -2934,8 +2934,11 @@ enum http_rc_e action_content_delete (struct req_args_s *args) {
 
 static enum http_rc_e
 _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
+	const char* force_versioning = g_tree_lookup(args->rq->tree_headers,
+			PROXYD_HEADER_FORCE_VERSIONING);
+
 	json_object *jarray = NULL;
-	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, NULL, DL()); }
+	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, force_versioning, DL()); }
 
 	if (!oio_url_has_fq_container(args->url))
 		return _reply_format_error(args,
@@ -2988,6 +2991,8 @@ _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
 // CONTENT{{
 // POST /v3.0/{NS}/content/delete_many?acct={account}&ref={container}
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// You can update system property policy.version of container
 //
 // .. code-block:: json
 //

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -2907,6 +2907,8 @@ enum http_rc_e action_content_show (struct req_args_s *args) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Unreference object from container
 //
+// You can update system property policy.version of container
+//
 // .. code-block:: http
 //
 //    POST /v3.0/OPENIO/content/delete?acct=my_account&ref=mycontainer&path=mycontent HTTP/1.1
@@ -2922,7 +2924,10 @@ enum http_rc_e action_content_show (struct req_args_s *args) {
 //
 // }}CONTENT
 enum http_rc_e action_content_delete (struct req_args_s *args) {
-	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, DL()); }
+	const char* force_versioning = g_tree_lookup(args->rq->tree_headers,
+			PROXYD_HEADER_FORCE_VERSIONING);
+
+	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, force_versioning, DL()); }
 	GError *err = _resolve_meta2(args, _prefer_master(), _pack, NULL, NULL);
 	return _reply_m2_error (args, err);
 }
@@ -2930,7 +2935,7 @@ enum http_rc_e action_content_delete (struct req_args_s *args) {
 static enum http_rc_e
 _m2_content_delete_many (struct req_args_s *args, struct json_object * jbody) {
 	json_object *jarray = NULL;
-	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, DL()); }
+	PACKER_VOID(_pack) { return m2v2_remote_pack_DEL (args->url, NULL, DL()); }
 
 	if (!oio_url_has_fq_container(args->url))
 		return _reply_format_error(args,

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -313,9 +313,13 @@ m2v2_remote_pack_DRAIN(struct oio_url_s *url, gint64 dl)
 }
 
 GByteArray*
-m2v2_remote_pack_DEL(struct oio_url_s *url, gint64 dl)
+m2v2_remote_pack_DEL(struct oio_url_s *url, const gchar* force_versioning, gint64 dl)
 {
-	return _m2v2_pack_request_with_flags(NAME_MSGNAME_M2V2_DEL, url, NULL, 0, dl);
+	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_DEL, url, NULL, dl);
+	if (force_versioning) {
+		metautils_message_add_field_str(msg, NAME_MSGKEY_FORCE_VERSIONING, force_versioning);
+	}
+	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -144,6 +144,7 @@ GByteArray* m2v2_remote_pack_DRAIN(
 
 GByteArray* m2v2_remote_pack_DEL(
 		struct oio_url_s *url,
+		const char *force_versioning,
 		gint64 deadline);
 
 GByteArray* m2v2_remote_pack_TRUNC(

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -585,9 +585,10 @@ class TestMeta2Containers(BaseTestCase):
         self.assertEqual(str(expected_missing_chunks),
                          data['system']['sys.m2.chunks.missing'])
 
-    def _delete_content(self, obj_name):
+    def _delete_content(self, obj_name, headers=None):
         params = self.param_content(self.ref, obj_name)
-        resp = self.request('POST', self.url_content('delete'), params=params)
+        resp = self.request('POST', self.url_content('delete'), params=params,
+                            headers=headers)
         self.assertEqual(resp.status, 204)
 
     def test_missing_chunks(self):
@@ -694,6 +695,34 @@ class TestMeta2Containers(BaseTestCase):
                             params=params)
         data = json.loads(resp.data)
         self.assertEqual("-1", data['system'].get("sys.m2.policy.version", 0))
+
+        resp = self.request('GET', self.url_container('list'),
+                            params=merge(params, {'all': 1}))
+        data = json.loads(resp.data)
+        self.assertEqual(2, len(data['objects']))
+
+        self._delete_content(path, headers={FORCEVERSIONING_HEADER: 1})
+        resp = self.request('POST', self.url_container('get_properties'),
+                            params=params)
+        data = json.loads(resp.data)
+        self.assertEqual("1", data['system'].get("sys.m2.policy.version", 0))
+
+        resp = self.request('GET', self.url_container('list'),
+                            params=merge(params, {'all': 1}))
+        data = json.loads(resp.data)
+        self.assertEqual(1, len(data['objects']))
+
+        self._delete_content(path, headers={FORCEVERSIONING_HEADER: -1})
+        resp = self.request('POST', self.url_container('get_properties'),
+                            params=params)
+        data = json.loads(resp.data)
+        self.assertEqual("-1", data['system'].get("sys.m2.policy.version", 0))
+
+        resp = self.request('GET', self.url_container('list'),
+                            params=merge(params, {'all': 1}))
+        data = json.loads(resp.data)
+        self.assertEqual(2, len(data['objects']))
+        self.assertTrue(data['objects'][0]['deleted'])
 
 
 class TestMeta2Contents(BaseTestCase):


### PR DESCRIPTION
##### SUMMARY

This commit bring same mecanism to update sys.m2.policy.versions
from header to content/delete operation: we want to control
if current version of object must be deleted or add a delete marker.

Fixes #OS-373

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
proxy and meta2

##### SDS VERSION
```
openio 4.5.2dev4
`