### PR TITLE
Account: Fix account refresh on missing values

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -181,10 +181,18 @@ class AccountBackend(RedisConn):
             objects_sum = objects_sum + redis.call('HGET', container_key,
                                                    'objects')
             bytes_sum = bytes_sum + redis.call('HGET', container_key, 'bytes')
-            damaged_objects_sum = damaged_objects_sum
-                    + redis.call('HGET', container_key, 'damaged_objects')
-            missing_chunks_sum = missing_chunks_sum
-                    + redis.call('HGET', container_key, 'missing_chunks')
+            local damaged_objects = redis.call('HGET', container_key,
+                                               'damaged_objects')
+            if damaged_objects == false then
+                damaged_objects = 0
+            end
+            damaged_objects_sum = damaged_objects_sum + damaged_objects
+            local missing_chunks = redis.call('HGET', container_key,
+                                              'missing_chunks')
+            if missing_chunks == false then
+                missing_chunks = 0
+            end
+            missing_chunks_sum = missing_chunks_sum + missing_chunks
         end;
 
         redis.call('HMSET', KEYS[1], 'objects', objects_sum,

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -566,6 +566,19 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(self.conn.hget('container:%s:%s' %
                                         (account_id, name), 'mtime'), mtime)
 
+    def test_update_container_missing_damaged_object(self):
+        backend = AccountBackend({}, self.conn)
+        account_id = random_str(16)
+        self.assertEqual(backend.create_account(account_id), account_id)
+        # initial container
+        name = '"{<container \'&\' name>}"'
+        backend.update_container(account_id, name, 0, 0, 0, 0, 0, 0)
+        self.conn.hdel('container:%s:%s' % (account_id, name),
+                       'damaged_objects')
+        backend.refresh_account(account_id)
+        self.assertEqual(self.conn.hget('account:%s' % (account_id),
+                                        'damaged_objects'), '0')
+
     def test_is_sup(self):
         backend = AccountBackend({}, self.conn)
         compare = (backend.lua_is_sup +


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There was an error when damaged_objects or missing_chunks were missing.
This happened when a container is created before oio-sds 18.10 and no object
is created after an update > 18.10.
The fix set the value to 0 but if some object had missing chunks before it will not
be printed and therefore the value would be erroneous.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the servicetype -->
account

##### SDS VERSION
<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 4.4.4.dev17
```

