### PR TITLE
Set to "on" the default of "proxy.prefer.slave_for_read"

### DIFF
--- a/Variables.md
+++ b/Variables.md
@@ -734,7 +734,7 @@ Used by `gcc`
 
 > In a proxy, upon a read request, should the proxy prefer a service known to host a SLAVE copy of the DB.
 
- * default: **FALSE**
+ * default: **TRUE**
  * type: gboolean
  * cmake directive: *OIO_PROXY_PREFER_SLAVE_FOR_READ*
 

--- a/conf.json
+++ b/conf.json
@@ -846,7 +846,7 @@
 			{ "type": "bool", "name": "flag_prefer_slave_for_read",
 				"key": "proxy.prefer.slave_for_read",
 				"descr": "In a proxy, upon a read request, should the proxy prefer a service known to host a SLAVE copy of the DB.",
-				"def": false,
+				"def": true,
 				"aliases": ["PreferSlave"]},
 
 			{ "type": "bool", "name": "flag_force_master",


### PR DESCRIPTION
##### SUMMARY
The default usage is now to focus the read() operations on SLAVE databases.

##### ISSUE TYPE
enhancement

##### COMPONENT NAME
oio-proxy

##### SDS VERSION
`openio 4.6.1.dev26`