### PR TITLE
Allow to encode fullpath with UTF-8 args

### DIFF
--- a/oio/common/fullpath.py
+++ b/oio/common/fullpath.py
@@ -20,6 +20,12 @@ def encode_fullpath(account, container, path, version, content_id):
     for k, v in locals().items():
         if not v:
             raise ValueError("Can't encode fullpath: missing %s" % k)
+    if isinstance(account, unicode):
+        account = account.encode('utf-8')
+    if isinstance(container, unicode):
+        container = container.encode('utf-8')
+    if isinstance(path, unicode):
+        path = path.encode('utf-8')
     return '{0}/{1}/{2}/{3}/{4}'.format(quote(account, ''),
                                         quote(container, ''),
                                         quote(path, ''),

--- a/tests/unit/common/test_fullpath.py
+++ b/tests/unit/common/test_fullpath.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 OpenIO SAS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+
+import unittest
+
+from oio.common.fullpath import encode_fullpath, decode_fullpath
+
+
+class FullpathTest(unittest.TestCase):
+
+    def test_encode(self):
+        fullpath = encode_fullpath("myaccount", "mycontainer", "myobject",
+                                   9876543210, "0123456789ABCDEF")
+        self.assertEqual(
+            "myaccount/mycontainer/myobject/9876543210/0123456789ABCDEF",
+            fullpath)
+
+    def test_encode_with_missing_account(self):
+        self.assertRaises(ValueError, encode_fullpath, None, "mycontainer",
+                          "myobject", 9876543210, "0123456789ABCDEF")
+
+    def test_encode_with_missing_container(self):
+        self.assertRaises(ValueError, encode_fullpath, "myaccount", None,
+                          "myobject", 9876543210, "0123456789ABCDEF")
+
+    def test_encode_with_missing_object(self):
+        self.assertRaises(ValueError, encode_fullpath, "myaccount",
+                          "mycontainer", None, 9876543210, "0123456789ABCDEF")
+
+    def test_encode_with_missing_object_version(self):
+        self.assertRaises(ValueError, encode_fullpath, "myaccount",
+                          "mycontainer", "myobject", None, "0123456789ABCDEF")
+
+    def test_encode_with_missing_object_id(self):
+        self.assertRaises(ValueError, encode_fullpath, "myaccount",
+                          "mycontainer", "myobject", 9876543210, None)
+
+    def test_encode_with_utf8_info(self):
+        fullpath = encode_fullpath("mŷaccount", "mycontainér", "myöbject",
+                                   9876543210, "0123456789ABCDEF")
+        self.assertEqual(
+            "m%C5%B7account/mycontain%C3%A9r/my%C3%B6bject/9876543210/"
+            "0123456789ABCDEF", fullpath)
+
+    def test_decode(self):
+        info = decode_fullpath(
+            "myaccount/mycontainer/myobject/9876543210/0123456789ABCDEF")
+        self.assertEqual(info, ("myaccount", "mycontainer", "myobject",
+                                "9876543210", "0123456789ABCDEF"))
+
+    def test_decode_with_wrong_format(self):
+        self.assertRaises(ValueError, decode_fullpath,
+                          "myaccount/mycontainer/myobject/9876543210")
+
+    def test_decode_with_utf8_info(self):
+        info = decode_fullpath(
+            "m%C5%B7account/mycontain%C3%A9r/my%C3%B6bject/9876543210/"
+            "0123456789ABCDEF")
+        self.assertEqual(info, ("mŷaccount", "mycontainér", "myöbject",
+                                "9876543210", "0123456789ABCDEF"))


### PR DESCRIPTION
##### SUMMARY

Allow to encode fullpath with UTF-8 args

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.2.10.dev2
```