### PR TITLE
Better integrity crawler

### DIFF
--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -20,11 +20,10 @@ import os
 import tempfile
 from string import hexdigits
 from datetime import datetime
-from collections import OrderedDict
 
 from oio.common.constants import chunk_xattr_keys, OIO_VERSION, \
     STRLEN_CHUNKID, CHUNK_XATTR_CONTENT_FULLPATH_PREFIX
-from oio.common.utils import cid_from_name, paths_gen
+from oio.common.utils import cid_from_name, paths_gen, CacheDict
 from oio.common.fullpath import decode_fullpath, decode_old_fullpath, \
     encode_fullpath
 from oio.common.xattr import set_fullpath_xattr
@@ -41,23 +40,6 @@ from oio.rdir.client import RdirClient
 XATTR_CHUNK_ID = chunk_xattr_keys['chunk_id']
 XATTR_OLD_FULLPATH = 'oio:'
 XATTR_OLD_FULLPATH_SIZE = 4
-
-
-# FIXME(FVE): move to utility class and document
-class CacheDict(OrderedDict):
-
-    def __init__(self, size=262144):
-        super(CacheDict, self).__init__()
-        self.size = size
-        self._check_size()
-
-    def __setitem__(self, key, value):
-        super(CacheDict, self).__setitem__(key, value)
-        self._check_size()
-
-    def _check_size(self):
-        while len(self) > self.size:
-            self.popitem(last=False)
 
 
 class BlobConverter(object):

--- a/oio/cli/admin/item_check.py
+++ b/oio/cli/admin/item_check.py
@@ -85,13 +85,14 @@ class ItemCheckCommand(lister.Lister):
 
     def _format_results(self):
         for res in self.checker.run():
-            if not res.errors:
+            if not res.has_errors:
                 status = 'OK'
+                yield (res.type, repr(res), status, str(None))
             else:
                 self.success = False
                 status = 'error'
-            yield (res.target.type, repr(res.target),
-                   status, res.errors_to_str())
+                yield (res.type, repr(res),
+                       status, res.latest_error_result().errors_to_str())
 
     def run(self, parsed_args):
         super(ItemCheckCommand, self).run(parsed_args)

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -17,6 +17,7 @@ import os
 import grp
 import pwd
 import fcntl
+from collections import OrderedDict
 from hashlib import sha256
 from random import getrandbits
 from io import RawIOBase
@@ -109,6 +110,24 @@ def statfs(volume):
     else:
         block_ratio = 1
     return min(inode_ratio, block_ratio)
+
+
+class CacheDict(OrderedDict):
+    """
+    OrderedDict subclass which holds a limited number of items.
+    """
+
+    def __init__(self, size=262144):
+        super(CacheDict, self).__init__()
+        self.size = size
+
+    def __setitem__(self, key, value):
+        super(CacheDict, self).__setitem__(key, value)
+        self._check_size()
+
+    def _check_size(self):
+        while len(self) > self.size:
+            self.popitem(last=False)
 
 
 class RingBuffer(list):

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -19,15 +19,18 @@ Recursively check account, container, content and chunk integrity.
 
 
 from __future__ import print_function
-from oio.common.green import Event, GreenPool, Queue, sleep, Semaphore,\
+from oio.common.green import Event, GreenPool, LightQueue, sleep, Semaphore,\
     ratelimit_function_build
 
 import os
 import csv
 import sys
+from time import time
 
+# from oio.blob.rebuilder import BlobRebuilder
 from oio.common import exceptions as exc
 from oio.common.fullpath import decode_fullpath
+# from oio.common.json import json
 from oio.common.logger import get_logger
 from oio.common.storage_method import STORAGE_METHODS
 from oio.common.utils import cid_from_name
