### PR TITLE
Event: Do not create _RDIR account on reference operations

### DIFF
--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -136,3 +136,6 @@ volume_xattr_keys = VOLUME_XATTR_KEYS
 CHUNK_SUFFIX_CORRUPT = '.corrupt'
 # Suffix of chunk file names that are not finished being uploaded
 CHUNK_SUFFIX_PENDING = '.pending'
+
+# Accounts that are used by internally oio-sds and should stay hidden
+HIDDEN_ACCOUNTS = ("_RDIR",)

--- a/oio/event/filters/account_update.py
+++ b/oio/event/filters/account_update.py
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from oio.common.constants import REQID_HEADER, CONNECTION_TIMEOUT, READ_TIMEOUT
+from oio.common.constants import REQID_HEADER, CONNECTION_TIMEOUT, \
+    READ_TIMEOUT, HIDDEN_ACCOUNTS
 from oio.common.exceptions import ClientException, OioTimeout
 from oio.common.utils import request_id
 from oio.event.evob import Event, EventError, EventTypes
@@ -47,7 +48,9 @@ class AccountUpdateFilter(Filter):
         }
 
         try:
-            if event.event_type in CONTAINER_EVENTS:
+            if event.env.get('url').get('account') in HIDDEN_ACCOUNTS:
+                pass
+            elif event.event_type in CONTAINER_EVENTS:
                 mtime = event.when / 1000000.0  # convert to seconds
                 data = event.data
                 url = event.env.get('url')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
_RDIR is a hidden account and should not be present in the account database.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->
events
##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.6.1.dev12
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Jira: OS-246
```
