### PR TITLE
conf: Manage well the modifiers on second-wide (epoch) time variables

### DIFF
--- a/confgen.py
+++ b/confgen.py
@@ -273,7 +273,7 @@ class Monotonic(Number):
 class Epoch(Number):
     def __init__(self, conf):
         super(Epoch, self).__init__(conf)
-        self.kind = 'OIO_VARKIND_time'
+        self.kind = 'OIO_VARKIND_epoch'
         self.ctype = "gint64"
         self.default = str2epoch(self.default)
         self.vmin = str2epoch(self.vmin)

--- a/core/oiovar.h
+++ b/core/oiovar.h
@@ -24,6 +24,7 @@ License along with this library.
 enum oio_var_kind_e {
 	OIO_VARKIND_time = 0,
 	OIO_VARKIND_size = 1,
+	OIO_VARKIND_epoch = 2,
 };
 
 /**

--- a/core/var.c
+++ b/core/var.c
@@ -255,6 +255,30 @@ _size_modifier (const char *unit)
 }
 
 static gint64
+_epoch_modifier(const char *unit)
+{
+	static struct _conversion_s {
+		const char unit[4];
+		const gint64 value;
+	} units[] = {
+		{"s", 1},
+		{"m", 60},       /* 60 seconds */
+		{"h", 3600},     /* 60 minutes */
+		{"d", 86400},    /* 24 hours */
+		{"w", 604800},   /* 7 days */
+		{"M", 2419200},  /* 4 weeks */
+		{"", 0},
+	};
+	if (!oio_str_is_set(unit))
+		return 1;
+	for (struct _conversion_s *pu=units; pu->unit[0] ;++pu) {
+		if (!strcmp(pu->unit, unit))
+			return pu->value;
+	}
+	return 0;
+}
+
+static gint64
 _time_modifier(const char *unit)
 {
 	static struct _conversion_s {
@@ -263,6 +287,7 @@ _time_modifier(const char *unit)
 	} units[] = {
 		{"ms", G_TIME_SPAN_MILLISECOND},
 		{"s", G_TIME_SPAN_SECOND},
+		{"m", G_TIME_SPAN_MINUTE},
 		{"h", G_TIME_SPAN_HOUR},
 		{"d", G_TIME_SPAN_DAY},
 		{"w", 7 * G_TIME_SPAN_DAY},
@@ -286,6 +311,8 @@ _unit(struct oio_var_record_s *rec, const char *end)
 			return _time_modifier(end);
 		case OIO_VARKIND_size:
 			return _size_modifier(end);
+		case OIO_VARKIND_epoch:
+			return _epoch_modifier(end);
 		default:
 			g_assert_not_reached();
 			return 0;


### PR DESCRIPTION
##### SUMMARY
Manage well values in /etc/oio/sds.conf files for variables declared as time since EPOCH, in seconds.
Prior to the fix, they were erroneously considered as millisecond values and they received the same modifier as the "monotonic" variables.

##### ISSUE TYPE
`bugfix`

##### COMPONENT NAME
`core`, `conf`

##### SDS VERSION
`openio 4.5.4.dev4`