@@ -43,7 +46,7 @@ IRREPARABLE_PREFIX = '#IRREPARABLE'
 
 class Target(object):
     """
-    Identify the target of a check.
+    Identify the target of a check, hold a log of errors.
     """
 
     def __init__(self, account, container=None, obj=None,
@@ -56,6 +59,13 @@ class Target(object):
         self.version = version
         self.chunk = chunk
         self._cid = cid
+
+        # List of tuples with a timestamp as first element,
+        # and an ItemResult as second element.
+        self.error_log = list()
+
+    def append_result(self, result):
+        self.error_log.append((time(), result))
 
     @property
     def cid(self):
@@ -88,6 +98,47 @@ class Target(object):
 
     def copy_account(self):
         return Target(self.account)
+
+    @property
+    def has_errors(self):
+        """
+        Tell if this target still presents errors.
+        Will return False if it showed errors in the past but does not show
+        them anymore.
+        """
+        return self.error_log and self.error_log[-1][1].errors
+
+    @property
+    def irreparable(self):
+        """
+        Tell if the target presents irreparable errors.
+
+        Check only the latest result. The "irreparable" situation may have been
+        temporary, for example if a rawx went down then up again.
+        """
+        return self.has_errors and self.latest_error_result().irreparable
+
+    def latest_error_result(self):
+        if self.has_errors:
+            return self.error_log[-1][1]
+        return None
+
+    def time_in_error(self):
+        """
+        Tell for how long this target has shown errors.
+
+        :rtype: tuple
+        :returns: the duration (in seconds) since we detected an error,
+            and the number of consecutive checks which showed an error.
+        """
+        if not self.has_errors:
+            return 0.0, 0
+        consecutive = list()
+        for res in reversed(self.error_log):
+            if not res[1]:
+                break
+            consecutive.append(res)
+        return time() - consecutive[-1][0], len(consecutive)
 
     def __repr__(self):
         if self.type == 'chunk':
@@ -126,10 +177,9 @@ class ItemResult(object):
     Must be serializable to be used in the Checker's return queue.
     """
 
-    def __init__(self, target, errors=None, irreparable=False):
+    def __init__(self, errors=None, irreparable=False):
         self.errors = errors if errors is not None else list()
         self.irreparable = irreparable
-        self.target = target
 
     def errors_to_str(self, separator='\n', err_format='%s'):
         """
@@ -145,6 +195,7 @@ class Checker(object):
                  error_file=None, rebuild_file=None, check_xattr=True,
                  limit_listings=0, request_attempts=1,
                  logger=None, verbose=False, check_hash=False,
+                 min_time_in_error=0.0, required_confirmations=0,
                  **_kwargs):
         self.pool = GreenPool(concurrency)
         self.error_file = error_file
@@ -189,11 +240,20 @@ class Checker(object):
         self.chunk_exceptions = 0
 
         self.list_cache = {}
-        self.running = {}
+        self.running_tasks = {}
         self.running_lock = Semaphore(1)
-        self.result_queue = Queue(concurrency)
+        self.result_queue = LightQueue(concurrency)
 
+        self.running = True
         self.run_time = 0
+
+        # Set of targets which must be checked again, to confirm
+        # or deny the issues reported by previous passes.
+        self.delayed_targets = dict()
+        # Minimum time in error and number of confirmations of the error
+        # before triggering a reconstruction action.
+        self.min_time_in_error = min_time_in_error
+        self.required_confirmations = required_confirmations
 
     def reset_stats(self):
         self.accounts_checked = 0
@@ -208,6 +268,26 @@ class Checker(object):
         self.container_exceptions = 0
         self.object_exceptions = 0
         self.chunk_exceptions = 0
+
+    def _spawn(self, func, target, *args, **kwargs):
+        """
+        Spawn a task on the internal GreenPool.
+        Discards the task if the pool is no more running.
+        """
+        if self.running:
+            return self.pool.spawn(func, target, *args, **kwargs)
+        self.logger.info("Discarding %s", target)
+        return None
+
+    def _spawn_n(self, func, target, *args, **kwargs):
+        """
+        Spawn a task on the internal GreenPool, do not wait for the result.
+        Discards the task if the pool is no more running.
+        """
+        if self.running:
+            return self.pool.spawn_n(func, target, *args, **kwargs)
+        self.logger.info("Discarding %s", target)
+        return None
 
     def complete_target_from_chunk_metadata(self, target, xattr_meta):
         """
@@ -275,7 +355,18 @@ class Checker(object):
         Put an item in the result queue.
         """
         # TODO(FVE): send to an external queue.
