### PR TITLE
oio-blob-mover: implement concurrency

### DIFF
--- a/bin/oio-blob-mover
+++ b/bin/oio-blob-mover
@@ -27,8 +27,11 @@ def make_arg_parser():
     parser.add_argument('--namespace', '--ns', help="Namespace")
     parser.add_argument('--volume', help="Volume to move")
     parser.add_argument('config', help="Configuration file or empty file")
-    parser.add_argument('--generate-config', action='store_true',
-                        help="Generate configuration file with given arguments")
+    parser.add_argument('--concurrency', type=int,
+                        help="Number of coroutines to spawn.")
+    parser.add_argument(
+        '--generate-config', action='store_true',
+        help="Generate configuration file with given arguments")
     parser.add_argument('--edit-config', action='store_true',
                         help="Edit configuration file with given arguments")
     parser.add_argument('--limit', type=int,
@@ -85,6 +88,7 @@ def generate_config_file(path, mode):
         add_value(cont, 'report_interval', args.report_interval)
         add_value(cont, 'bytes_per_second', args.bytes_per_second)
         add_value(cont, 'chunks_per_second', args.chunks_per_second)
+        add_value(cont, 'concurrency', args.concurrency)
         add_value(cont, 'user', args.user)
         add_value(cont, 'limit', args.limit)
         return dic_to_string(cont, header)

--- a/etc/blob-mover.conf-sample
+++ b/etc/blob-mover.conf-sample
@@ -12,13 +12,18 @@ namespace = NS
 #
 # Volume to move
 volume = /var/lib/oio/sds/vol1/NS/rawx-1/
+
 # Disk usage target (in percent)
-# usage_target = 0
+#usage_target = 0
+#
 # Disk usage check interval (in seconds)
-# usage_check_interval = 3600
+#usage_check_interval = 3600
+#
 # Report interval (in seconds)
-# report_interval = 3600
-# Throttle: max bytes per second
-# bytes_per_second = 100000000
-# Throttle: max chunks per second
-# chunks_per_second = 30
+#report_interval = 3600
+#
+# Throttle: max chunks per second (overall)
+#chunks_per_second = 30
+#
+# Concurrency: number of chunk move coroutines
+#concurrency = 10


### PR DESCRIPTION
##### SUMMARY
The chunk mover will now use 10 coroutines to move chunks in parallel. This can be changed with the `concurrency` parameter in the configuration file. The rate limiting is global (not per each coroutine).


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- oio-blob-mover

##### SDS VERSION
```
openio 4.5.4.dev5
```