### PR TITLE
Rename '--workers' to '--concurrency'

### DIFF
--- a/bin/oio-blob-improver
+++ b/bin/oio-blob-improver
@@ -55,8 +55,8 @@ def make_arg_parser():
     parser.add_argument('--stop-after-events', type=int, default=0,
                         help=('Stop the process after this number of events '
                               'have been processed. Useful for testing.'))
-    parser.add_argument('--workers', type=int,
-                        help="Number of workers (1)")
+    parser.add_argument('--concurrency', '--workers', type=int,
+                        help='Number of coroutines to spawn (1)')
     return parser
 
 
@@ -80,8 +80,8 @@ def main():
         conf['beanstalkd_tube'] = args.beanstalkd_tube
     if args.report_interval is not None:
         conf['report_interval'] = args.report_interval
-    if args.workers is not None:
-        conf['workers'] = args.workers
+    if args.concurrency is not None:
+        conf['concurrency'] = args.concurrency
     if args.chunks_per_second is not None:
         conf['items_per_second'] = args.chunks_per_second
     if args.retry_delay:

--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -66,9 +66,9 @@ tube for broken chunks events.
 
     # local
     parser.add_argument(
-        '--workers', type=int,
-        help='Number of workers. '
-             '(default=%d)' % BlobRebuilder.DEFAULT_WORKERS)
+        '--concurrency', '--workers', type=int,
+        help='Number of coroutines to spawn. '
+             '(default=%d)' % BlobRebuilder.DEFAULT_CONCURRENCY)
     parser.add_argument(
         '--chunks-per-second', type=int,
         help='Max chunks per second. '
@@ -97,7 +97,7 @@ tube for broken chunks events.
         help='Send broken chunks to beanstalkd tubes '
              'instead of rebuilding them locally '
              '(the following options are ignored: '
-             '--workers, --chunks-per-second, --delete-faulty-chunks).')
+             '--concurrency, --chunks-per-second, --delete-faulty-chunks).')
     parser.add_argument(
         '--distributed-tube',
         help='The beanstalkd tube to use to send the broken chunks. '
@@ -121,7 +121,7 @@ def main():
     # input
     conf['beanstalkd_worker_tube'] = args.beanstalkd_tube
     # local
-    conf['workers'] = args.workers
+    conf['concurrency'] = args.concurrency
     conf['items_per_second'] = args.chunks_per_second
     conf['dry_run'] = args.dry_run
     conf['try_chunk_delete'] = args.delete_faulty_chunks

--- a/bin/oio-meta1-rebuilder
+++ b/bin/oio-meta1-rebuilder
@@ -42,10 +42,10 @@ def make_arg_parser():
     parser.add_argument('namespace', help="Namespace")
     parser.add_argument('--report-interval', type=int,
                         help="Report interval in seconds (3600)")
-    parser.add_argument('--workers', type=int,
-                        help="Number of workers (1)")
+    parser.add_argument('--concurrency', '--workers', type=int,
+                        help='Number of coroutines to spawn. (1)')
     parser.add_argument('--prefixes-per-second', type=int,
-                        help="Max prefixes per second per workers (30)")
+                        help="Max prefixes per second per concurrency (30)")
     parser.add_argument('-q', '--quiet', action='store_true',
                         help="Don't print log on console")
     ifile_help = "Read container IDs from this file instead of redis. " \
@@ -75,8 +75,8 @@ if __name__ == '__main__':
 
     if args.report_interval is not None:
         conf['report_interval'] = args.report_interval
-    if args.workers is not None:
-        conf['workers'] = args.workers
+    if args.concurrency is not None:
+        conf['concurrency'] = args.concurrency
     if args.prefixes_per_second is not None:
         conf['items_per_second'] = args.prefixes_per_second
 

--- a/bin/oio-meta2-rebuilder
+++ b/bin/oio-meta2-rebuilder
@@ -54,9 +54,9 @@ and triggering a synchronization.
 
     # local
     parser.add_argument(
-        '--workers', type=int,
-        help='Number of workers. '
-             '(default=%d)' % Meta2Rebuilder.DEFAULT_WORKERS)
+        '--concurrency', '--workers', type=int,
+        help='Number of coroutines to spawn. '
+             '(default=%d)' % Meta2Rebuilder.DEFAULT_CONCURRENCY)
     parser.add_argument(
         '--items-per-second', type=int,
         help='Max items per second. '
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     conf['rdir_fetch_limit'] = args.rdir_fetch_limit
     conf['report_interval'] = args.report_interval
     # local
-    conf['workers'] = args.workers
+    conf['concurrency'] = args.concurrency
     conf['items_per_second'] = args.references_per_second
 
     logger = get_logger_from_args(args, default_conf=conf)

--- a/oio/cli/admin/common.py
+++ b/oio/cli/admin/common.py
@@ -282,9 +282,9 @@ The beanstalkd tube to use to send the items to rebuild. (default=%s)
                 help=distributed_tube_help)
         else:  # local
             parser.add_argument(
-                '--workers', type=int,
-                help='Number of workers. '
-                     '(default=%d)' % self.tool_class.DEFAULT_WORKERS)
+                '--concurrency', type=int,
+                help='Number of coroutines to spawn. '
+                     '(default=%d)' % self.tool_class.DEFAULT_CONCURRENCY)
 
     def check_and_load_parsed_args(self, app, parsed_args):
         self.tool_conf.update(app.client_manager.client_conf)