-        self.result_queue.put(ItemResult(target, errors, irreparable))
+        target.append_result(ItemResult(errors, irreparable))
+        self.result_queue.put(target)
+
+#    def send_chunk_job(self, target, irreparable=False):
+#        item = (self.api.namespace, target.cid,
+#                target.content_id, target.chunk)
+#        ev_dict = BlobRebuilder.task_event_from_item(item)
+#        if irreparable:
+#            ev_dict['data']['irreparable'] = irreparable
+#        job = json.dumps(ev_dict)
+#        self.error_sender.send_job(job)
+#        self.error_sender.job_done()  # Don't expect any response
 
     def write_error(self, target, irreparable=False):
         if not self.error_file:
@@ -458,12 +549,15 @@ class Checker(object):
         chunks_by_pos = _sort_chunks(chunks, stg_met.ec)
         tasks = list()
         for pos, pchunks in chunks_by_pos.iteritems():
-            tasks.append((pos, self.pool.spawn(
+            tasks.append((pos, self._spawn(
                 self._check_metachunk,
                 target.copy(), stg_met, pos, pchunks,
                 recurse=recurse)))
         errors = list()
         for pos, task in tasks:
+            if not task and not self.running:
+                errors.append("Pos %d skipped: checker is exiting" % pos)
+                continue
             try:
                 errors.extend(task.wait())
             except Exception as err:
@@ -480,11 +574,14 @@ class Checker(object):
             tcopy.content_id = ov['id']
             tcopy.version = str(ov['version'])
             tasks.append((tcopy.version,
-                          self.pool.spawn(self.check_obj,
-                                          tcopy,
-                                          recurse=recurse)))
+                          self._spawn(self.check_obj,
+                                      tcopy, recurse=recurse)))
         errors = list()
         for version, task in tasks:
+            if not task and not self.running:
+                errors.append(
+                    "Version %s skipped: checker is exiting" % version)
+                continue
             try:
                 task.wait()
             except Exception as err:
@@ -518,7 +615,7 @@ class Checker(object):
     def _get_cached_or_lock(self, lock_key):
         # If something is running, wait for it
         with self.running_lock:
-            event = self.running.get(lock_key)
+            event = self.running_tasks.get(lock_key)
         if event:
             event.wait()
             event = None
@@ -534,16 +631,16 @@ class Checker(object):
                 if lock_key in self.list_cache:
                     return self.list_cache[lock_key]
                 # Still nothing cached
-                event = self.running.get(lock_key)
+                event = self.running_tasks.get(lock_key)
                 if event is None:
-                    self.running[lock_key] = Event()
+                    self.running_tasks[lock_key] = Event()
                     return None
             event.wait()
 
     def _unlock(self, lock_key):
         with self.running_lock:
-            event = self.running[lock_key]
-            del self.running[lock_key]
+            event = self.running_tasks[lock_key]
+            del self.running_tasks[lock_key]
             event.send(True)
 
     def check_obj(self, target, recurse=0):
@@ -688,7 +785,7 @@ class Checker(object):
                     tcopy.obj = obj['name']
                     tcopy.content_id = obj['id']
                     tcopy.version = str(obj['version'])
-                    self.pool.spawn_n(self.check_obj, tcopy, recurse - 1)
+                    self._spawn_n(self.check_obj, tcopy, recurse - 1)
         self.send_result(target, errors)
         return container_listing, ct_meta
 
@@ -741,20 +838,20 @@ class Checker(object):
             for container in containers:
                 tcopy = target.copy_account()
                 tcopy.container = container
-                self.pool.spawn_n(self.check_container, tcopy, recurse - 1)
+                self._spawn_n(self.check_container, tcopy, recurse - 1)
 
         self.send_result(target, errors)
         return containers
 
     def check(self, target, recurse=0):
         if target.type == 'chunk':
-            self.pool.spawn_n(self.check_chunk, target)
+            self._spawn_n(self.check_chunk, target)
         elif target.type == 'object':
-            self.pool.spawn_n(self.check_obj, target, recurse)
+            self._spawn_n(self.check_obj, target, recurse)
         elif target.type == 'container':
-            self.pool.spawn_n(self.check_container, target, recurse)
+            self._spawn_n(self.check_container, target, recurse)
         else:
-            self.pool.spawn_n(self.check_account, target, recurse)
+            self._spawn_n(self.check_account, target, recurse)
 
     def check_all_accounts(self, recurse=0):
         all_accounts = self.api.account_list()
@@ -762,7 +859,7 @@ class Checker(object):
             self.check(Target(acct), recurse=recurse)
 
     def fetch_results(self, rate_limiter=None):
-        while not self.result_queue.empty():
+        while self.running and not self.result_queue.empty():
             res = self.result_queue.get(True)
             yield res
             # Rate limiting is done on the result queue for now.
@@ -772,18 +869,50 @@ class Checker(object):
             if rate_limiter is not None:
                 self.run_time = rate_limiter(self.run_time)
 
-    def log_result(self, result):
-        if result.errors:
-            if result.target.type == 'chunk':
-                # FIXME(FVE): check error criticity
-                # and set the irreparable flag.
-                self.write_chunk_error(result.target,
-                                       irreparable=result.irreparable)
+    def merge_with_delayed_target(self, target):
+        """
+        Merge the specified target with a delayed one.
+
+        :returns: the delayed target, if there is one, with an error log
+            including the errors of the new target. Return the new target
+            otherwise.
+        """
+        tkey = repr(target)
+        prev_target = self.delayed_targets.get(tkey, target)
+        if prev_target is not target:
+            errors = dict(prev_target.error_log)
+            errors.update(target.error_log)
+            prev_target.error_log = sorted(errors.items())
+        return prev_target
+
+    def log_result(self, target):
+        """
+        Log a check result, if it shows errors. Dispatch the errors to the
+        appropriate destinations (log files, queues, etc.).
+        """
+        # The result may come from a new target, or from an old target
+        # we checked another time, or both.
+        target = self.merge_with_delayed_target(target)
+        if target.has_errors:
+            time_in_error, confirmations = target.time_in_error()
+            if (time_in_error < self.min_time_in_error or
+                    confirmations < self.required_confirmations):
+                self.logger.info("Delaying check for %s, %d/%d confirmations",
+                                 target, confirmations,
+                                 self.required_confirmations)
+                self.delayed_targets[repr(target)] = target
             else:
-                self.write_error(result.target, irreparable=result.irreparable)
-            self.logger.warn('%s:%s\n%s', result.target,
-                             ' irreparable' if result.irreparable else '',
-                             result.errors_to_str(err_format='  %s'))
+                if target.type == 'chunk':
+                    self.write_chunk_error(target,
+                                           irreparable=target.irreparable)
+                else:
+                    self.write_error(target, irreparable=target.irreparable)
+                self.delayed_targets.pop(repr(target), None)
+            self.logger.warn(
+                '%s:%s\n%s',
+                target,
+                ' irreparable' if target.irreparable else '',
+                target.latest_error_result().errors_to_str(err_format='  %s'))
 
     def run(self, rate_limiter=None):
         """
@@ -791,16 +920,21 @@ class Checker(object):
 
         :returns: a generator yielding check results.
         """
-        while self.pool.running() + self.pool.waiting():
+        while self.running and (self.pool.running() + self.pool.waiting()):
             for result in self.fetch_results(rate_limiter):
                 self.log_result(result)
                 yield result
             sleep(0.1)
-        self.pool.waitall()
+        if self.running:
+            self.pool.waitall()
         # No rate limiting
         for result in self.fetch_results():
             self.log_result(result)
             yield result
+
+    def stop(self):
+        self.logger.info("Stopping")
+        self.running = False
 
     def report(self):
         success = True
@@ -850,26 +984,43 @@ def run_once(checker, entries=None, rate_limiter=None):
             checker.check(Target(*entry), recurse=DEFAULT_DEPTH)
     else:
         checker.check_all_accounts(recurse=DEFAULT_DEPTH)
-    for _ in checker.run():
+    for _ in checker.run(rate_limiter):
         pass
     if not checker.report():
         sys.exit(1)
 
 
-def run_indefinitely(checker, entries=None, rate_limiter=None):
-    while True:
+def run_indefinitely(checker, entries=None, rate_limiter=None,
+                     pause_between_passes=0.0):
+    def _stop(*args):
+        checker.stop()
+
+    import signal
+    signal.signal(signal.SIGINT, _stop)
+    signal.signal(signal.SIGQUIT, _stop)
+    signal.signal(signal.SIGTERM, _stop)
+
+    while checker.running:
+        for target in checker.delayed_targets.values():
+            checker.check(target, recurse=0)
         if entries:
             for entry in entries:
                 checker.check(Target(*entry), recurse=DEFAULT_DEPTH)
         else:
             checker.check_all_accounts(recurse=DEFAULT_DEPTH)
         for _ in checker.run(rate_limiter):
-            # TODO(FVE): check if the ItemResult describes chunk errors
-            # and send an event to the oio-rebuild tube.
             pass
         checker.report()
         checker.list_cache = dict()
         checker.reset_stats()
+        if checker.running and pause_between_passes > 0.0:
+            checker.logger.info("Pausing for %.3fs", pause_between_passes)
+            iterations, rest = divmod(pause_between_passes, 1)
+            sleep(rest)
+            for _ in range(int(iterations)):
+                if not checker.running:
+                    break
+                sleep(1.0)
 
 
 def main():
@@ -898,6 +1049,12 @@ def main():
     parser.add_argument('--concurrency', '--workers', type=int,
                         default=50,
                         help='Number of concurrent checks (default: 50).')
+    parser.add_argument('--confirmations', type=int,
+                        default=0,
+                        help=("BETA: report an error only after this number "
+                              "of confirmations (default: 0, report "
+                              "immediately). Makes sense only when running "
+                              "this tool as a daemon."))
     parser.add_argument('--daemon',
                         action='store_true',
                         help=("Loop indefinitely, until killed."))
@@ -910,12 +1067,23 @@ def main():
                         dest='output_for_chunk_rebuild',
                         help="Write chunk errors in a file with a format " +
                         "suitable as 'openio-admin chunk rebuild' input.")
