### PR TITLE
Python API: rework EC upload code

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -743,7 +743,7 @@ class EcMetachunkWriter(io.MetachunkWriter):
         # init generator
         ec_stream.send(None)
 
-        def send(data):
+        def encode_and_send(data):
             self.checksum.update(data)
             self.global_checksum.update(data)
             # get the encoded fragments
@@ -804,17 +804,17 @@ class EcMetachunkWriter(io.MetachunkWriter):
                         bytes_transferred += len(data)
                         if len(data) == 0:
                             break
-                        send(data)
+                        encode_and_send(data)
                 else:
                     while True:
                         data = read(self.buffer_size())
                         bytes_transferred += len(data)
                         if len(data) == 0:
                             break
-                        send(data)
+                        encode_and_send(data)
 
                 # flush out buffered data
-                send('')
+                encode_and_send('')
 
                 # wait for all data to be processed
                 for writer in writers:


### PR DESCRIPTION
##### SUMMARY
The previous code may have considered as successes some uploads that had failed (removing elements from the list we are iterating on is a bad thing). Now we build a list with only the chunks which do not see any error yet.

Also, parallelize the upload of the trailers, so a slow chunk upload does not block the termination of the other chunk uploads.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.5.2.dev4
```
