### PR TITLE
Integrity crawler: fix rebuilder input

### DIFF
--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -36,6 +36,9 @@ from oio.blob.client import BlobClient
 from oio.api.object_storage import _sort_chunks
 
 
+IRREPARABLE_PREFIX = '#IRREPARABLE'
+
+
 class Target(object):
     def __init__(self, account, container=None, obj=None, chunk=None):
         self.account = account
@@ -126,7 +129,7 @@ class Checker(object):
     def write_error(self, target, irreparable=False):
         error = list()
         if irreparable:
-            error.append('#IRREPARABLE')
+            error.append(IRREPARABLE_PREFIX)
         error.append(target.account)
         if target.container:
             error.append(target.container)
@@ -139,7 +142,7 @@ class Checker(object):
     def write_rebuilder_input(self, target, obj_meta, irreparable=False):
         error = list()
         if irreparable:
-            error.append('#IRREPARABLE')
+            error.append(IRREPARABLE_PREFIX)
         error.append(target.cid)
         error.append(obj_meta['id'])
         error.append(target.chunk)

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -94,8 +94,8 @@ class Checker(object):
 
         self.rebuild_file = rebuild_file
         if self.rebuild_file:
-            fd = open(self.rebuild_file, 'a')
-            self.rebuild_writer = csv.writer(fd, delimiter='|')
+            self.fd = open(self.rebuild_file, 'a')
+            self.rebuild_writer = csv.writer(self.fd, delimiter='|')
 
         conf = {'namespace': namespace}
         self.account_client = AccountClient(

--- a/tests/functional/crawler/test_integrity_crawler.py
+++ b/tests/functional/crawler/test_integrity_crawler.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import tempfile
+import fileinput
+import os
+
+from oio.common.utils import cid_from_name
+from oio.crawler.integrity import Checker, Target, IRREPARABLE_PREFIX
+from oio.event.evob import EventTypes
+from tests.utils import BaseTestCase, random_str
+
+
+class TestIntegrityCrawler(BaseTestCase):
+    def setUp(self):
+        super(TestIntegrityCrawler, self).setUp()
+        self.container = 'ct-' + random_str(8)
+        self.obj = 'obj-' + random_str(8)
+        self.account = 'test-integrity-' + random_str(8)
+        self.storage.object_create(
+            self.account, self.container, obj_name=self.obj, data="chunk")
+        _, self.rebuild_file = tempfile.mkstemp()
+        self.checker = Checker(self.ns, rebuild_file=self.rebuild_file)
+        self.meta, chunks = self.storage.object_locate(
+            self.account, self.container, self.obj)
+        self.chunk = chunks[0]
+        self.irreparable = len(chunks) == 1
+        self.storage.blob_client.chunk_delete(self.chunk['real_url'])
+
+    def tearDown(self):
+        super(TestIntegrityCrawler, self).tearDown()
+        os.remove(self.rebuild_file)
+        self.storage.container_flush(self.account, self.container)
+        self.storage.container_delete(self.account, self.container)
+        self.wait_for_event('oio-preserved',
+                            type_=EventTypes.CONTAINER_DELETED,
+                            fields={'user': self.container})
+        self.storage.account_delete(self.account)
+
+    def _verify_rebuilder_input(self):
+        try:
+            line = fileinput.input(self.rebuild_file).next().strip()
+            cid = cid_from_name(self.account, self.container)
+            expected = '|'.join([cid, self.meta['id'], self.chunk['url']])
+            if self.irreparable:
+                expected = IRREPARABLE_PREFIX + '|' + expected
+            self.assertEqual(expected, line)
+        finally:
+            fileinput.close()
+
+    def test_account_rebuilder_output(self):
+        self.checker.check(Target(self.account))
+        self.checker.wait()
+        self.checker.fd.flush()
+        self._verify_rebuilder_input()
+
+    def test_container_rebuilder_output(self):
+        self.checker.check(Target(self.account, container=self.container))
+        self.checker.wait()
+        self.checker.fd.flush()
+        self._verify_rebuilder_input()
+
+    def test_object_rebuilder_output(self):
+        self.checker.check(Target(self.account, container=self.container,
+                                  obj=self.obj))
+        self.checker.wait()
+        self.checker.fd.flush()
+        self._verify_rebuilder_input()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix error when `--output-for-blob-rebuilder` is used with only object checking.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->
oio-crawler-integrity
##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.6.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
```
Jira: OS-423
```
