### PR TITLE
sqliterepo: prevent unneeded loop at election start

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2225,13 +2225,18 @@ _result_GETVERS (GError *enet, struct election_member_s *m,
 		if (err && err->code == CODE_CONTAINER_NOTFOUND) {
 			/* We don't have the base! If we are here, we can suppose we have
 			 * already checked that we are actually in the list of peers of
-			 * the election. We must ask for a fresh copy of the base. */
+			 * the election. We must ask for a fresh copy of the base.
+			 * Update 2019-06-26: get_version() is supposed to create an
+			 * empty(ish) database (with only the schema). */
+			GRID_NOTICE("BUG: get_version() should create the database file, "
+					"but returned: (%d) %s (reqid=%s)",
+					err->code, err->message, oio_ext_get_reqid());
 			g_clear_error(&err);
 			err = NEWERROR(CODE_PIPEFROM, "Local database missing");
 		} else if (err) {
-			GRID_WARN("GETVERS error [%s.%s]: (%d) %s",
+			GRID_WARN("GETVERS error [%s.%s]: (%d) %s (reqid=%s)",
 					m->inline_name.base, m->inline_name.type,
-					err->code, err->message);
+					err->code, err->message, oio_ext_get_reqid());
 		}
 	}
 
@@ -2240,7 +2245,7 @@ _result_GETVERS (GError *enet, struct election_member_s *m,
 		err = version_validate_diff(vlocal, vremote, &worst);
 		if (NULL != err) {
 			if (err->code == CODE_PIPETO) {
-				GRID_DEBUG("Remote outdated : (%d) %s",
+				GRID_DEBUG("Remote outdated: (%d) %s",
 						err->code, err->message);
 				g_clear_error(&err);
 			}

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1863,7 +1863,8 @@ sqlx_repository_get_version2(sqlx_repository_t *repo, const struct sqlx_name_s *
 	struct sqlx_sqlite3_s *sq3 = NULL;
 
 	*result = NULL;
-	err = sqlx_repository_open_and_lock(repo, n, SQLX_OPEN_LOCAL, &sq3, NULL);
+	err = sqlx_repository_open_and_lock(repo, n,
+			SQLX_OPEN_CREATE|SQLX_OPEN_LOCAL|SQLX_OPEN_URGENT, &sq3, NULL);
 	if (NULL != err)
 		return err;
 

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -35,15 +35,19 @@ License along with this library.
 #include "sqlx_remote.h"
 #include "gridd_client_pool.h"
 
-
-static const char * zoo_state2str(int state) {
+/* Unfortunately, state2String() is not exported by Zookeeper. */
+const char * zoo_state2str(int state) {
 #define ON_STATE(N) do { if (state == ZOO_##N##_STATE) return #N; } while (0)
 	ON_STATE(EXPIRED_SESSION);
 	ON_STATE(AUTH_FAILED);
 	ON_STATE(CONNECTING);
 	ON_STATE(ASSOCIATING);
 	ON_STATE(CONNECTED);
-	return "STATE?";
+#if ZOO_MAJOR_VERSION > 3 || (ZOO_MAJOR_VERSION == 3 && ZOO_MINOR_VERSION >= 5)
+	ON_STATE(READONLY);
+	ON_STATE(NOTCONNECTED);
+#endif
+	return "INVALID_STATE";
 }
 
 static const char * zoo_zevt2str(int zevt) {

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -109,6 +109,9 @@ void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
  * Zookeeper handle. */
 int sqlx_sync_uses_handle(struct sqlx_sync_s *ss, zhandle_t *zh);
 
+/** Get a string describing one of Zookeeper's state constants. */
+const char * zoo_state2str(int state);
+
 /* -------------------------------------------------------------------------- */
 
 struct sqlx_name_s;

--- a/sqliterepo/version.h
+++ b/sqliterepo/version.h
@@ -51,7 +51,7 @@ GTree* version_extract_expected(GTree *current, struct TableSequence *changes);
 
 /**
  * Compute the diff between both versions, and returns an error if the worst
- * version is > 1 in basolute value.
+ * version is > 1 in absolute value.
  *
  * @param worst the worst difference matched, with the considering 'src - dst'
  * @return the error that occured

--- a/tools/benchmark/oio-bench-container-create.py
+++ b/tools/benchmark/oio-bench-container-create.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python2
+
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+from eventlet import sleep
+from eventlet.greenpool import GreenPool
+from eventlet.queue import LightQueue
+from oio import ObjectStorageApi
+
+
+API = None
+POOL = None
+RESULTS = None
+
+
+def create_loop(prefix):
+    iteration = 0
+    while True:
+        name = prefix + str(iteration)
+        iteration += 1
+        try:
+            API.container_create('benchmark', name)
+            RESULTS.put(name)
+            sleep(0)
+        except Exception as err:
+            print err
+
+
+def main(threads, delay=2.0, duration=30.0):
+    counter = 0
+    created = list()
+    now = start = checkpoint = time.time()
+    POOL.starmap(create_loop, [('%d-' % n, ) for n in range(threads)])
+    while now - start < duration:
+        res = RESULTS.get()
+        counter += 1
+        if now - checkpoint > delay:
+            print "%d containers in %fs, %f containers per second." % (
+                counter, now - checkpoint, counter / (now - checkpoint))
+            counter = 0
+            checkpoint = now
+        created.append(res)
+        now = time.time()
+    for coro in POOL.coroutines_running:
+        coro.kill()
+    while not RESULTS.empty():
+        created.append(RESULTS.get(block=False))
+    end = time.time()
+    rate = len(created) / (end - start)
+    print "End. %d containers created in %fs, %f containers per second." % (
+        len(created), end - start, rate)
+    print "Cleaning..."
+    for _ in POOL.starmap(API.container_delete,
+                          [('benchmark', n) for n in created]):
+        pass
+    POOL.waitall()
+    return rate
+
+
+if __name__ == '__main__':
+    import os
+    import sys
+    THREADS = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    API = ObjectStorageApi(os.getenv('OIO_NS', 'OPENIO'))
+    RESULTS = LightQueue(THREADS * 10)
+    POOL = GreenPool(THREADS)
+    main(THREADS)

--- a/tools/oio-test-rebuilder.sh
+++ b/tools/oio-test-rebuilder.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 NAMESPACE=$($(which oio-test-config.py) -n)
-WORKERS=10
+WORKERS=4
 CLI=$(which openio)
 
 SVCID_ENABLED=$(openio cluster list rawx -c 'Service Id' -f value | grep -v 'n/a')
@@ -169,7 +169,9 @@ oio_meta_rebuilder()
   REBULD_TIME=$(date +%s)
   set +e
 
-  echo >&2 "Start the rebuilding for the ${TYPE} ${META_IP_TO_REBUILD}" \
+  sleep 3s
+
+  echo >&2 "Start the rebuilding for ${TYPE} ${META_IP_TO_REBUILD}" \
       "with ${WORKERS} workers"
   if ! $(which oio-"${TYPE}"-rebuilder) --workers "${WORKERS}" \
       "${NAMESPACE}"; then
@@ -186,7 +188,7 @@ oio_meta_rebuilder()
     if [ "${TYPE}" == "meta1" ]; then
       if ! USER=$(/usr/bin/sqlite3 "${META}" "SELECT user FROM users LIMIT 1" \
           2> /dev/null); then
-        echo >&2 "${META}: sqlite3 failed for the ${TYPE} ${META_IP_TO_REBUILD}"
+        echo >&2 "${META}: sqlite3 failed for ${TYPE} ${META_IP_TO_REBUILD}"
         FAIL=true
         continue
       fi
@@ -198,7 +200,7 @@ oio_meta_rebuilder()
 
     META_AFTER=${META//"${TMP_VOLUME}"/"${META_LOC_TO_REBUILD}"}
     if ! [ -f "${META_AFTER}" ]; then
-      echo >&2 "${META}: No such file for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: missing file for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
@@ -206,13 +208,17 @@ oio_meta_rebuilder()
     if ! LAST_REBUILD=$(/usr/bin/sqlite3 "${META_AFTER}" \
         "SELECT v FROM admin where k == 'user.sys.last_rebuild'" \
         2> /dev/null); then
-      echo >&2 "${META}: sqlite3 failed for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: sqlite3 failed for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
-    if [ -z "${LAST_REBUILD}" ] \
-        || [ "${REBULD_TIME}" -gt "${LAST_REBUILD}" ]; then
-      echo >&2 "${META}: Last rebuild too old for the ${TYPE} ${META_IP_TO_REBUILD}"
+    if [ -z "${LAST_REBUILD}" ]
+    then
+      echo >&2 "${META}: no rebuild date found for ${TYPE} ${META_IP_TO_REBUILD}"
+      FAIL=true
+    elif [ "${REBULD_TIME}" -gt "${LAST_REBUILD}" ];
+    then
+      echo >&2 "${META}: last rebuild date too old for ${TYPE} ${META_IP_TO_REBUILD}: ${LAST_REBUILD} < ${REBULD_TIME}"
       FAIL=true
       continue
     fi
@@ -222,7 +228,7 @@ oio_meta_rebuilder()
     if ! /usr/bin/sqlite3 "${TMP_FILE_BEFORE}" \
         "DELETE FROM admin WHERE k == 'version:main.admin';
         DELETE FROM admin WHERE k == 'user.sys.last_rebuild'" &> /dev/null; then
-      echo >&2 "${META}: sqlite3 failed for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: sqlite3 failed for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
@@ -232,18 +238,18 @@ oio_meta_rebuilder()
     if ! /usr/bin/sqlite3 "${TMP_FILE_AFTER}" \
         "DELETE FROM admin WHERE k == 'version:main.admin';
         DELETE FROM admin WHERE k == 'user.sys.last_rebuild'" &> /dev/null; then
-      echo >&2 "${META}: sqlite3 failed for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: sqlite3 failed for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
     if ! DIFF=$(mysqldiff "${TMP_FILE_BEFORE}" "${TMP_FILE_AFTER}" \
         2> /dev/null); then
-      echo >&2 "${META}: sqldiff failed for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: sqldiff failed for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
     if [ -n "${DIFF}" ]; then
-      echo >&2 "${META}: Wrong content for the ${TYPE} ${META_IP_TO_REBUILD}"
+      echo >&2 "${META}: Wrong content for ${TYPE} ${META_IP_TO_REBUILD}"
       FAIL=true
       continue
     fi
@@ -322,13 +328,13 @@ oio_blob_rebuilder()
     IFS=$OLD_IFS
   fi
 
-  echo >&2 "Create an incident for the rawx ${RAWX_ID_TO_REBUILD}"
+  echo >&2 "Create an incident for rawx ${RAWX_ID_TO_REBUILD}"
   $CLI volume admin incident "${RAWX_ID_TO_REBUILD}"
 
   update_timeout 1
   set +e
 
-  echo >&2 "Start the rebuilding for the rawx ${RAWX_ID_TO_REBUILD}"
+  echo >&2 "Start the rebuilding for rawx ${RAWX_ID_TO_REBUILD}"
   if ! $(which oio-blob-rebuilder) --volume "${RAWX_ID_TO_REBUILD}" \
       --workers "${WORKERS}" --allow-same-rawx "${NAMESPACE}"; then
     FAIL=true
@@ -355,13 +361,13 @@ oio_blob_rebuilder()
     CHUNK_ID=${CHUNK##*/}
     if ! FULLPATH=$(/usr/bin/getfattr -n "user.oio.content.fullpath:${CHUNK_ID}" \
         --only-values "${CHUNK}" 2> /dev/null); then
-      echo >&2 "${CHUNK}: Missing fullpath attribute for the rawx ${RAWX_ID_TO_REBUILD}"
+      echo >&2 "${CHUNK}: Missing fullpath attribute for rawx ${RAWX_ID_TO_REBUILD}"
       FAIL=true
       continue
     fi
     if ! POSITION=$(/usr/bin/getfattr -n "user.grid.chunk.position" \
         --only-values "${CHUNK}" 2> /dev/null); then
-      echo >&2 "${CHUNK}: Missing attribute for the rawx ${RAWX_ID_TO_REBUILD}"
+      echo >&2 "${CHUNK}: Missing attribute for rawx ${RAWX_ID_TO_REBUILD}"
       FAIL=true
       continue
     fi
@@ -375,7 +381,7 @@ oio_blob_rebuilder()
         --object-version "${VERSION}" -f value -c Pos -c Id \
         | /bin/grep "^${POSITION} " | /usr/bin/cut -d' ' -f2) \
         || [ -z "${CHUNK_URLS}" ]; then
-      echo >&2 "${CHUNK}: Location failed for the rawx ${RAWX_ID_TO_REBUILD}"
+      echo >&2 "${CHUNK}: Location failed for rawx ${RAWX_ID_TO_REBUILD}"
       FAIL=true
       continue
     fi
@@ -383,15 +389,13 @@ oio_blob_rebuilder()
     IFS=$'\n'
     for CHUNK_URL in $(echo "${CHUNK_URLS}"); do
       if [ "${CHUNK_URL##*/}" = "${CHUNK_ID}" ]; then
-        echo >&2 "${CHUNK}: (${CHUNK_URL}) meta2 not updated for the rawx " \
-            "${RAWX_ID_TO_REBUILD}"
+        echo >&2 "${CHUNK}: (${CHUNK_URL}) meta2 not updated for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue
       fi
       if ! $(which oio-crawler-integrity) "${NAMESPACE}" "${ACCOUNT}" \
           "${CONTAINER}" "${CONTENT}" "${CHUNK_URL}" &> /dev/null; then
-        echo >&2 "${CHUNK}: (${CHUNK_URL}) oio-crawler-integrity failed for the" \
-            "rawx ${RAWX_ID_TO_REBUILD}"
+        echo >&2 "${CHUNK}: (${CHUNK_URL}) oio-crawler-integrity failed for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue
       fi
@@ -403,21 +407,18 @@ oio_blob_rebuilder()
       fi
       if ! /usr/bin/wget -O "${TMP_FILE_AFTER}" "${CURLABLE}" \
           &> /dev/null; then
-        echo >&2 "${CHUNK}: (${CURLABLE}) wget failed for the rawx" \
-            "${RAWX_ID_TO_REBUILD}"
+        echo >&2 "${CHUNK}: (${CURLABLE}) wget failed for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue
       fi
       if ! DIFF=$(/usr/bin/diff "${CHUNK}" "${TMP_FILE_AFTER}" \
           2> /dev/null); then
-        echo >&2 "${CHUNK}: (${CHUNK_URL}) diff failed for the rawx" \
-            "${RAWX_ID_TO_REBUILD}"
+        echo >&2 "${CHUNK}: (${CHUNK_URL}) diff failed for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue
       fi
       if [ -n "${DIFF}" ]; then
-        echo >&2 "${CHUNK}: (${CHUNK_URL}) Wrong content for the rawx" \
-            "${RAWX_ID_TO_REBUILD}"
+        echo >&2 "${CHUNK}: (${CHUNK_URL}) difference found for rawx ${RAWX_ID_TO_REBUILD}"
         FAIL=true
         continue
       fi
@@ -431,7 +432,7 @@ oio_blob_rebuilder()
     printf "${RED}\noio-blob-rebuilder: FAILED\n${NO_COLOR}"
     exit 1
   else
-    echo >&2 "Remove the incident for the rawx ${RAWX_ID_TO_REBUILD}"
+    echo >&2 "Remove the incident for rawx ${RAWX_ID_TO_REBUILD}"
     $CLI volume admin clear "${RAWX_ID_TO_REBUILD} --before-incident"
 
     printf "${GREEN}\noio-blob-rebuilder: OK\n${NO_COLOR}"

--- a/tools/oio-travis-tests.sh
+++ b/tools/oio-travis-tests.sh
@@ -378,7 +378,7 @@ func_tests_rebuilder_mover () {
 		dd if=/dev/urandom of=/tmp/openio_object_$i bs=1K \
 				count=$(shuf -i 1-2000 -n 1) 2> /dev/null
 		echo "object create container-${RANDOM} /tmp/openio_object_$i" \
-				"--name object-${RANDOM}"
+				"--name object-${RANDOM} -f value"
 	done | ${PYTHON} $(which openio)
 
 	if [ -n "${REBUILDER}" ]; then


### PR DESCRIPTION
##### SUMMARY
External DB_VERS requests used to create the database, but internal ones did not. This resulted in a meta2 service never being elected master during M2_CREATE requests. Now that the internal requests also create the database, a simple benchmark shows a 3x performance increase (3x more meta2 databases created per second).

Jira: OS-411

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- sqliterepo

##### SDS VERSION
```
openio 4.2.10.dev2
```