### PR TITLE
Raise ServiceBusy when chunk quorum is not reached

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -616,16 +616,16 @@ class MetachunkWriter(object):
         :raises `exc.SourceReadTimeout`: if there is a timeout while reading
             data from the client
         :raises `exc.OioTimeout`: if there is a timeout among the errors
-        :raises `exc.OioException`: if quorum has not been reached
+        :raises `exc.ServiceBusy`: if quorum has not been reached
             for any other reason
         """
         if len(successes) < self.quorum:
             errors = group_chunk_errors(
                 ((chunk["url"], chunk.get("error", "success"))
                  for chunk in successes + failures))
-            new_exc = exc.OioException(
-                "RAWX write failure, quorum not reached (%d/%d): %s" %
-                (len(successes), self.quorum, errors))
+            new_exc = exc.ServiceBusy(
+                message=("RAWX write failure, quorum not reached (%d/%d): %s" %
+                         (len(successes), self.quorum, errors)))
             for err in [x.get('error') for x in failures]:
                 if isinstance(err, exc.SourceReadError):
                     raise exc.SourceReadError(new_exc)

--- a/oio/common/exceptions.py
+++ b/oio/common/exceptions.py
@@ -277,6 +277,11 @@ class UnsatisfiableRange(ClientException):
 
 # FIXME(FVE): ServiceBusy is not a client exception
 class ServiceBusy(ClientException):
+    """
+    This kind of exceptions tell that the system was "busy" and could not
+    handle the request at the moment. The user is invited to retry after a
+    few seconds.
+    """
     def __init__(self, http_status=503, status=None, message=None):
         super(ServiceBusy, self).__init__(http_status, status, message)
 

--- a/oio/conscience/client.py
+++ b/oio/conscience/client.py
@@ -144,6 +144,11 @@ class ConscienceClient(ProxyClient):
             params['full'] = '1'
         resp, body = self._request('GET', '/list', params=params, **kwargs)
         if resp.status == 200:
+            # TODO(FVE): do that in the proxy
+            for srv in body:
+                if 'id' not in srv:
+                    srv_id = srv['tags'].get('tag.service_id', srv['addr'])
+                    srv['id'] = srv_id
             return body
         else:
             raise OioException("failed to get list of %s services: %s"

--- a/tests/unit/api/test_ec.py
+++ b/tests/unit/api/test_ec.py
@@ -94,7 +94,10 @@ class TestEC(unittest.TestCase):
         with set_http_connect(*resps):
             handler = EcMetachunkWriter(self.sysmeta, self.meta_chunk(),
                                         checksum, self.storage_method)
-            self.assertRaises(exc.OioException, handler.stream, source, size)
+            # From now on, exceptions happening during chunk upload are
+            # considered retryable, and thus will tell the caller the
+            # service was just too busy.
+            self.assertRaises(exc.ServiceBusy, handler.stream, source, size)
 
     def test_write_quorum_success(self):
         checksum = self.checksum()
@@ -129,8 +132,7 @@ class TestEC(unittest.TestCase):
         with set_http_connect(*resps):
             handler = EcMetachunkWriter(self.sysmeta, self.meta_chunk(),
                                         checksum, self.storage_method)
-            # TODO use specialized Exception
-            self.assertRaises(exc.OioException, handler.stream, source, size)
+            self.assertRaises(exc.ServiceBusy, handler.stream, source, size)
 
     def test_write_connect_errors(self):
         test_cases = [

--- a/tests/unit/api/test_replication.py
+++ b/tests/unit/api/test_replication.py
@@ -87,7 +87,7 @@ class TestReplication(unittest.TestCase):
         with set_http_connect(*resps):
             handler = ReplicatedMetachunkWriter(
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
-            self.assertRaises(exc.OioException, handler.stream, source, size)
+            self.assertRaises(exc.ServiceBusy, handler.stream, source, size)
 
     def test_write_quorum_success(self):
         checksum = self.checksum()
@@ -126,7 +126,7 @@ class TestReplication(unittest.TestCase):
         with set_http_connect(*resps):
             handler = ReplicatedMetachunkWriter(
                 self.sysmeta, meta_chunk, checksum, self.storage_method)
-            self.assertRaises(exc.OioException, handler.stream, source, size)
+            self.assertRaises(exc.ServiceBusy, handler.stream, source, size)
 
     def test_write_timeout(self):
         checksum = self.checksum()


### PR DESCRIPTION
##### SUMMARY
Raise a ServiceBusy error when writing an object and the quorum of the
chunks is not reached, and this cannot be attributed to a timeout.

Jira: OS-434

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.6.1.dev26
```