### PR TITLE
Prepare contents in the proxy

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -491,7 +491,7 @@ Used by `gcc`
 
 > Should the meta2 check the container state (quota, etc) before generating chunks.
 
- * default: **TRUE**
+ * default: **FALSE**
  * type: gboolean
  * cmake directive: *OIO_META2_GENERATE_PRECHECK*
 

--- a/conf.json
+++ b/conf.json
@@ -31,7 +31,7 @@
 			{ "type": "bool", "name": "meta2_flag_precheck_on_generate",
 				"key": "meta2.generate.precheck",
 				"descr": "Should the meta2 check the container state (quota, etc) before generating chunks.",
-				"def": true },
+				"def": false },
 
 			{ "type": "bool", "name": "meta2_flag_delete_exceeding_versions",
 				"key": "meta2.delete_exceeding_versions",

--- a/core/http_internals.h
+++ b/core/http_internals.h
@@ -166,7 +166,7 @@ struct oio_proxy_content_prepare_out_s
 };
 
 GError * oio_proxy_call_content_prepare (CURL *h, struct oio_url_s *u,
-		gsize size, gboolean autocreate,
+		gsize size, const char *stgpol,
 		struct oio_proxy_content_prepare_out_s *out);
 
 struct oio_proxy_content_create_in_s
@@ -178,8 +178,9 @@ struct oio_proxy_content_create_in_s
 	const char *hash;
 	const char *stgpol;
 	const char *chunk_method;
-	unsigned int append : 1;
-	unsigned int update : 1; // accept holes in metachunk positions
+	guint8 append : 1;
+	guint8 update : 1; // accept holes in metachunk positions
+	guint8 autocreate : 1; // autocreate the reference and link a (set of) container(s)
 	const char * const * properties;
 };
 

