### PR TITLE
Allow lifecycle to work with sharded buckets

### DIFF
--- a/oio/cli/lifecycle/lifecycle.py
+++ b/oio/cli/lifecycle/lifecycle.py
@@ -35,14 +35,19 @@ class LifecycleApply(lister.Lister):
             metavar='<container>',
             help='Container on which to apply lifecycle rules'
         )
+        parser.add_argument(
+            '--recursive',
+            type=bool,
+            help='For sharded S3 buckets, recurse on sub containers.'
+        )
         return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)
-        lc = ContainerLifecycle(self.app.client_manager.storage,
-                                self.app.client_manager.account,
-                                parsed_args.container,
-                                self.log)
+        lc = ContainerLifecycle(
+            self.app.client_manager.storage, self.app.client_manager.account,
+            parsed_args.container, self.log,
+            recursive=parsed_args.recursive)
         if not lc.load():
             raise LifecycleNotFound(
                 "No lifecycle configuration for container %s in account %s" %

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -122,3 +122,7 @@ volume_xattr_keys = {
 CHUNK_SUFFIX_CORRUPT = '.corrupt'
 # Suffix of chunk file names that are not finished being uploaded
 CHUNK_SUFFIX_PENDING = '.pending'
+
+# Container Hierarchy
+CH_ENCODED_SEPARATOR = '%2F'
+CH_SEPARATOR = '/'


### PR DESCRIPTION
##### SUMMARY

This PR will allow LifeCycle to be applied on bucket with Container Hierarcht=y

This behavior is triggered by flag on command line.
If set, a container listing will be triggered with `container%2F` as prefix.

The object listing will enrich metadata of objects to contains
original name in current container, computed name (with path)
and current container.

All tests against filter are unchanged, but API calls will use
`org_name` and `container's object`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Python LifeCycle

##### SDS VERSION
```
4.6.1dev3
```