@@ -294,4 +294,4 @@ The beanstalkd tube to use to send the items to rebuild. (default=%s)
             self.tool_conf['distributed_beanstalkd_worker_tube'] = \
                 parsed_args.distributed_tube
         else:  # local
-            self.tool_conf['workers'] = parsed_args.workers
+            self.tool_conf['concurrency'] = parsed_args.concurrency

--- a/oio/cli/directory/directory.py
+++ b/oio/cli/directory/directory.py
@@ -287,7 +287,7 @@ class DirectoryWarmup(DirectoryCmd):
 
     def get_parser(self, prog_name):
         parser = super(DirectoryWarmup, self).get_parser(prog_name)
-        parser.add_argument('--workers', type=int, default=1,
+        parser.add_argument('--concurrency', '--workers', type=int, default=1,
                             help="How many concurrent bases to warm up")
         parser.add_argument('--proxy', type=str, default=None,
                             help="Specific proxy IP:PORT")
@@ -299,7 +299,7 @@ class DirectoryWarmup(DirectoryCmd):
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
         digits = self.app.client_manager.meta1_digits
-        workers_count = parsed_args.workers
+        concurrency = parsed_args.concurrency
 
         conf = {'namespace': self.app.client_manager.namespace}
         if parsed_args.proxy:
@@ -310,12 +310,12 @@ class DirectoryWarmup(DirectoryCmd):
             conf.update({'proxyd_url': proxy})
 
         workers = list()
-        with green.ContextPool(workers_count) as pool:
+        with green.ContextPool(concurrency) as pool:
             pile = GreenPile(pool)
             prefix_queue = Queue(16)
 
             # Prepare some workers
-            for _ in range(workers_count):
+            for _ in range(concurrency):
                 worker = WarmupWorker(self.app.client_manager.client_conf,
                                       self.log)
                 workers.append(worker)

--- a/oio/common/tool.py
+++ b/oio/common/tool.py
@@ -38,7 +38,7 @@ class Tool(object):
     DEFAULT_BEANSTALKD_WORKER_TUBE = 'oio-process'
     DEFAULT_REPORT_INTERVAL = 3600
     DEFAULT_ITEM_PER_SECOND = 30
-    DEFAULT_WORKERS = 1
+    DEFAULT_CONCURRENCY = 1
     DEFAULT_DISTRIBUTED_BEANSTALKD_WORKER_TUBE = 'oio-process'
 
     def __init__(self, conf, beanstalkd_addr=None, logger=None):
@@ -307,20 +307,20 @@ class _LocalDispatcher(_Dispatcher):
     def __init__(self, conf, tool):
         super(_LocalDispatcher, self).__init__(conf, tool)
 
-        nb_workers = int_value(self.conf.get(
-            'workers'), self.tool.DEFAULT_WORKERS)
+        concurrency = int_value(self.conf.get(
+            'concurrency'), self.tool.DEFAULT_CONCURRENCY)
         self.max_items_per_second = int_value(self.conf.get(
             'items_per_second'), self.tool.DEFAULT_ITEM_PER_SECOND)
         if self.max_items_per_second > 0:
             # Max 5 seconds in advance
             queue_size = self.max_items_per_second * 5
         else:
-            queue_size = nb_workers * 1024
+            queue_size = concurrency * 1024
         self.queue_workers = eventlet.Queue(queue_size)
         self.queue_reply = eventlet.Queue()
 
         self.workers = list()
-        for _ in range(nb_workers):
+        for _ in range(concurrency):
             worker = self.tool.create_worker(
                 self.queue_workers, self.queue_reply)
             self.workers.append(worker)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -787,7 +787,7 @@ on_die=cry
 template_gridinit_blob_rebuilder = """
 [Service.${NS}-${SRVTYPE}-${SRVNUM}]
 group=${NS},localhost,${SRVTYPE}
-command=oio-blob-rebuilder --workers 10 --beanstalkd ${QUEUE_URL} --log-facility local0 --log-syslog-prefix OIO,OPENIO,${SRVTYPE},${SRVNUM} ${NS}
+command=oio-blob-rebuilder --concurrency 10 --beanstalkd ${QUEUE_URL} --log-facility local0 --log-syslog-prefix OIO,OPENIO,${SRVTYPE},${SRVNUM} ${NS}
 enabled=true
 start_at_boot=false
 on_die=cry


### PR DESCRIPTION
##### SUMMARY

Rename '--workers' to '--concurrency' to avoid confusion:
- `workers` -> processes
- `concurrency` -> coroutines

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Admin CLI
- `oio-blob-improver`
- `oio-blob-rebuilder`
- `oio-meta1-rebuilder`
- `oio-meta2-rebuilder`
- `openio directory warmup`

##### SDS VERSION

```
openio 5.0.1.dev1
```