### PR TITLE
oio-crawler-integrity: report missing chunk positions

### DIFF
--- a/oio/cli/admin/item_check.py
+++ b/oio/cli/admin/item_check.py
@@ -78,7 +78,7 @@ class ItemCheckCommand(lister.Lister):
             error_file=parsed_args.output,
             rebuild_file=parsed_args.output_for_chunk_rebuild,
             request_attempts=parsed_args.attempts,
-            integrity=parsed_args.checksum,
+            check_hash=parsed_args.checksum,
             logger=self.logger)
 
         return self.columns, self._take_action(parsed_args)

--- a/oio/cli/admin/item_rebuild.py
+++ b/oio/cli/admin/item_rebuild.py
@@ -67,7 +67,7 @@ class ChunkRebuildCommand(ItemRebuildCommand):
 
         parser.add_argument(
             '--input-file',
-            help='Read chunks from this file instead of rdir. '
+            help='Read chunks from this file. '
                  'Each line should be formatted like '
                  '"container_id|content_id|short_chunk_id_or_position".')
 
@@ -116,13 +116,14 @@ class ChunkRebuildCommand(ItemRebuildCommand):
 
 class ChunkRebuild(ChunkRebuildCommand):
     """
-    Rebuild chunks that were on the specified file.
+    Rebuild the specified chunks.
     """
 
 
 class ChunkDistributedRebuild(ChunkRebuildCommand):
     """
-    Rebuild chunks that were on the specified file across the platform.
+    Rebuild the specified chunks,
+    using several workers across the platform.
     """
 
     distributed = True

--- a/oio/common/tool.py
+++ b/oio/common/tool.py
@@ -544,7 +544,7 @@ class _DistributedDispatcher(_Dispatcher):
 
     def _all_events_are_processed(self):
         """
-        Tell is all workers have finished to process their events.
+        Tell if all workers have finished to process their events.
         """
         if self.sending:
             return False

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -30,6 +30,7 @@ from oio.common import exceptions as exc
 from oio.common.fullpath import decode_fullpath
 from oio.common.logger import get_logger
 from oio.common.storage_method import STORAGE_METHODS
+from oio.common.utils import cid_from_name
 from oio.api.object_storage import ObjectStorageApi
 from oio.api.object_storage import _sort_chunks
 from oio.rdir.client import RdirClient
@@ -51,7 +52,20 @@ class Target(object):
         self.content_id = content_id
         self.version = version
         self.chunk = chunk
