### PR TITLE
Forward timeout parameters to AccountClient

### DIFF
--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -20,6 +20,7 @@ from werkzeug.exceptions import NotFound, BadRequest, Conflict
 from functools import wraps
 
 from oio.account.backend import AccountBackend
+from oio.common.constants import STRLEN_REQID
 from oio.common.json import json
 from oio.common.logger import get_logger
 from oio.common.wsgi import WerkzeugApp
@@ -29,12 +30,15 @@ from oio.common.easy_value import true_value
 def access_log(func):
 
     @wraps(func)
-    def _access_log_wrapper(self, *args, **kwargs):
+    def _access_log_wrapper(self, req, *args, **kwargs):
         from time import time
         pre = time()
-        rc = func(self, *args, **kwargs)
+        rc = func(self, req, *args, **kwargs)
         post = time()
-        self.logger.info("%s %0.6f", func.__name__, post - pre)
+        reqid = req.headers.get('X-oio-req-id', '-')[:STRLEN_REQID]
+        # func time size user reqid
+        self.logger.info("%s %0.6f %s %s %s",
+                         func.__name__, post - pre, '-', '-', reqid)
         return rc
 
     return _access_log_wrapper

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -32,6 +32,9 @@ TIMEOUT_HEADER = HEADER_PREFIX + 'timeout'
 CONNECTION_TIMEOUT = 2.0
 READ_TIMEOUT = 30.0
 
+# Name of keywords used to set timeouts
+TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
+
 STRLEN_REFERENCEID = 66
 STRLEN_CHUNKID = 64
 

--- a/oio/common/constants.py
+++ b/oio/common/constants.py
@@ -37,6 +37,7 @@ TIMEOUT_KEYS = ('connection_timeout', 'read_timeout', 'write_timeout')
 
 STRLEN_REFERENCEID = 66
 STRLEN_CHUNKID = 64
+STRLEN_REQID = 63
 
 # Version of the format of chunk extended attributes
 OIO_VERSION = '4.2'

--- a/oio/common/decorators.py
+++ b/oio/common/decorators.py
@@ -14,7 +14,7 @@
 # License along with this library.
 
 from functools import wraps
-from oio.common.utils import request_id
+from oio.common.utils import request_id, set_deadline_from_read_timeout
 from oio.common.exceptions import NotFound, NoSuchAccount, NoSuchObject, \
     NoSuchContainer, reraise
 
@@ -86,3 +86,19 @@ def handle_object_not_found(fnc):
                 err.message = "Object '%s' does not exist." % obj
                 reraise(NoSuchObject, err)
     return _wrapped
+
+
+def patch_kwargs(fnc):
+    """
+    Patch keyword arguments with the ones passed to the class' constructor.
+    Compute a deadline if a timeout is provided and there is no deadline
+    already. Requires the class to have a `_global_kwargs` member (dict).
+    """
+    @wraps(fnc)
+    def _patch_kwargs(self, *args, **kwargs):
+        for argk, argv in self._global_kwargs.items():
+            if argk not in kwargs:
+                kwargs[argk] = argv
+        set_deadline_from_read_timeout(kwargs)
+        return fnc(self, *args, **kwargs)
+    return _patch_kwargs

--- a/tests/unit/account/test_accountclient.py
+++ b/tests/unit/account/test_accountclient.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import unittest
+from mock import MagicMock as Mock
+
+from oio.account.client import AccountClient
+from tests.unit.api import FakeApiResponse
+
+
+class AccountClientTest(unittest.TestCase):
+
+    def _build_account_client(self, **kwargs):
+        endpoint = "http://1.2.3.4:8000"
+        resp = FakeApiResponse()
+        body = {"listing": [['ct', 0, 0, 0]]}
+        client = AccountClient({'namespace': 'fake'},
+                               endpoint=endpoint,
+                               proxy_endpoint=endpoint,
+                               **kwargs)
+        client._direct_request = Mock(return_value=(resp, body))
+        client._get_account_addr = Mock(return_value=endpoint)
+        return client
+
+    def test_keyword_args(self):
+        # Pass read_timeout to the class constructor
+        client = self._build_account_client(read_timeout=66.6)
+
+        # Do NOT pass read_timeout to the method call
+        client.container_list('acct')
+        # Ensure the internal methods have been called with a read_timeout
+        call_args = client._direct_request.call_args
+        self.assertIn('read_timeout', call_args[1])
+        self.assertEqual(66.6, call_args[1]['read_timeout'])
+
+        # Now pass a read_timeout to the method call
+        client.container_list('acct', read_timeout=33.3)
+        # Ensure the internal methods have been called with a read_timeout
+        call_args = client._direct_request.call_args
+        self.assertIn('read_timeout', call_args[1])
+        self.assertEqual(33.3, call_args[1]['read_timeout'])


### PR DESCRIPTION
##### SUMMARY
As for `ObjectStorageApi`, apply timeouts passed to the `AccountClient` constructor to all method calls.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 4.6.1.dev53
```