--- a/core/tool_sdk.c
+++ b/core/tool_sdk.c
@@ -79,6 +79,12 @@ static int _upload (int argc, char **argv, gboolean append, int replace) {
 	src.data.hook.cb = _gen;
 	src.data.hook.ctx = NULL;
 	src.data.hook.size = size;
+
+	const gchar *props[] = {
+		"policy", g_getenv("OIO_POLICY"),
+		NULL
+	};
+
 	struct oio_sds_ul_dst_s dst = OIO_SDS_UPLOAD_DST_INIT;
 	dst.url = url;
 	dst.autocreate = 1;
@@ -86,6 +92,7 @@ static int _upload (int argc, char **argv, gboolean append, int replace) {
 	dst.append = BOOL(append);
 	dst.partial = BOOL(replace >= 0);
 	dst.meta_pos = replace;
+	dst.properties = (const char * const *)props;
 
 	if (dst.append || dst.partial) {
 		void _cb(void *i UNUSED, enum oio_sds_content_key_e k, const char *v) {

--- a/meta2v2/CMakeLists.txt
+++ b/meta2v2/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(meta2v2utils STATIC
 		meta2_bean_utils.c
 		meta2_utils_json_in.c
 		meta2_utils_json_out.c
+		meta2_utils_lb.c
 )
 
 target_link_libraries(meta2v2utils
@@ -67,7 +68,6 @@ add_library(meta2v2 STATIC
 		${CMAKE_CURRENT_BINARY_DIR}/autogen_storage.c
 		generic_backend.c
 		meta2_utils.c
-		meta2_utils_lb.c
 		meta2_backend.c)
 
 target_link_libraries(meta2v2

--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -29,14 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <meta2v2/generic.h>
 #include <meta2v2/autogen.h>
 #include <meta2v2/meta2_utils_json.h>
-
-#define RANDOM_UID(uid,uid_size) \
-	struct { guint64 now; guint32 r; guint16 pid; guint16 th; } uid; \
-	uid.now = oio_ext_real_time (); \
-	uid.r = oio_ext_rand_int(); \
-	uid.pid = getpid(); \
-	uid.th = oio_log_current_thread_id(); \
-	gsize uid_size = sizeof(uid);
+#include <meta2v2/meta2_utils_lb.h>
 
 static GError*
 _get_container_policy(struct sqlx_sqlite3_s *sq3, struct namespace_info_s *nsinfo,
@@ -64,25 +57,6 @@ _is_empty_prop(gpointer bean)
 		return FALSE;
 	GByteArray *val = PROPERTIES_get_value((struct bean_PROPERTIES_s *)bean);
 	return !val || !val->len || !val->data;
-}
-
-gchar*
-m2v2_build_chunk_url (const char *srv, const char *id)
-{
-	return g_strconcat("http://", srv, "/", id, NULL);
-}
-
-static gchar*
-m2v2_build_chunk_url_storage (const struct storage_policy_s *pol,
-		const gchar *str_id)
-{
-	switch(data_security_get_type(storage_policy_get_data_security(pol))) {
-	case STGPOL_DS_BACKBLAZE:
-		return g_strconcat("b2/", str_id, NULL);
-	default:
-		return NULL;
-	}
-	return NULL;
 }
 
 void
@@ -2207,269 +2181,24 @@ out:
 
 /* GENERATOR ---------------------------------------------------------------- */
 
-struct gen_ctx_s
-{
-	struct oio_url_s *url;
-	const struct storage_policy_s *pol;
-	struct oio_lb_s *lb;
-	guint8 *uid;
-	gsize uid_size;
-	guint8 h[16];
-	gint64 size;
-	gint64 chunk_size;
-	m2_onbean_cb cb;
-	gpointer cb_data;
-};
-
-static guint
-_policy_parameter(struct storage_policy_s *pol, const gchar *key, guint def)
-{
-	const char *s;
-	if (!pol || !key)
-		return def;
-	s = data_security_get_param(storage_policy_get_data_security(pol), key);
-	if (!s)
-		return def;
-	return (guint) atoi(s);
-}
-
-static void
-_m2_generate_alias_header(struct gen_ctx_s *ctx)
-{
-	const gchar *p;
-	p = ctx->pol ? storage_policy_get_name(ctx->pol) : "none";
-
-	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
-	const gint64 now = oio_ext_real_time ();
-
-	struct bean_ALIASES_s *alias = _bean_create(&descr_struct_ALIASES);
-	ALIASES_set2_alias(alias, oio_url_get(ctx->url, OIOURL_PATH));
-	gint64 version;
-	if (oio_url_has(ctx->url, OIOURL_VERSION) &&
-			(version = g_ascii_strtoll(
-				oio_url_get(ctx->url, OIOURL_VERSION), NULL, 10)) > 0) {
-		ALIASES_set_version(alias, version);
-	} else {
-		ALIASES_set_version(alias, now);
-	}
-	ALIASES_set_ctime(alias, now / G_TIME_SPAN_SECOND);
-	ALIASES_set_mtime(alias, now / G_TIME_SPAN_SECOND);
-	ALIASES_set_deleted(alias, FALSE);
-	ALIASES_set2_content(alias, ctx->uid, ctx->uid_size);
-	ctx->cb(ctx->cb_data, alias);
-
-	struct bean_CONTENTS_HEADERS_s *header;
-	header = _bean_create(&descr_struct_CONTENTS_HEADERS);
-	CONTENTS_HEADERS_set_size(header, ctx->size);
-	CONTENTS_HEADERS_set2_id(header, ctx->uid, ctx->uid_size);
-	CONTENTS_HEADERS_set2_policy(header, p);
-	CONTENTS_HEADERS_nullify_hash(header);
-	CONTENTS_HEADERS_set_ctime(header, now / G_TIME_SPAN_SECOND);
-	CONTENTS_HEADERS_set_mtime(header, now / G_TIME_SPAN_SECOND);
-	CONTENTS_HEADERS_set2_mime_type(header, OIO_DEFAULT_MIMETYPE);
-
-	GString *chunk_method = storage_policy_to_chunk_method(ctx->pol);
-	CONTENTS_HEADERS_set_chunk_method(header, chunk_method);
-	g_string_free(chunk_method, TRUE);
-	ctx->cb(ctx->cb_data, header);
-}
-
-static int
-is_stgpol_backblaze(const struct storage_policy_s *pol)
-{
-	switch(data_security_get_type(storage_policy_get_data_security(pol))) {
-		case STGPOL_DS_BACKBLAZE:
-			return TRUE;
-		default:
-			return FALSE;
-	}
-	return FALSE;
-}
-
-static GString*
-_selected_item_quality_to_json(GString *inout,
-		struct oio_lb_selected_item_s *sel)
-{
-	GString *qual = inout? : g_string_sized_new(128);
-	g_string_append_c(qual, '{');
-	oio_str_gstring_append_json_pair_int(qual,
-			"expected_dist", sel->expected_dist);
-	g_string_append_c(qual, ',');
-	oio_str_gstring_append_json_pair_int(qual,
-			"final_dist", sel->final_dist);
-	g_string_append_c(qual, ',');
-	oio_str_gstring_append_json_pair_int(qual,
-			"warn_dist", sel->warn_dist);
-	g_string_append_c(qual, ',');
-	oio_str_gstring_append_json_pair(qual,
-			"expected_slot", sel->expected_slot);
-	g_string_append_c(qual, ',');
-	oio_str_gstring_append_json_pair(qual,
-			"final_slot", sel->final_slot);
-	g_string_append_c(qual, '}');
-	return qual;
-}
-
-struct bean_CHUNKS_s *
-generate_chunk_bean(struct oio_lb_selected_item_s *sel,
-		const struct storage_policy_s *policy)
-{
-	guint8 binid[32];
-	gchar *chunkid, strid[65];
-
-	oio_buf_randomize(binid, sizeof(binid));
-	oio_str_bin2hex(binid, sizeof(binid), strid, sizeof(strid));
-
-	if (sel->item->id) {
-		gchar shifted_id[LIMIT_LENGTH_SRVID];
-		g_strlcpy(shifted_id, sel->item->id, sizeof(shifted_id));
-		meta1_url_shift_addr(shifted_id);
-		chunkid = m2v2_build_chunk_url(shifted_id, strid);
-	} else {
-		EXTRA_ASSERT(policy != NULL);
-		chunkid = m2v2_build_chunk_url_storage(policy, strid);
-	}
-
-	struct bean_CHUNKS_s *chunk = _bean_create(&descr_struct_CHUNKS);
-	CHUNKS_set2_id(chunk, chunkid);
-	CHUNKS_set_ctime(chunk, oio_ext_real_time() / G_TIME_SPAN_SECOND);
-	g_free(chunkid);
-
-	return chunk;
-}
-
-struct bean_PROPERTIES_s *
-generate_chunk_quality_bean(struct oio_lb_selected_item_s *sel,
-		const gchar *chunkid, struct oio_url_s *url)
-{
-	GString *qual = _selected_item_quality_to_json(NULL, sel);
-	struct bean_PROPERTIES_s *prop = _bean_create(&descr_struct_PROPERTIES);
-	gchar *prop_key = g_alloca(
-			sizeof(OIO_CHUNK_SYSMETA_PREFIX) + strlen(chunkid));
-	sprintf(prop_key, OIO_CHUNK_SYSMETA_PREFIX"%s", chunkid);
-	PROPERTIES_set2_key(prop, prop_key);
-	PROPERTIES_set2_value(prop, (guint8*)qual->str, qual->len);
-	if (url && oio_url_has(url, OIOURL_PATH))
-		PROPERTIES_set2_alias(prop, oio_url_get(url, OIOURL_PATH));
-
-	g_string_free(qual, TRUE);
-	return prop;
-}
-
-static void
-_gen_chunk(struct gen_ctx_s *ctx, struct oio_lb_selected_item_s *sel,
-		gint64 cs, guint pos, gint subpos)
-{
-	gchar strpos[24];
-
-	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
-
-	if (subpos < 0)
-		g_snprintf(strpos, sizeof(strpos), "%u", pos);
-	else
-		g_snprintf(strpos, sizeof(strpos), "%u.%d", pos, subpos);
-
-	struct bean_CHUNKS_s *chunk = generate_chunk_bean(sel, ctx->pol);
-	CHUNKS_set2_content(chunk, ctx->uid, ctx->uid_size);
-	CHUNKS_set2_hash(chunk, ctx->h, sizeof(ctx->h));
-	CHUNKS_set_size(chunk, cs);
-	CHUNKS_set2_position(chunk, strpos);
-	ctx->cb(ctx->cb_data, chunk);
-
-	/* Create a property to represent the quality of the selected chunk. */
-	struct bean_PROPERTIES_s *prop = generate_chunk_quality_bean(
-			sel, CHUNKS_get_id(chunk)->str, ctx->url);
-	ctx->cb(ctx->cb_data, prop);
-
-}
-
-static GError*
-_m2_generate_chunks(struct gen_ctx_s *ctx,
-		gint64 mcs /* actual metachunk size */,
-		gboolean subpos)
-{
-	GError *err = NULL;
-
-	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
-
-	_m2_generate_alias_header(ctx);
-
-	guint pos = 0;
-	gint64 esize = MAX(ctx->size, 1);
-	for (gint64 s = 0; s < esize && !err; s += mcs, ++pos) {
-		int i = 0;
-		void _on_id(struct oio_lb_selected_item_s *sel, gpointer u UNUSED)
-		{
-			if (is_stgpol_backblaze(ctx->pol)) {
-				// Shortcut for backblaze
-				_gen_chunk(ctx, NULL, ctx->chunk_size, pos, -1);
-			} else {
-				_gen_chunk(ctx, sel, ctx->chunk_size, pos, subpos? i : -1);
-			}
-			i++;
-		}
-		const char *pool = storage_policy_get_service_pool(ctx->pol);
-		// FIXME(FVE): set last argument
-		if ((err = oio_lb__poll_pool(ctx->lb, pool, NULL, _on_id, NULL))) {
-			g_prefix_error(&err, "at position %u: did not find enough "
-					"services matching the criteria for pool [%s]: ",
-					pos, pool);
-		}
-	}
-
-	return err;
-}
 
 GError*
 m2_generate_beans(struct oio_url_s *url, gint64 size, gint64 chunk_size,
 		struct storage_policy_s *pol, struct oio_lb_s *lb,
 		m2_onbean_cb cb, gpointer cb_data)
 {
-	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(url, OIOURL_WHOLE));
-	EXTRA_ASSERT(url != NULL);
-
-	if (!oio_url_has(url, OIOURL_PATH))
-		return NEWERROR(CODE_BAD_REQUEST, "Missing path");
-	if (size < 0)
-		return NEWERROR(CODE_BAD_REQUEST, "Invalid size");
-	if (chunk_size <= 0)
-		return NEWERROR(CODE_BAD_REQUEST, "Invalid chunk size");
-
-	RANDOM_UID(_uid, uid_size);
-	guint8 *uid = (guint8 *) &_uid;
-	const gchar *content_id = oio_url_get(url, OIOURL_CONTENTID);
-	if (content_id) {
-		gsize len = strlen(content_id);
-		uid_size = len/2;
-		oio_str_hex2bin(content_id, uid, uid_size);
+	GSList *beans = NULL;
+	GError *err = oio_generate_beans(url, size, chunk_size, pol, lb, &beans);
+	if (err)
+		return err;
+	if (cb) {
+		for (GSList *l=beans; l; l=l->next)
+			cb(cb_data, l->data);
+		g_slist_free(beans);
+	} else {
+		_bean_cleanl2(beans);
 	}
-	struct gen_ctx_s ctx;
-	memset(&ctx, 0, sizeof(ctx));
-
-	ctx.url = url;
-	ctx.pol = pol;
-	ctx.uid = uid;
-	ctx.uid_size = uid_size;
-	ctx.size = size;
-	ctx.chunk_size = chunk_size;
-	ctx.cb = cb;
-	ctx.cb_data = cb_data;
-	ctx.lb = lb;
-
-	if (!pol)
-		return _m2_generate_chunks(&ctx, chunk_size, 0);
-
-	gint64 k;
-	switch (data_security_get_type(storage_policy_get_data_security(pol))) {
-		case STGPOL_DS_BACKBLAZE:
-		case STGPOL_DS_PLAIN:
-			return _m2_generate_chunks(&ctx, chunk_size, 0);
-		case STGPOL_DS_EC:
-			k = _policy_parameter(pol, DS_KEY_K, 6);
-			return _m2_generate_chunks(&ctx, k*chunk_size, TRUE);
-		default:
-			return NEWERROR(CODE_POLICY_NOT_SUPPORTED, "Invalid policy type");
-	}
+	return NULL;
 }
 
 enum _content_broken_state_e
@@ -2714,8 +2443,8 @@ _check_ec_content(struct m2v2_sorted_content_s *content,
 
 	gint64 size = CONTENTS_HEADERS_get_size(content->header);
 	struct checked_content_s *checked_content = _checked_content_new(
-			partial, 0, _policy_parameter(pol, DS_KEY_K, 6),
-			_policy_parameter(pol, DS_KEY_M, 3));
+			partial, 0, storage_policy_parameter(pol, DS_KEY_K, 6),
+			storage_policy_parameter(pol, DS_KEY_M, 3));
 
 	g_tree_foreach(content->metachunks, _foreach_check_ec_content,
 			checked_content);
@@ -2829,7 +2558,7 @@ m2db_check_content_quality(struct m2v2_sorted_content_s *sorted_content,
 				g_string_append_c(out, ',');
 				oio_str_gstring_append_json_quote(out, "quality");
 				g_string_append_c(out, ':');
-				_selected_item_quality_to_json(out, item);
+				m2_selected_item_quality_to_json(out, item);
 				if (item->final_dist <= item->warn_dist ||
 						strcmp(item->final_slot, item->expected_slot)) {
 					must_send_event = TRUE;

--- a/meta2v2/meta2_utils.h
+++ b/meta2v2/meta2_utils.h
@@ -51,9 +51,6 @@ struct list_params_s
 	guint8 flag_local     :1;
 };
 
-gchar* m2v2_build_chunk_url(const char *srv, const char *id);
-
-
 struct m2v2_position_s {
 	int meta, intra;
 	unsigned int flag_parity : 1;

--- a/meta2v2/meta2_utils_lb.c
+++ b/meta2v2/meta2_utils_lb.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <metautils/lib/metautils.h>
 #include <metautils/lib/metacomm.h>
@@ -65,7 +66,7 @@ out:
 	return err;
 }
 
-//------------------------------------------------------------------------------
+/* ------------------------------------------------------------------------- */
 
 GError*
 get_spare_chunks(struct oio_lb_s *lb, const char *pool,
@@ -93,7 +94,7 @@ get_spare_chunks(struct oio_lb_s *lb, const char *pool,
 	return err;
 }
 
-//------------------------------------------------------------------------------
+/* ------------------------------------------------------------------------- */
 
 static oio_location_t *
 convert_chunks_to_locations(struct oio_lb_pool_s *pool, const gchar *ns_name,
@@ -167,3 +168,279 @@ get_conditioned_spare_chunks(struct oio_lb_s *lb, const char *pool,
 	return err;
 }
 
+/* ------------------------------------------------------------------------- */
+
+static gchar*
+m2v2_build_chunk_url (const char *srv, const char *id)
+{
+	return g_strconcat("http://", srv, "/", id, NULL);
+}
+
+static gchar*
+m2v2_build_chunk_url_storage (const struct storage_policy_s *pol,
+		const gchar *str_id)
+{
+	switch(data_security_get_type(storage_policy_get_data_security(pol))) {
+	case STGPOL_DS_BACKBLAZE:
+		return g_strconcat("b2/", str_id, NULL);
+	default:
+		return NULL;
+	}
+	return NULL;
+}
+
+struct gen_ctx_s
+{
+	struct oio_url_s *url;
+	const struct storage_policy_s *pol;
+	struct oio_lb_s *lb;
+	guint8 *uid;
+	gsize uid_size;
+	guint8 h[16];
+	gint64 size;
+	gint64 chunk_size;
+	GSList **out;
+};
+
+static void
+_collect_bean(struct gen_ctx_s *ctx, gpointer bean)
+{
+	*ctx->out = g_slist_prepend(*ctx->out, bean);
+}
+
+static void
+_m2_generate_alias_header(struct gen_ctx_s *ctx)
+{
+	const gchar *p;
+	p = ctx->pol ? storage_policy_get_name(ctx->pol) : "none";
+
+	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
+	const gint64 now = oio_ext_real_time ();
+
+	struct bean_ALIASES_s *alias = _bean_create(&descr_struct_ALIASES);
+	ALIASES_set2_alias(alias, oio_url_get(ctx->url, OIOURL_PATH));
+	gint64 version;
+	if (oio_url_has(ctx->url, OIOURL_VERSION) &&
+			(version = g_ascii_strtoll(
+				oio_url_get(ctx->url, OIOURL_VERSION), NULL, 10)) > 0) {
+		ALIASES_set_version(alias, version);
+	} else {
+		ALIASES_set_version(alias, now);
+	}
+	ALIASES_set_ctime(alias, now / G_TIME_SPAN_SECOND);
+	ALIASES_set_mtime(alias, now / G_TIME_SPAN_SECOND);
+	ALIASES_set_deleted(alias, FALSE);
+	ALIASES_set2_content(alias, ctx->uid, ctx->uid_size);
+	_collect_bean(ctx, alias);
+
+	struct bean_CONTENTS_HEADERS_s *header;
+	header = _bean_create(&descr_struct_CONTENTS_HEADERS);
+	CONTENTS_HEADERS_set_size(header, ctx->size);
+	CONTENTS_HEADERS_set2_id(header, ctx->uid, ctx->uid_size);
+	CONTENTS_HEADERS_set2_policy(header, p);
+	CONTENTS_HEADERS_nullify_hash(header);
+	CONTENTS_HEADERS_set_ctime(header, now / G_TIME_SPAN_SECOND);
+	CONTENTS_HEADERS_set_mtime(header, now / G_TIME_SPAN_SECOND);
+	CONTENTS_HEADERS_set2_mime_type(header, OIO_DEFAULT_MIMETYPE);
+
+	GString *chunk_method = storage_policy_to_chunk_method(ctx->pol);
+	CONTENTS_HEADERS_set_chunk_method(header, chunk_method);
+	g_string_free(chunk_method, TRUE);
+	_collect_bean(ctx, header);
+}
+
+static int
+is_stgpol_backblaze(const struct storage_policy_s *pol)
+{
+	switch(data_security_get_type(storage_policy_get_data_security(pol))) {
+		case STGPOL_DS_BACKBLAZE:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+	return FALSE;
+}
+
+GString*
+m2_selected_item_quality_to_json(GString *inout,
+		struct oio_lb_selected_item_s *sel)
+{
+	GString *qual = inout? : g_string_sized_new(128);
+	g_string_append_c(qual, '{');
+	oio_str_gstring_append_json_pair_int(qual,
+			"expected_dist", sel->expected_dist);
+	g_string_append_c(qual, ',');
+	oio_str_gstring_append_json_pair_int(qual,
+			"final_dist", sel->final_dist);
+	g_string_append_c(qual, ',');
+	oio_str_gstring_append_json_pair_int(qual,
+			"warn_dist", sel->warn_dist);
+	g_string_append_c(qual, ',');
+	oio_str_gstring_append_json_pair(qual,
+			"expected_slot", sel->expected_slot);
+	g_string_append_c(qual, ',');
+	oio_str_gstring_append_json_pair(qual,
+			"final_slot", sel->final_slot);
+	g_string_append_c(qual, '}');
+	return qual;
+}
+
+struct bean_CHUNKS_s *
+generate_chunk_bean(struct oio_lb_selected_item_s *sel,
+		const struct storage_policy_s *policy)
+{
+	guint8 binid[32];
+	gchar *chunkid, strid[65];
+
+	oio_buf_randomize(binid, sizeof(binid));
+	oio_str_bin2hex(binid, sizeof(binid), strid, sizeof(strid));
+
+	if (sel->item->id) {
+		gchar shifted_id[LIMIT_LENGTH_SRVID];
+		g_strlcpy(shifted_id, sel->item->id, sizeof(shifted_id));
+		meta1_url_shift_addr(shifted_id);
+		chunkid = m2v2_build_chunk_url(shifted_id, strid);
+	} else {
+		EXTRA_ASSERT(policy != NULL);
+		chunkid = m2v2_build_chunk_url_storage(policy, strid);
+	}
+
+	struct bean_CHUNKS_s *chunk = _bean_create(&descr_struct_CHUNKS);
+	CHUNKS_set2_id(chunk, chunkid);
+	CHUNKS_set_ctime(chunk, oio_ext_real_time() / G_TIME_SPAN_SECOND);
+	g_free(chunkid);
+
+	return chunk;
+}
+
+struct bean_PROPERTIES_s *
+generate_chunk_quality_bean(struct oio_lb_selected_item_s *sel,
+		const gchar *chunkid, struct oio_url_s *url)
+{
+	GString *qual = m2_selected_item_quality_to_json(NULL, sel);
+	struct bean_PROPERTIES_s *prop = _bean_create(&descr_struct_PROPERTIES);
+	gchar *prop_key = g_alloca(
+			sizeof(OIO_CHUNK_SYSMETA_PREFIX) + strlen(chunkid));
+	sprintf(prop_key, OIO_CHUNK_SYSMETA_PREFIX"%s", chunkid);
+	PROPERTIES_set2_key(prop, prop_key);
+	PROPERTIES_set2_value(prop, (guint8*)qual->str, qual->len);
+	if (url && oio_url_has(url, OIOURL_PATH))
+		PROPERTIES_set2_alias(prop, oio_url_get(url, OIOURL_PATH));
+
+	g_string_free(qual, TRUE);
+	return prop;
+}
+
+static void
+_gen_chunk(struct gen_ctx_s *ctx, struct oio_lb_selected_item_s *sel,
+		gint64 cs, guint pos, gint subpos)
+{
+	gchar strpos[24];
+
+	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
+
+	if (subpos < 0)
+		g_snprintf(strpos, sizeof(strpos), "%u", pos);
+	else
+		g_snprintf(strpos, sizeof(strpos), "%u.%d", pos, subpos);
+
+	struct bean_CHUNKS_s *chunk = generate_chunk_bean(sel, ctx->pol);
+	CHUNKS_set2_content(chunk, ctx->uid, ctx->uid_size);
+	CHUNKS_set2_hash(chunk, ctx->h, sizeof(ctx->h));
+	CHUNKS_set_size(chunk, cs);
+	CHUNKS_set2_position(chunk, strpos);
+	_collect_bean(ctx, chunk);
+
+	/* Create a property to represent the quality of the selected chunk. */
+	struct bean_PROPERTIES_s *prop = generate_chunk_quality_bean(
+			sel, CHUNKS_get_id(chunk)->str, ctx->url);
+	_collect_bean(ctx, prop);
+
+}
+
+static GError*
+_m2_generate_chunks(struct gen_ctx_s *ctx,
+		gint64 mcs /* actual metachunk size */,
+		gboolean subpos)
+{
+	GError *err = NULL;
+
+	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(ctx->url, OIOURL_WHOLE));
+
+	_m2_generate_alias_header(ctx);
+
+	guint pos = 0;
+	gint64 esize = MAX(ctx->size, 1);
+	for (gint64 s = 0; s < esize && !err; s += mcs, ++pos) {
+		int i = 0;
+		void _on_id(struct oio_lb_selected_item_s *sel, gpointer u UNUSED)
+		{
+			if (is_stgpol_backblaze(ctx->pol)) {
+				// Shortcut for backblaze
+				_gen_chunk(ctx, NULL, ctx->chunk_size, pos, -1);
+			} else {
+				_gen_chunk(ctx, sel, ctx->chunk_size, pos, subpos? i : -1);
+			}
+			i++;
+		}
+		const char *pool = storage_policy_get_service_pool(ctx->pol);
+		// FIXME(FVE): set last argument
+		if ((err = oio_lb__poll_pool(ctx->lb, pool, NULL, _on_id, NULL))) {
+			g_prefix_error(&err, "at position %u: did not find enough "
+					"services matching the criteria for pool [%s]: ",
+					pos, pool);
+		}
+	}
+
+	return err;
+}
+
+GError*
+oio_generate_beans(struct oio_url_s *url, gint64 size, gint64 chunk_size,
+		struct storage_policy_s *pol, struct oio_lb_s *lb,
+		GSList **out)
+{
+	GRID_TRACE2("%s(%s)", __FUNCTION__, oio_url_get(url, OIOURL_WHOLE));
+	EXTRA_ASSERT(url != NULL);
+
+	if (!oio_url_has(url, OIOURL_PATH))
+		return BADREQ("Missing path");
+	if (size < 0)
+		return BADREQ("Invalid size");
+	if (chunk_size <= 0)
+		return BADREQ("Invalid chunk size");
+
+	RANDOM_UID(_uid, uid_size);
+	guint8 *uid = (guint8 *) &_uid;
+	const gchar *content_id = oio_url_get(url, OIOURL_CONTENTID);
+	if (content_id) {
+		gsize len = strlen(content_id);
+		uid_size = len/2;
+		oio_str_hex2bin(content_id, uid, uid_size);
+	}
+
+	struct gen_ctx_s ctx = {};
+	ctx.url = url;
+	ctx.pol = pol;
+	ctx.uid = uid;
+	ctx.uid_size = uid_size;
+	ctx.size = size;
+	ctx.chunk_size = chunk_size;
+	ctx.lb = lb;
+	ctx.out = out;
+
+	if (!pol)
+		return _m2_generate_chunks(&ctx, chunk_size, 0);
+
+	gint64 k;
+	switch (data_security_get_type(storage_policy_get_data_security(pol))) {
+		case STGPOL_DS_BACKBLAZE:
+		case STGPOL_DS_PLAIN:
+			return _m2_generate_chunks(&ctx, chunk_size, 0);
+		case STGPOL_DS_EC:
+			k = storage_policy_parameter(pol, DS_KEY_K, 6);
+			return _m2_generate_chunks(&ctx, k*chunk_size, TRUE);
+		default:
+			return NEWERROR(CODE_POLICY_NOT_SUPPORTED, "Invalid policy type");
+	}
+}

--- a/meta2v2/meta2_utils_lb.h
+++ b/meta2v2/meta2_utils_lb.h
@@ -67,8 +67,8 @@ GError* get_spare_chunks(struct oio_lb_s *lb,
  * @param result Pointer to a list where spare chunks will be inserted
  * @return A GError in case of error
  */
-GError* get_conditioned_spare_chunks(struct oio_lb_s *lbp,
-		const char *stgpol, const gchar *ns_name,
+GError* get_conditioned_spare_chunks(struct oio_lb_s *lb,
+		const char *pool, const gchar *ns_name,
 		GSList *notin, GSList *broken,
 		GSList **result);
 

--- a/meta2v2/meta2_utils_lb.h
+++ b/meta2v2/meta2_utils_lb.h
@@ -24,11 +24,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <metautils/lib/metautils.h>
 #include <glib.h>
 
-/**
- * Signature of functions converting (struct service_info_s *)
- * to chunk information.
- */
-typedef gpointer (*srvinfo_to_chunk_f)(struct service_info_s *si);
+#define RANDOM_UID(uid,uid_size) \
+	struct { guint64 now; guint32 r; guint16 pid; guint16 th; } uid; \
+	uid.now = oio_ext_real_time (); \
+	uid.r = oio_ext_rand_int(); \
+	uid.pid = getpid(); \
+	uid.th = oio_log_current_thread_id(); \
+	gsize uid_size = sizeof(uid);
+
+GString* m2_selected_item_quality_to_json(GString *inout,
+		struct oio_lb_selected_item_s *sel);
+
+GError* oio_generate_beans(
+		struct oio_url_s *url, gint64 size, gint64 chunk_size,
+		struct storage_policy_s *pol, struct oio_lb_s *lb,
+		GSList **out);
 
 /**
  * Get as many spare chunks as required to upload one metachunk with the

--- a/metautils/lib/lb.c
+++ b/metautils/lib/lb.c
@@ -34,6 +34,10 @@ License along with this library.
 
 #include "metautils.h"
 
+static struct oio_lb_pool_s *
+oio_lb_pool__from_storage_policy(struct oio_lb_world_s *lbw,
+		const struct storage_policy_s *stgpol);
+
 void
 oio_lb_world__feed_service_info_list(struct oio_lb_world_s *lbw,
 		GSList *services)

--- a/metautils/lib/lb.h
+++ b/metautils/lib/lb.h
@@ -48,8 +48,9 @@ void oio_lb_world__feed_from_string(struct oio_lb_world_s *self,
 GError *oio_lb_world__feed_from_file(struct oio_lb_world_s *self,
 		const gchar *main_slot, const gchar *src_file);
 
-/** Check there is a pool for each storage policy. If not, create a dummy one.
- * @see oio_lb_pool__from_storage_policy */
+/** Check there is a pool for each storage policy. If not,
+ * create a service pool returning sets of services satisfying
+ * the specified storage policy */
 void oio_lb_world__reload_storage_policies(struct oio_lb_world_s *lbw,
 		struct oio_lb_s *lb, struct namespace_info_s *nsinfo);
 
@@ -69,12 +70,6 @@ struct oio_lb_pool_s *oio_lb_pool__from_service_policy(
 		struct oio_lb_world_s *lbw,
 		const gchar *srvtype,
 		struct service_update_policies_s *pols);
-
-/** Create a service pool returning sets of services satisfying
- * the specified storage policy */
-struct oio_lb_pool_s *oio_lb_pool__from_storage_policy(
-		struct oio_lb_world_s *lbw,
-		const struct storage_policy_s *stgpol);
 
 /* Repeatedly call oio_lb_pool__poll(), check for unbalanced situations,
  * and count how many times each service has been selected. */

--- a/metautils/lib/storage_policy.h
+++ b/metautils/lib/storage_policy.h
@@ -92,6 +92,15 @@ gint64 data_security_get_int64_param(const struct data_security_s *ds,
 		const char *key, gint64 def);
 
 static inline gint64
+storage_policy_parameter(struct storage_policy_s *pol, const char *key, gint64 def)
+{
+	if (!pol || !key)
+		return def;
+	return data_security_get_int64_param(
+			storage_policy_get_data_security(pol), key, def);
+}
+
+static inline gint64
 data_security_decode_param_int64 (const char *encoded, const char *k, gint64 def)
 {
 	gint64 rc = def;

--- a/oio/cli/cluster/cluster.py
+++ b/oio/cli/cluster/cluster.py
@@ -233,6 +233,14 @@ class ClusterUnlockAll(lister.Lister):
         return columns, self._unlock_all(parsed_args)
 
 
+def _sleep_interval():
+    yield 0.5
+    yield 1.0
+    yield 2.0
+    while True:
+        yield 3.0
+
+
 class ClusterWait(lister.Lister):
     """Wait for services to get a score above specified value."""
 
@@ -300,6 +308,7 @@ class ClusterWait(lister.Lister):
                             srv['type'], srv['id'], srv['score'])
                 raise Exception(msg)
 
+        interval = _sleep_interval()
         while True:
             descr = []
             for type_ in types:
@@ -317,7 +326,7 @@ class ClusterWait(lister.Lister):
                         self.log.debug("Only %d services up", ok)
                         check_deadline()
                         maybe_unlock(descr)
-                        sleep(1.0)
+                        sleep(next(interval))
                         continue
                 # No service down, and enough services, we are done.
                 for srv in descr:
@@ -327,7 +336,7 @@ class ClusterWait(lister.Lister):
                 self.log.debug("Still %d services down", ko)
                 check_deadline()
                 maybe_unlock(descr)
-                sleep(1.0)
+                sleep(next(interval))
 
     def take_action(self, parsed_args):
         columns = ('Type', 'Service', 'Score')

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -2352,6 +2352,8 @@ _action_m2_content_prepare(struct req_args_s *args, struct json_object *jargs,
 
 	const gchar *strsize = !jsize ? NULL : json_object_get_string (jsize);
 	const gchar *stgpol = !jpol ? NULL : json_object_get_string (jpol);
+	if (!stgpol)
+		stgpol = oio_ns_storage_policy;
 
 	/* Parse the size */
 	if (!strsize)

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -98,19 +98,6 @@ GByteArray* m2v2_remote_pack_DEDUP(
 		struct oio_url_s *url,
 		gint64 deadline);
 
-GByteArray* m2v2_remote_pack_BEANS(
-		struct oio_url_s *url,
-		const char *pol,
-		gint64 size,
-		gboolean append,
-		gint64 deadline);
-
-GByteArray* m2v2_remote_pack_SPARE(
-		struct oio_url_s *url,
-		const char *pol,
-		GSList *notin_list,
-		GSList *broken_list,
-		gint64 deadline);
 
 GByteArray* m2v2_remote_pack_PUT(
 		struct oio_url_s *url,

--- a/tests/functional/cli/cluster/test_cluster.py
+++ b/tests/functional/cli/cluster/test_cluster.py
@@ -127,6 +127,6 @@ class ClusterTest(CliTestCase):
         data = json.loads(output)
         self.assertTrue(all([node['Result'] == 'unlocked' for node in data]))
         # Wait for services to be non-zero-scored
-        output = self.openio('cluster wait rawx -d 99 -s 20' + opts)
+        output = self.openio('cluster wait rawx -d 99 -s 1' + opts)
         data = json.loads(output)
-        self.assertTrue(all([node['Score'] > 20 for node in data]))
+        self.assertTrue(all([node['Score'] > 1 for node in data]))

--- a/tests/functional/container/test_container.py
+++ b/tests/functional/container/test_container.py
@@ -1036,18 +1036,13 @@ class TestMeta2Contents(BaseTestCase):
         return True
 
     def test_prepare(self):
-        headers = {'X-oio-action-mode': 'autocreate'}
         params = self.param_content(self.ref, random_content())
 
         resp = self.request('POST', self.url_content('prepare'), params=params)
         self.assertError(resp, 400, 400)
+        # A content/prepare now works despite the container is not created
         resp = self.request('POST', self.url_content('prepare'),
                             params=params, data=json.dumps({'size': 1024}))
-        self.assertError(resp, 404, 406)
-        resp = self.request('POST', self.url_content('prepare'),
-                            params=params, data=json.dumps({'size': 1024}),
-                            headers=headers)
-        self.assertEqual(resp.status, 200)
         self.assertTrue(self.valid_chunks(self.json_loads(resp.data)))
         # TODO test /content/prepare with additional useless parameters
         # TODO test /content/prepare with invalid sizes
@@ -1069,8 +1064,11 @@ class TestMeta2Contents(BaseTestCase):
         self.assertEqual(resp.status, 400)
 
     def test_spare_with_one_missing(self):
+        stg_policy = self.conscience.info().get(
+                'options', dict()).get('storage_policy')
         headers = {'X-oio-action-mode': 'autocreate'}
         params = self.param_content(self.ref, random_content())
+        params.update({'stgpol': stg_policy})
         resp = self.request('POST', self.url_content('prepare2'),
                             params=params, data=json.dumps({'size': 1024}),
                             headers=headers)
@@ -1094,8 +1092,12 @@ class TestMeta2Contents(BaseTestCase):
         self.assertEqual(1, len(spare_data['properties']))
 
     def _test_spare_with_n_broken(self, count_broken):
+        stg_policy = self.conscience.info().get(
+                'options', dict()).get('storage_policy')
+
         headers = {'X-oio-action-mode': 'autocreate'}
         params = self.param_content(self.ref, random_content())
+        params.update({'stgpol': stg_policy})
         resp = self.request('POST', self.url_content('prepare2'),
                             params=params, data=json.dumps({'size': 1024}),
                             headers=headers)
@@ -1119,6 +1121,7 @@ class TestMeta2Contents(BaseTestCase):
                             data=json.dumps(
                                 {"notin": chunks,
                                  "broken": broken}))
+        print resp.data
         self.assertEqual(resp.status, 200)
         spare_data = self.json_loads(resp.data)
         # Since we extracted N chunks, there must be exactly N chunks in

--- a/tests/functional/m2_filters/test_filters.py
+++ b/tests/functional/m2_filters/test_filters.py
@@ -84,14 +84,14 @@ class TestFilters(BaseTestCase):
         path = 'test_worm'
         content = self._new_content(data, path, True)
 
-        # Prepare without admin mode
-        self.assertRaises(Conflict, self._prepare_content, path, None, False)
-        self.assertRaises(Conflict, self._prepare_content, path,
-                          content.content_id, False)
-        self.assertRaises(Conflict, self._prepare_content, 'test_worm_prepare',
-                          content.content_id, False)
-        self.assertRaises(Conflict, self._prepare_content, path, random_id(32),
-                          False)
+        # Prepare without admin mode:
+        # Since the 'prepare' step is done in the proxy, there is no check
+        # on the pre-existence of the content. The subsequent prepare MUST
+        # now work despite the presence of the content.
+        self._prepare_content(path, None, False)
+        self._prepare_content(path, content.content_id, False)
+        self._prepare_content('test_worm_prepare', content.content_id, False)
+        self._prepare_content(path, random_id(32), False)
 
         # Overwrite without admin mode
         data2 = random_data(11)

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -992,7 +992,7 @@ defaults = {
     'REPLI_M1': 1,
     'COMPRESSION': "off",
     MONITOR_PERIOD: 1,
-    M1_DIGITS: 4}
+    M1_DIGITS: 2}
 
 # XXX When /usr/sbin/httpd is present we suspect a Redhat/Centos/Fedora
 # environment. If not, we consider being in a Ubuntu/Debian environment.

--- a/tools/oio-test-suites.sh
+++ b/tools/oio-test-suites.sh
@@ -148,7 +148,7 @@ ec_tests () {
 	SIZE0=$((256*1024*1024))
 	export OIO_USER=user-$RANDOM OIO_PATH=path-$RANDOM
 	echo $OIO_NS $OIO_ACCOUNT $OIO_USER $OIO_PATH
-	( export G_DEBUG_LEVEL=W ; ./core/tool_sdk put $SIZE0 )
+	( export G_DEBUG_LEVEL=W ; ${WRKDIR}/core/tool_sdk put $SIZE0 )
 	openio object save $OIO_USER $OIO_PATH
 	SIZE=$(stat --printf='%s' $OIO_PATH)
 	/bin/rm "$OIO_PATH"
@@ -250,7 +250,7 @@ func_tests () {
 	rm "/$HOME/.oio/sds.conf"
 	export OIO_PROXY=$(oio-test-config.py -t proxy -1)
 	export OIO_ECD=$(oio-test-config.py -t ecd -1)
-	./core/tool_sdk_noconf
+	${WRKDIR}/core/tool_sdk_noconf
 
 	gridinit_cmd -S $HOME/.oio/sds/run/gridinit.sock stop
 	sleep 0.5

--- a/tools/oio-test-suites.sh
+++ b/tools/oio-test-suites.sh
@@ -167,15 +167,17 @@ test_zookeeper_failure() {
 	# Old systemd versions do not recognize --value, whence the eval hack
 	#MainPID=$(sudo systemctl show -p MainPID --value zookeeper)
 	eval $(sudo systemctl show -p MainPID zookeeper)
-	sudo kill -STOP $MainPID
-	openio election debug meta2 test_zookeeper_failure
-	sleep 11
-	sudo kill -CONT $MainPID
+	if [[ -n "$MainPID" ]] && [[ $MainPID -gt 0 ]] ; then
+		sudo kill -STOP $MainPID
+		openio election debug meta2 test_zookeeper_failure
+		sleep 11
+		sudo kill -CONT $MainPID
 
-	openio election debug meta2 test_zookeeper_failure
-	openio container locate test_zookeeper_failure
-	openio election debug meta2 test_zookeeper_failure
-	openio container delete test_zookeeper_failure
+		openio election debug meta2 test_zookeeper_failure
+		openio container locate test_zookeeper_failure
+		openio election debug meta2 test_zookeeper_failure
+		openio container delete test_zookeeper_failure
+	fi
 }
 
 func_tests () {


### PR DESCRIPTION
##### SUMMARY
Perform the chunks polling in `oio-proxy` instead of `oio-meta2-server`.
* One RPC less in the PUT roundtrip: reduced latency but no preliminary check of the existence of the content.
* The storage policy is now *required* in the content/prepare request, then known by the client.

##### ISSUE TYPE
`enhancement`

##### COMPONENT NAME
`proxy`, `meta2`

##### SDS VERSION
`openio 4.6.1.dev19`