+    parser.add_argument('--pause-between-passes', type=float, default=0.0,
+                        help=("When running as a daemon, make a pause before "
+                              "restarting from the beginning "
+                              "(default: 0.0 seconds)."))
     parser.add_argument('-p', '--presence',
                         action='store_true', default=False,
                         help="Presence check, the xattr check is skipped.")
     parser.add_argument('-r', '--ratelimit',
-                        help=('Set the rate limiting policy. '
+                        help=('Set the hour-based rate limiting policy. '
                               'Ex: "0h30:10;6h45:2;15h30:3;9h45:5;20h00:8".'))
+    parser.add_argument('--time-in-error', type=float,
+                        default=0.0,
+                        help=("BETA: report an error only after the item has "
+                              "shown errors for this amount of time "
+                              "(default: 0.0 seconds, report immediately). "
+                              "Makes sense only when running this tool "
+                              "as a daemon."))
 
     args = parser.parse_args()
 
@@ -944,6 +1112,8 @@ def main():
         request_attempts=args.attempts,
         logger=logger,
         verbose=not args.quiet,
+        min_time_in_error=args.time_in_error,
+        required_confirmations=args.confirmations,
     )
 
     if args.ratelimit:
@@ -952,6 +1122,7 @@ def main():
         rate_limiter = None
 
     if args.daemon:
-        run_indefinitely(checker, entries, rate_limiter)
+        run_indefinitely(checker, entries, rate_limiter,
+                         pause_between_passes=args.pause_between_passes)
     else:
         run_once(checker, entries, rate_limiter)


### PR DESCRIPTION
##### SUMMARY
- Implement new parameters to control when the tool reports problems:
  - after a specified number of confirmations,
  - after a specified delay.
- Allow the tool to wait between passes.
- Send broken object events to a user-selected queue, for example the input queue of `oio-blob-rebuilder`. It is advised to also specify a delay before sending events, otherwise temporary failures may trigger unwanted chunk rebuilds.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- `oio-crawler-integrity`

##### SDS VERSION
```
openio 4.6.1.dev15
```