### PR TITLE
Defragment meta2 databases on demand

### DIFF
--- a/oio/cli/admin/item_vacuum.py
+++ b/oio/cli/admin/item_vacuum.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from cliff import lister
+
+from oio.cli.admin.common import ContainerCommandMixin
+
+
+class ContainerVacuum(ContainerCommandMixin, lister.Lister):
+    """
+    Vacuum (defragment) a database.
+
+    Execute the operation on the master service, then
+    resynchronize the database on the slaves.
+    """
+
+    columns = ('Container', 'Status')
+
+    def get_parser(self, prog_name):
+        parser = super(ContainerVacuum, self).get_parser(prog_name)
+        ContainerCommandMixin.patch_parser(self, parser)
+        return parser
+
+    def _take_action(self, parsed_args):
+        admin = self.app.client_manager.admin
+        if parsed_args.is_cid:
+            for cid in parsed_args.containers:
+                try:
+                    admin.vacuum_base("meta2", cid=cid,
+                                      reqid=self.app.request_id())
+                    yield cid, "OK"
+                except Exception as err:
+                    yield cid, str(err)
+        else:
+            for cname in parsed_args.containers:
+                try:
+                    admin.vacuum_base("meta2",
+                                      account=self.app.options.account,
+                                      reference=cname,
+                                      reqid=self.app.request_id())
+                    yield cname, "OK"
+                except Exception as err:
+                    yield cname, str(err)
+
+    def take_action(self, parsed_args):
+        ContainerCommandMixin.check_and_load_parsed_args(
+            self, self.app, parsed_args)
+        return self.columns, self._take_action(parsed_args)

--- a/oio/directory/admin.py
+++ b/oio/directory/admin.py
@@ -239,6 +239,14 @@ class AdminClient(ProxyClient):
         _, body = self._request('POST', '/remove', params=params, **kwargs)
         return body
 
+    @loc_params
+    def vacuum_base(self, params, **kwargs):
+        """
+        Vacuum (defragment) the database on the master service, then
+        resynchronize it on the slaves.
+        """
+        self._request('POST', '/vacuum', params=params, **kwargs)
+
     # Proxy's cache and config actions ################################
 
     def _proxy_endpoint(self, proxy_netloc=None):

--- a/proxy/actions.h
+++ b/proxy/actions.h
@@ -113,6 +113,7 @@ enum http_rc_e action_admin_status (struct req_args_s *args);
 enum http_rc_e action_admin_info (struct req_args_s *args);
 enum http_rc_e action_admin_drop_cache (struct req_args_s *args);
 enum http_rc_e action_admin_sync (struct req_args_s *args);
+enum http_rc_e action_admin_vacuum(struct req_args_s *args);
 enum http_rc_e action_admin_leave (struct req_args_s *args);
 enum http_rc_e action_admin_debug (struct req_args_s *args);
 enum http_rc_e action_admin_copy (struct req_args_s *args);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -1057,7 +1057,12 @@ configure_request_handlers (void)
 	 * hosting the CID. */
 	SET("/$NS/admin/drop_cache/#POST", action_admin_drop_cache);
 
+	/* Ask the slaves to copy the database from the master.*/
 	SET("/$NS/admin/sync/#POST", action_admin_sync);
+
+	/* Defragment the database on the master,
+	 * then resynchronize it on the slaves. */
+	SET("/$NS/admin/vacuum/#POST", action_admin_vacuum);
 
 	/* Ask each peer to exit the election ("DB_LEAVE"). */
 	SET("/$NS/admin/leave/#POST", action_admin_leave);

--- a/proxy/sqlx_actions.c
+++ b/proxy/sqlx_actions.c
@@ -335,6 +335,13 @@ action_admin_sync (struct req_args_s *args)
 }
 
 enum http_rc_e
