### PR TITLE
Prevent slow ZK callbacks from creating empty databases

### DIFF
--- a/bin/oio-meta2-mover
+++ b/bin/oio-meta2-mover
@@ -18,7 +18,9 @@
 import argparse
 import sys
 
+from oio.cli import make_logger_args_parser, get_logger_from_args
 from oio.directory.meta1 import Meta1RefMapping
+
 
 def make_arg_parser():
     descr = """
@@ -26,7 +28,8 @@ def make_arg_parser():
     If the destination service isn't set,
     a destination service is automatically selected.
     """
-    parser = argparse.ArgumentParser(description=descr)
+    parser = argparse.ArgumentParser(description=descr,
+                                     parents=[make_logger_args_parser()])
     parser.add_argument('namespace',
                         metavar='<namespace>',
                         help="Namespace")
@@ -48,10 +51,11 @@ def make_arg_parser():
 
 if __name__ == '__main__':
     args = make_arg_parser().parse_args()
+    logger = get_logger_from_args(args)
 
     moved_ok = None
     try:
-        mapping = Meta1RefMapping(args.namespace)
+        mapping = Meta1RefMapping(args.namespace, logger=logger)
         moved = mapping.move(args.src_service, args.dest_service, args.base,
                              'meta2')
         kwargs = {'src_service': args.src_service}

--- a/core/ext.c
+++ b/core/ext.c
@@ -241,18 +241,19 @@ const char *oio_ext_get_reqid (void) {
 	return oio_str_is_set(l->reqid) ? l->reqid : NULL;
 }
 