-        self.cid = cid
+        self._cid = cid
+
+    @property
+    def cid(self):
+        if not self._cid and self.account and self.container:
+            self._cid = cid_from_name(self.account, self.container)
+        return self._cid
+
+    @cid.setter
+    def cid(self, cid):
+        if cid is not None:
+            self._cid = cid
+            self.account = None
+            self.container = None
 
     def copy(self):
         return Target(
@@ -109,8 +123,9 @@ class ItemResult(object):
     Must be serializable to be used in the Checker's return queue.
     """
 
-    def __init__(self, target, errors=None):
+    def __init__(self, target, errors=None, irreparable=False):
         self.errors = errors if errors is not None else list()
+        self.irreparable = irreparable
         self.target = target
 
     def errors_to_str(self, separator='\n', err_format='%s'):
@@ -124,13 +139,16 @@ class ItemResult(object):
 
 class Checker(object):
     def __init__(self, namespace, concurrency=50,
-                 error_file=None, rebuild_file=None, full=True,
+                 error_file=None, rebuild_file=None, check_xattr=True,
                  limit_listings=0, request_attempts=1,
-                 logger=None, verbose=False, integrity=False):
+                 logger=None, verbose=False, check_hash=False,
+                 **_kwargs):
         self.pool = GreenPool(concurrency)
         self.error_file = error_file
-        self.full = bool(full)
-        self.integrity = bool(integrity)
+        self.check_xattr = bool(check_xattr)
+        self.check_hash = bool(check_hash)
+        self.logger = logger or get_logger({'namespace': namespace},
+                                           name='integrity', verbose=verbose)
         # Optimisation for when we are only checking one object
         # or one container.
         # 0 -> do not limit
@@ -146,8 +164,6 @@ class Checker(object):
             fd = open(self.rebuild_file, 'a')
             self.rebuild_writer = csv.writer(fd, delimiter='|')
 
-        self.logger = logger or get_logger({'namespace': namespace},
-                                           name='integrity', verbose=verbose)
         self.api = ObjectStorageApi(
             namespace,
             logger=self.logger,
@@ -235,12 +251,12 @@ class Checker(object):
         target.version = meta['version']
         target.account, target.container = self.api.resolve_cid(target.cid)
 
-    def send_result(self, target, errors=None):
+    def send_result(self, target, errors=None, irreparable=False):
         """
         Put an item in the result queue.
         """
         # TODO(FVE): send to an external queue.
-        self.result_queue.put(ItemResult(target, errors))
+        self.result_queue.put(ItemResult(target, errors, irreparable))
 
     def write_error(self, target, irreparable=False):
         if not self.error_file:
@@ -258,19 +274,10 @@ class Checker(object):
         self.error_writer.writerow(error)
 
     def write_rebuilder_input(self, target, irreparable=False):
-        # FIXME(FVE): cid can be computed from account and container names
-        if target.cid:
-            cid = target.cid
-        else:
-            ct_meta = self.list_cache[(target.account, target.container)][1]
-            try:
-                cid = ct_meta['system']['sys.name'].split('.', 1)[0]
-            except KeyError:
-                cid = ct_meta['properties']['sys.name'].split('.', 1)[0]
         error = list()
         if irreparable:
             error.append('#IRREPARABLE')
-        error.append(cid)
+        error.append(target.cid)
         # FIXME(FVE): ensure we always resolve content_id,
         # or pass object version along with object name.
         error.append(target.content_id or target.obj)
@@ -327,7 +334,7 @@ class Checker(object):
 
         try:
             xattr_meta = self.api.blob_client.chunk_head(
-                chunk, xattr=self.full, check_hash=self.integrity)
+                chunk, xattr=self.check_xattr, check_hash=self.check_hash)
         except exc.NotFound as err:
             self.chunk_not_found += 1
             errors.append('Not found: %s' % (err, ))
@@ -352,16 +359,18 @@ class Checker(object):
             else:
                 db_meta = obj_listing[chunk]
 
-            if db_meta and xattr_meta and self.full:
+            if db_meta and xattr_meta and self.check_xattr:
                 errors.extend(
                     self._check_chunk_xattr(target, db_meta, xattr_meta))
 
-        self.send_result(target, errors)
+        # Do not send errors directly, let the caller do it.
+        # Indeed, it may want to check if the chunks can be repaired or not.
         self.chunks_checked += 1
         return errors, obj_meta
 
     def check_chunk(self, target):
         errors, _obj_meta = self._check_chunk(target)
+        self.send_result(target, errors)
         return errors
 
     def _check_metachunk(self, target, stg_met, pos, chunks,
@@ -373,6 +382,7 @@ class Checker(object):
         """
         required = stg_met.expected_chunks
         errors = list()
+        chunk_results = list()
 
         if len(chunks) < required:
             missing_chunks = required - len(chunks)
@@ -380,29 +390,38 @@ class Checker(object):
                 subs = {x['num'] for x in chunks}
                 for sub in range(required):
                     if sub not in subs:
-                        errors.append(
-                            "Missing chunk at position %d.%d" % (pos, sub))
+                        chkt = target.copy()
+                        chkt.chunk = '%d.%d' % (pos, sub)
+                        err = "Missing chunk at position %s" % chkt.chunk
+                        chunk_results.append((chkt, [err]))
+                        errors.append(err)
             else:
                 for _ in range(missing_chunks):
-                    errors.append("Missing chunk at position %d" % pos)
+                    chkt = target.copy()
+                    chkt.chunk = '%d.%d' % (pos, sub)
+                    err = "Missing chunk at position %d" % pos
+                    chunk_results.append((chkt, [err]))
+                    errors.append(err)
 
         if recurse > 0:
             for chunk in chunks:
                 tcopy = target.copy()
                 tcopy.chunk = chunk['url']
                 chunk_errors, _ = self._check_chunk(tcopy)
+                chunk_results.append((tcopy, chunk_errors))
                 if chunk_errors:
-                    # The errors have already been reported by _check_chunk,
-                    # but we must count this chunk among the unusable chunks
-                    # of the current metachunk.
                     errors.append("Unusable chunk %s at position %s" % (
                         chunk['url'], chunk['pos']))
 
         irreparable = required - len(errors) < stg_met.min_chunks_to_read
         if irreparable:
             errors.append(
-                "Unavailable metachunk at position %s (%d/%d chunks)" % (
-                    pos, required - len(errors), stg_met.expected_chunks))
+                "Unavailable metachunk at position %s "
+                "(%d/%d chunks available, %d/%d required)" % (
+                    pos, required - len(errors), stg_met.expected_chunks,
+                    stg_met.min_chunks_to_read, stg_met.expected_chunks))
+        for tgt, errs in chunk_results:
+            self.send_result(tgt, errs, irreparable)
         # Since the "metachunk" is not an official item type,
         # this method does not report errors itself. Errors will
         # be reported as object errors.