+action_admin_vacuum(struct req_args_s *args)
+{
+	PACKER_VOID(_pack) { return sqlx_pack_VACUUM(_u, FALSE, DL()); }
+	return _sqlx_action_noreturn(args, CLIENT_PREFER_MASTER, _pack);
+}
+
+enum http_rc_e
 action_admin_leave (struct req_args_s *args)
 {
 	PACKER_VOID(_pack) { return sqlx_pack_EXITELECTION (_u, DL()); }

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,6 +150,7 @@ openio.admin =
     container_locate = oio.cli.admin.item_locate:ContainerLocate
     container_move = oio.cli.admin.item_move:ContainerMove
     container_repair = oio.cli.admin.item_repair:ContainerRepair
+    container_vacuum = oio.cli.admin.item_vacuum:ContainerVacuum
     directory_check = oio.cli.admin.service_check:DirectoryCheck
     election_debug = oio.cli.election.election:ElectionDebug
     election_leave = oio.cli.election.election:ElectionLeave

--- a/sqliterepo/sqlite_utils.h
+++ b/sqliterepo/sqlite_utils.h
@@ -72,6 +72,10 @@ License along with this library.
 #define SQLX_ADMIN_BASETYPE SQLX_ADMIN_PREFIX_SYS "type"
 #endif
 
+#ifndef SQLX_ADMIN_LAST_VACUUM
+#define SQLX_ADMIN_LAST_VACUUM SQLX_ADMIN_PREFIX_SYS "last_vacuum"
+#endif
+
 /** Can read and write */
 #define ADMIN_STATUS_ENABLED  0x00000000
 /** Cannot write but can read */

--- a/sqliterepo/sqlx_macros.h
+++ b/sqliterepo/sqlx_macros.h
@@ -44,6 +44,7 @@ License along with this library.
 #define NAME_MSGNAME_SQLX_DUMP               "DB_DUMP"
 #define NAME_MSGNAME_SQLX_RESTORE            "DB_RESTORE"
 #define NAME_MSGNAME_SQLX_RESYNC             "DB_RESYNC"
+#define NAME_MSGNAME_SQLX_VACUUM             "DB_VACUUM"
 
 /* repository-wide */
 #define NAME_MSGNAME_SQLX_INFO               "DB_INFO"

--- a/sqliterepo/sqlx_remote.c
+++ b/sqliterepo/sqlx_remote.c
@@ -120,6 +120,16 @@ sqlx_pack_RESYNC(const struct sqlx_name_s *name, gint64 deadline)
 }
 
 GByteArray*
+sqlx_pack_VACUUM(const struct sqlx_name_s *name, gboolean local, gint64 deadline)
+{
+	gint8 local2 = BOOL(local);
+	MESSAGE req = make_request(NAME_MSGNAME_SQLX_VACUUM, NULL, name, deadline);
+	if (local)
+		metautils_message_add_field(req, NAME_MSGKEY_LOCAL, &local2, 1);
+	return message_marshall_gba_and_clean(req);
+}
+
+GByteArray*
 sqlx_pack_STATUS(const struct sqlx_name_s *name, gint64 deadline)
 {
 	MESSAGE req = make_request(NAME_MSGNAME_SQLX_STATUS, NULL, name, deadline);

--- a/sqliterepo/sqlx_remote.h
+++ b/sqliterepo/sqlx_remote.h
@@ -103,7 +103,7 @@ GByteArray* sqlx_pack_PIPEFROM(const struct sqlx_name_s *name, const gchar *sour
 GByteArray* sqlx_pack_PIPETO(const struct sqlx_name_s *name, const gchar *target, gint64 deadline);
 GByteArray* sqlx_pack_REMOVE(const struct sqlx_name_s *name, gint64 deadline);
 GByteArray* sqlx_pack_RESYNC(const struct sqlx_name_s *name, gint64 deadline);
-
+GByteArray* sqlx_pack_VACUUM(const struct sqlx_name_s *name, gboolean local, gint64 deadline);
 GByteArray* sqlx_pack_DUMP(const struct sqlx_name_s *name, gboolean chunked, gint64 deadline);
 GByteArray* sqlx_pack_RESTORE(const struct sqlx_name_s *name, const guint8 *raw, gsize rawsize, gint64 deadline);
 

--- a/sqliterepo/sqlx_remote_ex.h
+++ b/sqliterepo/sqlx_remote_ex.h
@@ -27,4 +27,8 @@ License along with this library.
 GError* sqlx_remote_execute_DESTROY_many(gchar **targets, GByteArray *sid,
 		struct sqlx_name_s *name, gint64 deadline);
 
+/* Ask followers to download the whole database from the leader. */
+GError* sqlx_remote_execute_RESYNC_many(gchar **targets, GByteArray *sid,
+		struct sqlx_name_s *name, gint64 deadline);
+
 #endif /*OIO_SDS__sqliterepo__sqlx_remote_ex_h*/


### PR DESCRIPTION
##### SUMMARY
Defragment (call `vacuum`) the database on the master service, then resynchronize it on the slaves. This works for meta0, meta1 and meta2 services, but the CLI only implements it for meta2 services (`openio-admin container vacuum`).

Jira: OS-299

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- sqliterepo
- CLI

##### SDS VERSION
```
openio 4.6.1.dev25
```