-void oio_ext_set_reqid (const char *reqid) {
+const char *oio_ext_set_reqid(const char *reqid) {
 	struct oio_ext_local_s *l = _local_ensure ();
 	l->reqid[0] = '\0';
 	if (oio_str_is_set(reqid))
 		g_strlcpy(l->reqid, reqid, sizeof(l->reqid));
+	return l->reqid;
 }
 
-void oio_ext_set_random_reqid(void) {
-	oio_ext_set_prefixed_random_reqid(NULL);
+const char *oio_ext_set_random_reqid(void) {
+	return oio_ext_set_prefixed_random_reqid(NULL);
 }
 
-void oio_ext_set_prefixed_random_reqid(const char *prefix) {
+const char *oio_ext_set_prefixed_random_reqid(const char *prefix) {
 	struct {
 		pid_t pid:16;
 		guint8 buf[14];
@@ -267,7 +268,7 @@ void oio_ext_set_prefixed_random_reqid(const char *prefix) {
 	}
 	oio_buf_randomize(bulk.buf, sizeof(bulk.buf) - plen/2);
 	oio_str_bin2hex((guint8*)&bulk, sizeof(bulk), hex+plen, sizeof(hex) - plen);
-	oio_ext_set_reqid(hex);
+	return oio_ext_set_reqid(hex);
 }
 
 gint64 oio_ext_get_deadline(void) {

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -66,14 +66,14 @@ GError * oio_ext_extract_json (struct json_object *j,
 		struct oio_ext_json_mapping_s *tab);
 
 /** Set a thread-local variable with a copy of the given request id. */
-void oio_ext_set_reqid (const char *reqid);
+const char *oio_ext_set_reqid(const char *reqid);
 
 /** Calls oio_ext_set_reqid() with a randomly generated string */
-void oio_ext_set_random_reqid (void);
+const char *oio_ext_set_random_reqid(void);
 
 /** Calls oio_ext_set_reqid() with a randomly generated string,
  * with the specified prefix. */
-void oio_ext_set_prefixed_random_reqid(const char *prefix);
+const char *oio_ext_set_prefixed_random_reqid(const char *prefix);
 
 /* DO NOT FREE ... In facts, DO NOT EVEN CONSIDER USING THIS FUNCTION!
  * Gets the PRNG associated to the local thread, and allocates on if none

--- a/oio/cli/election/election.py
+++ b/oio/cli/election/election.py
@@ -45,6 +45,12 @@ class ElectionCmd(Lister):
             default=False,
             help="Interpret <reference> as a CID",
             action='store_true')
+        parser.add_argument(
+            '--service-id',
+            metavar='<service-id>',
+            action='append',
+            help="Query only this service ID")
+
         # TODO(FVE): add the timeout option to all openio subcommands
         # FVE: I chose 32s because the timeout between the proxy and the
         # services is usually 30s.
@@ -78,7 +84,8 @@ class ElectionPing(ElectionCmd):
 
         data = self.app.client_manager.election.election_ping(
             service_type=service_type, account=account, reference=reference,
-            cid=cid, timeout=parsed_args.timeout)
+            cid=cid, timeout=parsed_args.timeout,
+            service_id=parsed_args.service_id)
 
         columns = ('Id', 'Status', 'Message')
         data = sorted(data.iteritems())
@@ -97,7 +104,8 @@ class ElectionStatus(ElectionCmd):
 
         data = self.app.client_manager.election.election_status(
             service_type=service_type, account=account, reference=reference,
-            cid=cid, timeout=parsed_args.timeout)
+            cid=cid, timeout=parsed_args.timeout,
+            service_id=parsed_args.service_id)
 
         columns = ('Id', 'Status', 'Message')
         data = sorted(data["peers"].iteritems())
@@ -116,7 +124,8 @@ class ElectionDebug(ElectionCmd):
 
         data = self.app.client_manager.election.election_debug(
             service_type=service_type, account=account, reference=reference,
-            cid=cid, timeout=parsed_args.timeout)
+            cid=cid, timeout=parsed_args.timeout,
+            service_id=parsed_args.service_id)
 
         columns = ('Id', 'Status', 'Message', 'Body')
         data = sorted(data.iteritems())
@@ -148,14 +157,6 @@ class ElectionSync(ElectionCmd):
 
 class ElectionLeave(ElectionCmd):
     """Ask all peers to leave an election."""
-
-    def get_parser(self, prog_name):
-        parser = super(ElectionLeave, self).get_parser(prog_name)
-        parser.add_argument(
-            '--service-id',
-            metavar='<service-id>',
-            help="Leave the election only for this service ID")
-        return parser
 
     def take_action(self, parsed_args):
         self.log.debug('take_action(%s)', parsed_args)

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2228,6 +2228,11 @@ _result_GETVERS (GError *enet, struct election_member_s *m,
 		GRID_DEBUG("GETVERS error [%s.%s]: (%d) %s",
 				m->inline_name.base, m->inline_name.type,
 				err->code, err->message);
+	} else if (m->requested_LEAVE) {
+		/* Prevent calling get_version, which would create an empty database.
+		 * Use CODE_CONTAINER_MIGRATED, because we detected this case while
+		 * moving containers. */
+		err = NEWERROR(CODE_CONTAINER_MIGRATED, "Requested leave");
 	} else {
 		NAME2CONST(name, m->inline_name);
 		err = m->manager->config->get_version(m->manager->config->ctx, &name, &vlocal);

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -583,7 +583,7 @@ static gboolean _direct_getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result);
 
 static gboolean _direct_pipefrom (struct sqlx_peering_s *self,
@@ -839,7 +839,8 @@ struct evtclient_GETVERS_s
 	sqlx_peering_getvers_end_f hook;
 	struct election_member_s *m;
 	GTree *vremote;
-	guint reqid;
+	// FIXME(FVE): move reqid to event_client_s
+	char reqid[LIMIT_LENGTH_REQID];
 };
 
 static void
@@ -895,7 +896,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result)
 {
 	struct sqlx_peering_direct_s *p = (struct sqlx_peering_direct_s*) self;
@@ -910,7 +911,9 @@ _direct_getvers (struct sqlx_peering_s *self,
 	mc->ec.on_end = (gridd_client_end_f) on_end_GETVERS;
 	mc->hook = result;
 	mc->m = m;
-	mc->reqid = reqid;
+	if (!reqid)
+		reqid = oio_ext_get_reqid();
+	g_strlcpy(mc->reqid, reqid, LIMIT_LENGTH_REQID);
 	mc->vremote = NULL;
 
 	const gint64 now = oio_ext_monotonic_time();
@@ -985,7 +988,7 @@ sqlx_peering__getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result)
 {
 #ifdef HAVE_EXTRA_DEBUG

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -127,7 +127,7 @@ typedef void (*sqlx_peering_pipefrom_end_f) (GError *e,
 
 typedef void (*sqlx_peering_getvers_end_f) (GError *e,
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		GTree *vremote);
 
 /* Represents what an election needs to communicate with its peers. */
@@ -151,7 +151,7 @@ struct sqlx_peering_vtable_s
 			const struct sqlx_name_inline_s *n,
 			/* out */
 			struct election_member_s *m,
-			guint reqid,
+			const char *reqid,
 			sqlx_peering_getvers_end_f result);
 
 	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
@@ -187,7 +187,7 @@ gboolean sqlx_peering__getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result);
 
 gboolean sqlx_peering__pipefrom (struct sqlx_peering_s *self,

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -119,7 +119,7 @@ static gboolean _peering_getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result);
 
 static gboolean _peering_pipefrom (struct sqlx_peering_s *self,
@@ -158,7 +158,7 @@ _peering_getvers (struct sqlx_peering_s *self,
 		const struct sqlx_name_inline_s *n,
 		/* out */
 		struct election_member_s *m,
-		guint reqid,
+		const char *reqid,
 		sqlx_peering_getvers_end_f result)
 {
 	(void) self, (void) url, (void) n;


### PR DESCRIPTION
##### SUMMARY
We recently allowed internal calls `get_version` to create dummy database files, in order to make meta2 database creation faster. But in the case of slow Zookeeper callbacks (few milliseconds vs. few microseconds), coming after actual database removal, this resulted in dummy database staying there forever. Now we check if an election leave order has not been received before calling `get_version`.

Also, a few tools have been developed to help debugging this issue.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- sqliterepo

##### SDS VERSION
```
openio 4.6.1.dev2
```