@@ -732,10 +751,12 @@ class Checker(object):
             if result.target.type == 'chunk':
                 # FIXME(FVE): check error criticity
                 # and set the irreparable flag.
-                self.write_chunk_error(result.target)
+                self.write_chunk_error(result.target,
+                                       irreparable=result.irreparable)
             else:
-                self.write_error(result.target)
-            self.logger.warn('%s:\n%s', result.target,
+                self.write_error(result.target, irreparable=result.irreparable)
+            self.logger.warn('%s:%s\n%s', result.target,
+                             ' irreparable' if result.irreparable else '',
                              result.errors_to_str(err_format='  %s'))
 
     def run(self):
@@ -853,7 +874,7 @@ def main():
         error_file=args.output,
         concurrency=args.concurrency,
         rebuild_file=args.output_for_chunk_rebuild,
-        full=not args.presence,
+        check_xattr=not args.presence,
         limit_listings=limit_listings,
         request_attempts=args.attempts,
         verbose=True,

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -777,7 +777,8 @@ class BeanstalkdSender(TubedBeanstalkd):
     def job_done(self):
         """
         Declare that a job previously sent by this sender
-        has been fully processed.
+        has been fully processed (the sender received a response,
+        or does not expect one).
         """
         with self.nb_jobs_lock:
             self.nb_jobs -= 1

--- a/tests/functional/cli/admin/test_item_check.py
+++ b/tests/functional/cli/admin/test_item_check.py
@@ -97,16 +97,17 @@ class ItemCheckTest(CliTestCase):
     def test_account_check(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -126,6 +127,7 @@ class ItemCheckTest(CliTestCase):
     def test_account_with_depth(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
 
@@ -137,17 +139,17 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         output = self.openio_admin(
             'account check %s --depth 1 %s'
             % (self.account, self.check_opts))
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         output = self.openio_admin(
             'account check %s --depth 2 %s'
@@ -170,16 +172,17 @@ class ItemCheckTest(CliTestCase):
     def test_account_check_with_checksum(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -205,14 +208,14 @@ class ItemCheckTest(CliTestCase):
         expected_items.append(
             'chunk chunk=%s error' % (corrupted_chunk['url']))
         expected_items.remove(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
 
         # Check with checksum
@@ -224,18 +227,19 @@ class ItemCheckTest(CliTestCase):
     def test_account_check_with_missing_chunk(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             if chunk['url'] == missing_chunk['url']:
@@ -257,25 +261,27 @@ class ItemCheckTest(CliTestCase):
     def test_account_check_with_missing_container(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_container = "item_check_missing_container_" + random_str(4)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
                 'chunk chunk=%s OK' % (chunk['url']))
+        cid = cid_from_name(self.account, missing_container)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, missing_container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, missing_container, cid))
 
         # Create a container only in account service
         metadata = dict()
@@ -294,6 +300,7 @@ class ItemCheckTest(CliTestCase):
     def test_account_check_with_missing_account(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         mising_account = "item_check_missing_account_" + random_str(4)
 
@@ -308,12 +315,12 @@ class ItemCheckTest(CliTestCase):
 
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -328,18 +335,19 @@ class ItemCheckTest(CliTestCase):
     def test_account_check_with_multiple_accounts(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         second_account = "item_check_second_account_" + random_str(4)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -364,16 +372,17 @@ class ItemCheckTest(CliTestCase):
     def test_container_check(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -388,48 +397,49 @@ class ItemCheckTest(CliTestCase):
     def test_container_check_with_cid(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
                 'chunk chunk=%s OK' % (chunk['url']))
 
         # Check all items
-        container_id = cid_from_name(self.account, self.container)
         output = self.openio_admin(
             'container check %s --cid %s'
-            % (container_id, self.check_opts))
+            % (cid, self.check_opts))
         self.assert_list_output(expected_items, output)
 
     def test_container_with_depth(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
 
         # Check part of items
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         output = self.openio_admin(
             '--oio-account %s container check %s --depth 0 %s'
             % (self.account, self.container, self.check_opts))
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         output = self.openio_admin(
             '--oio-account %s container check %s --depth 1 %s'
@@ -457,16 +467,17 @@ class ItemCheckTest(CliTestCase):
     def test_container_check_with_checksum(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -492,14 +503,14 @@ class ItemCheckTest(CliTestCase):
         expected_items.append(
             'chunk chunk=%s error' % (corrupted_chunk['url']))
         expected_items.remove(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
 
         # Check with checksum
@@ -512,18 +523,19 @@ class ItemCheckTest(CliTestCase):
     def test_container_check_with_missing_chunk(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             if chunk['url'] == missing_chunk['url']:
@@ -548,12 +560,13 @@ class ItemCheckTest(CliTestCase):
             self.account, self.container, self.obj_name)
 
         missing_container = "item_check_missing_container_" + random_str(4)
+        cid = cid_from_name(self.account, missing_container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, missing_container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, missing_container, cid))
 
         # Check with missing container
         output = self.openio_admin(
@@ -577,13 +590,14 @@ class ItemCheckTest(CliTestCase):
             expected_returncode=1)
         self.assert_list_output(expected_items, output)
 
+        cid = cid_from_name(self.account, self.container)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -598,16 +612,17 @@ class ItemCheckTest(CliTestCase):
     def test_container_check_with_missing_account(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s error' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -627,18 +642,19 @@ class ItemCheckTest(CliTestCase):
     def test_container_check_with_multiple_containers(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         second_container = "item_check_second_container_" + random_str(4)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -654,9 +670,10 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         # Check two containers
+        cid = cid_from_name(self.account, second_container)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, second_container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, second_container, cid))
         output = self.openio_admin(
             '--oio-account %s container check %s %s %s'
             % (self.account, self.container, second_container,
@@ -666,16 +683,17 @@ class ItemCheckTest(CliTestCase):
     def test_object_check(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -691,41 +709,42 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_cid(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
                 'chunk chunk=%s OK' % (chunk['url']))
 
         # Check all items
-        container_id = cid_from_name(self.account, self.container)
         output = self.openio_admin(
             'object check --cid %s %s %s'
-            % (container_id, self.obj_name, self.check_opts))
+            % (cid, self.obj_name, self.check_opts))
         self.assert_list_output(expected_items, output)
 
     def test_object_check_with_object_version(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -758,12 +777,12 @@ class ItemCheckTest(CliTestCase):
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                second_version_meta['id'], second_version_meta['version']))
         for chunk in second_version_chunks:
             expected_items.append(
@@ -777,9 +796,9 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -795,16 +814,17 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_auto(self):
         self.container, obj_meta, obj_chunks = self.create_object_auto(
             self.account, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -820,18 +840,19 @@ class ItemCheckTest(CliTestCase):
     def test_object_with_depth(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
 
         # Check part of items
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         output = self.openio_admin(
             '--oio-account %s object check %s %s --depth 0 %s'
@@ -869,16 +890,17 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_checksum(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -906,14 +928,14 @@ class ItemCheckTest(CliTestCase):
         expected_items.append(
             'chunk chunk=%s error' % (corrupted_chunk['url']))
         expected_items.remove(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
 
         # Check with checksum
@@ -926,18 +948,19 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_missing_chunk(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             if chunk['url'] == missing_chunk['url']:
@@ -960,17 +983,18 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_missing_object(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_obj = "item_check_missing_obj_" + random_str(4)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s error'
-            % (self.account, self.container, missing_obj))
+            'object account=%s, container=%s, cid=%s, obj=%s error'
+            % (self.account, self.container, cid, missing_obj))
 
         # Check with missing object
         output = self.openio_admin(
@@ -980,9 +1004,9 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -997,16 +1021,17 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_missing_container(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -1025,16 +1050,17 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_missing_account(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         expected_items = list()
         expected_items.append('account account=%s error' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -1054,18 +1080,19 @@ class ItemCheckTest(CliTestCase):
     def test_object_check_with_multiple_objects(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         second_obj = "item_check_second_obj_" + random_str(4)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             expected_items.append(
@@ -1083,9 +1110,9 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, second_obj,
+            % (self.account, self.container, cid, second_obj,
                second_obj_meta['id'], second_obj_meta['version']))
         for chunk in second_obj_chunks:
             expected_items.append(
@@ -1103,18 +1130,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (chunk['url']))
 
@@ -1127,18 +1155,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_checksum(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (chunk['url']))
 
@@ -1169,18 +1198,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_missing_chunk(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         missing_chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s error' % missing_chunk['url'])
 
@@ -1203,18 +1233,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_missing_object(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s error' % (chunk['url']))
 
@@ -1236,18 +1267,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_missing_container(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (chunk['url']))
 
@@ -1263,18 +1295,19 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_missing_account(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
 
         expected_items = list()
         expected_items.append('account account=%s error' % self.account)
         expected_items.append(
-            'container account=%s, container=%s error'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s error'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (chunk['url']))
         # Remove account
@@ -1290,6 +1323,7 @@ class ItemCheckTest(CliTestCase):
     def test_chunk_check_with_multiple_objects(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         chunk = random.choice(obj_chunks)
         second_obj = "item_check_second_obj_" + random_str(4)
@@ -1297,12 +1331,12 @@ class ItemCheckTest(CliTestCase):
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (chunk['url']))
 
@@ -1318,9 +1352,9 @@ class ItemCheckTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s OK'
-            % (self.account, self.container, second_obj,
+            % (self.account, self.container, cid, second_obj,
                second_obj_meta['id'], second_obj_meta['version']))
         expected_items.append('chunk chunk=%s OK' % (second_chunk['url']))
 

--- a/tests/functional/cli/admin/test_item_rebuild.py
+++ b/tests/functional/cli/admin/test_item_rebuild.py
@@ -63,6 +63,7 @@ class ItemRebuildTest(CliTestCase):
     def test_chunk_rebuild(self):
         obj_meta, obj_chunks = self.create_object(
             self.account, self.container, self.obj_name)
+        cid = cid_from_name(self.account, self.container)
 
         stg_met = STORAGE_METHODS.load(obj_meta['chunk_method'])
         if stg_met.expected_chunks <= stg_met.min_chunks_to_read:
@@ -71,16 +72,16 @@ class ItemRebuildTest(CliTestCase):
         expected_items = list()
         expected_items.append('account account=%s OK' % self.account)
         expected_items.append(
-            'container account=%s, container=%s OK'
-            % (self.account, self.container))
+            'container account=%s, container=%s, cid=%s OK'
+            % (self.account, self.container, cid))
 
         # Delete first chunk
         missing_chunk = random.choice(obj_chunks)
         self.api.blob_client.chunk_delete(missing_chunk['url'])
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, self.obj_name,
+            % (self.account, self.container, cid, self.obj_name,
                obj_meta['id'], obj_meta['version']))
         for chunk in obj_chunks:
             if chunk['url'] == missing_chunk['url']:
@@ -98,9 +99,9 @@ class ItemRebuildTest(CliTestCase):
         second_missing_chunk = random.choice(second_obj_chunks)
         self.api.blob_client.chunk_delete(second_missing_chunk['url'])
         expected_items.append(
-            'object account=%s, container=%s, obj=%s, content_id=%s, '
+            'object account=%s, container=%s, cid=%s, obj=%s, content_id=%s, '
             'version=%s error'
-            % (self.account, self.container, second_obj,
+            % (self.account, self.container, cid, second_obj,
                second_obj_meta['id'], second_obj_meta['version']))
         for chunk in second_obj_chunks:
             if chunk['url'] == second_missing_chunk['url']:
@@ -121,14 +122,13 @@ class ItemRebuildTest(CliTestCase):
         self.assert_list_output(expected_items, output)
 
         expected_items = list()
-        container_id = cid_from_name(self.account, self.container)
         expected_items.append(
             '%s|%s|%s|%s OK' % (
-                self.ns, container_id, obj_meta['id'],
+                self.ns, cid, obj_meta['id'],
                 missing_chunk['url']))
         expected_items.append(
             '%s|%s|%s|%s OK' % (
-                self.ns, container_id, second_obj_meta['id'],
+                self.ns, cid, second_obj_meta['id'],
                 second_missing_chunk['url']))
 
         # Rebuild missing chunks


### PR DESCRIPTION
##### SUMMARY
Actually report missing chunk positions. These were reported on the standard log, but not in output files. This is now fixed.

Also, check the number of chunks against the quorum before reporting errors, such that missing chunks are potentially reported as irreparable (and not uselessly sent to the blob-rebuilder).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- oio-crawler-integrity

##### SDS VERSION
```
openio 4.6.1.dev12
```