### PR TITLE
Set an operation-dependent prefix on request ids

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -251,6 +251,11 @@ const char *oio_ext_set_reqid(const char *reqid) {
 }
 
 const char *oio_ext_set_random_reqid(void) {
+#ifdef HAVE_EXTRA_DEBUG
+	GRID_DEBUG(
+			"%s is deprecated, please call oio_ext_set_prefixed_random_reqid",
+			__FUNCTION__);
+#endif
 	return oio_ext_set_prefixed_random_reqid(NULL);
 }
 

--- a/metautils/lib/comm_message.c
+++ b/metautils/lib/comm_message.c
@@ -66,6 +66,10 @@ _create_named (const char *name, gint64 dl, gboolean with_id)
 		const char *id = oio_ext_get_reqid ();
 		if (id)
 			metautils_message_set_ID (result, id, strlen(id));
+#if HAVE_EXTRA_DEBUG
+		else
+			GRID_WARN("No reqid provided for %s message", name);
+#endif
 	}
 
 	if (dl > 0) {

--- a/oio/api/object_storage.py
+++ b/oio/api/object_storage.py
@@ -30,7 +30,8 @@ from oio.common.utils import cid_from_name, GeneratorIO, monotonic_time, \
     depaginate, set_deadline_from_read_timeout
 from oio.common.easy_value import float_value, true_value
 from oio.common.logger import get_logger
-from oio.common.decorators import ensure_headers, ensure_request_id
+from oio.common.decorators import ensure_headers, ensure_request_id, \
+    ensure_request_id2
 from oio.common.storage_method import STORAGE_METHODS
 from oio.common.constants import OIO_VERSION, HEADER_PREFIX
 from oio.common.decorators import handle_account_not_found, \
@@ -653,7 +654,7 @@ class ObjectStorageApi(object):
     @handle_container_not_found
     @patch_kwargs
     @ensure_headers
-    @ensure_request_id
+    @ensure_request_id2(prefix="create-")
     def object_create_ext(self, account, container, file_or_path=None,
                           data=None, etag=None, obj_name=None, mime_type=None,
                           metadata=None, policy=None, key_file=None,

--- a/oio/conscience/checker/http.py
+++ b/oio/conscience/checker/http.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from oio.common import exceptions as exc
+from oio.common.constants import REQID_HEADER
 from oio.common.http_urllib3 import urllibexc
+from oio.common.utils import request_id
 from oio.conscience.checker.base import BaseChecker
 
 
@@ -42,7 +44,9 @@ class HttpChecker(BaseChecker):
         try:
             # We have clues that the connection will be reused quickly to get
             # stats, thus we do not explicitely require its closure.
-            resp = self.agent.pool_manager.request("GET", self.url)
+            hdrs = {REQID_HEADER: request_id('chk-')}
+            resp = self.agent.pool_manager.request("GET", self.url,
+                                                   headers=hdrs)
             if resp.status == 200:
                 self.success = True
             else:

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -14,7 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from oio.common.json import json
+from oio.common.constants import REQID_HEADER
 from oio.common.http_urllib3 import urllibexc
+from oio.common.utils import request_id
 from oio.conscience.stats.base import BaseStat
 
 
@@ -72,8 +74,10 @@ class HttpStat(BaseStat):
             # We have troubles identifying connections that have been closed
             # on the remote side but not on the local side, thus we
             # explicitely require the connection to be closed.
+            reqid = request_id('stat-')
             resp = self.agent.pool_manager.request(
-                'GET', self.url, headers={'Connection': 'close'})
+                'GET', self.url, headers={'Connection': 'close',
+                                          REQID_HEADER: reqid})
             if resp.status == 200:
                 result = self._parse_func(resp.data)
             else:

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -212,10 +212,14 @@ handler_action (struct http_request_s *rq, struct http_reply_ctx_s *rp)
 
 	/* Get a request id for the current request */
 	const char *reqid = g_tree_lookup (rq->tree_headers, PROXYD_HEADER_REQID);
-	if (reqid)
+	if (reqid) {
 		oio_ext_set_reqid(reqid);
-	else
-		oio_ext_set_random_reqid();
+	} else {
+#if HAVE_EXTRA_DEBUG
+		GRID_DEBUG("Received %s request without request id", rq->cmd);
+#endif
+		oio_ext_set_prefixed_random_reqid("proxy-");
+    }
 
 	/* Load the optional 'admin' flag */
 	const char *admin = g_tree_lookup (rq->tree_headers, PROXYD_HEADER_ADMIN);

--- a/rdir/rdir.c
+++ b/rdir/rdir.c
@@ -2391,7 +2391,7 @@ handler_action(struct http_request_s *rq, struct http_reply_ctx_s *rp)
 	if (reqid)
 		oio_ext_set_reqid(reqid);
 	else
-		oio_ext_set_random_reqid();
+		oio_ext_set_prefixed_random_reqid("rdir-");
 
 	/* parse the URLL and forward to the backend if the route matches */
 	struct req_args_s args = {0};


### PR DESCRIPTION
##### SUMMARY
Add more prefix for request-id to identify operation

Some debugs logs will be emitted with EXTRA_DEBUG when proxy receives request without reqid or reqid is generated without prefix

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
sds

##### SDS VERSION
```
5.0.1dev4
```


##### ADDITIONAL INFORMATION

We have still investigate why DB_USE from autocreate operation doesn't reuse reqid from original request.