### PR TITLE
blob-rebuilder: implement --rdir-timeout parameter

### DIFF
--- a/bin/oio-blob-rebuilder
+++ b/bin/oio-blob-rebuilder
@@ -43,6 +43,8 @@ tube for broken chunks events.
     parser.add_argument('--rdir-fetch-limit', type=int,
                         help="Maximum of entries returned in "
                              "each rdir response (100)")
+    parser.add_argument('--rdir-timeout', type=float,
+                        help="Timeout for rdir operations, in seconds (60.0)")
     parser.add_argument('--report-interval', type=int,
                         help="Report interval in seconds (3600)")
     parser.add_argument('--workers', type=int,
@@ -124,6 +126,8 @@ def main():
         conf['distributed_tube'] = args.distributed_tube
     if args.rdir_fetch_limit is not None:
         conf['rdir_fetch_limit'] = args.rdir_fetch_limit
+    if args.rdir_timeout is not None:
+        conf['rdir_timeout'] = args.rdir_timeout
     if args.report_interval is not None:
         conf['report_interval'] = args.report_interval
     if args.workers is not None:

--- a/oio/cli/volume/client.py
+++ b/oio/cli/volume/client.py
@@ -47,10 +47,10 @@ class VolumeClientCli(object):
     def volume_admin_clear(self, volume, **kwargs):
         return self.volume.admin_clear(volume, **kwargs)
 
-    def volume_show(self, volume):
+    def volume_show(self, volume, **kwargs):
         from oio.common.json import json
 
-        info = self.volume.status(volume)
+        info = self.volume.status(volume, **kwargs)
         data = {}
         containers = info.get('container')
         data['chunk'] = info.get('chunk')

--- a/oio/cli/volume/volume.py
+++ b/oio/cli/volume/volume.py
@@ -126,7 +126,7 @@ class ShowVolume(show.ShowOne):
         self.log.debug('take_action(%s)', parsed_args)
 
         data = self.app.client_manager.volume.volume_show(
-            volume=parsed_args.volume
+            volume=parsed_args.volume, read_timeout=60.0
         )
         return zip(*sorted(data.iteritems()))
 


### PR DESCRIPTION
##### SUMMARY
This new parameter allows to set the timeout for rdir operations. The
default value is 60.0s (was 30s before this commit).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- oio-blob-rebuilder

##### SDS VERSION
```
openio 4.2.11.dev12
```