### PR TITLE
cmake: Only install prod-related tools in other build types than Debug

### DIFF
--- a/cluster/module/CMakeLists.txt
+++ b/cluster/module/CMakeLists.txt
@@ -38,6 +38,6 @@ target_link_libraries(conscience
 bin_prefix(conscience -daemon)
 
 install(TARGETS conscience
-		LIBRARY DESTINATION ${GRIDD_PLUGINS_DIRECTORY}
+		LIBRARY DESTINATION ${LD_LIBDIR}
 		RUNTIME DESTINATION bin)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,19 +82,27 @@ add_executable(tool_roundtrip tool_roundtrip.c)
 target_link_libraries(tool_roundtrip oiosds)
 
 install(FILES
-		oiocfg.h
-		oiodir.h
-		oioext.h
-		oiolog.h
-		oioloc.h
-		oiostr.h
-		oiourl.h
-		oiovar.h
-		oiocs.h
-		oiolb.h
+			oiocfg.h
+			oiodir.h
+			oioext.h
+			oiolog.h
+			oioloc.h
+			oiostr.h
+			oiourl.h
+			oiovar.h
+			oiocs.h
+			oiolb.h
 		DESTINATION include/core)
 
-install(TARGETS oiocore oiosds
+install(TARGETS
+			oiocore
+			oiosds
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		PUBLIC_HEADER DESTINATION include)
 
+install(TARGETS
+			tool_sdk_noconf
+			tool_roundtrip
+			tool_sdk
+		DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)

--- a/meta0v2/CMakeLists.txt
+++ b/meta0v2/CMakeLists.txt
@@ -54,9 +54,22 @@ target_link_libraries(meta0_server
 		sqlxsrv
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
-install(TARGETS meta0utils meta0remote meta0v2 meta0_server meta0_client
+install(TARGETS
+			meta0utils
+			meta0remote
+			meta0v2
+			meta0_server
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		RUNTIME DESTINATION bin)
+
+# As soon as the admin CLI is able to efficiently check a meta0
+# service without that command, we can uncomment the directive that
+# reserve the tool for the DEVEL use cases.
+install(TARGETS
+			meta0_client
+		RUNTIME DESTINATION bin
+		#CONFIGURATIONS Debug
+		COMPONENT dev)
 
 install(TARGETS meta0remote
 		LIBRARY DESTINATION ${LD_LIBDIR}

--- a/meta1v2/CMakeLists.txt
+++ b/meta1v2/CMakeLists.txt
@@ -47,7 +47,16 @@ add_executable(meta1_client meta1_client.c)
 bin_prefix(meta1_client -meta1-client)
 target_link_libraries(meta1_client metautils meta1remote)
 
-install(TARGETS meta1v2 meta1_server meta1remote meta1_client
+install(TARGETS
+			meta1v2
+			meta1_server
+			meta1remote
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		RUNTIME DESTINATION bin)
 
+# TODO(jfs): This tool should ne be necessary on any other use cases
+#            than DEVEL.
+install(TARGETS
+			meta1_client
+		RUNTIME DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)

--- a/meta2v2/CMakeLists.txt
+++ b/meta2v2/CMakeLists.txt
@@ -100,7 +100,10 @@ target_link_libraries(meta2_server meta2v2
         hcresolve metautils gridcluster server
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES})
 
-install(TARGETS meta2v2 meta2_server meta2v2utils
+install(TARGETS
+			meta2v2
+			meta2_server
+			meta2v2utils
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		RUNTIME DESTINATION bin)
 

--- a/metautils/lib/CMakeLists.txt
+++ b/metautils/lib/CMakeLists.txt
@@ -352,8 +352,12 @@ target_link_libraries(tool_sigfpe
 		${GLIB2_LIBRARIES})
 
 
-install(TARGETS metautils
+install(TARGETS
+			metautils
 		LIBRARY DESTINATION ${LD_LIBDIR}
-		RUNTIME DESTINATION bin
 		PUBLIC_HEADER DESTINATION include)
 
+install(TARGETS
+			tool_sigfpe
+		DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)

--- a/rawx-lib/tools/CMakeLists.txt
+++ b/rawx-lib/tools/CMakeLists.txt
@@ -20,6 +20,8 @@ bin_prefix(gs_uncompress -rawx-uncompress)
 target_link_libraries(gs_uncompress ${REQLIBS})
 
 install(TARGETS
-		gs_compress gs_uncompress
-		RUNTIME DESTINATION bin)
+			gs_compress
+			gs_uncompress
+		RUNTIME DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)
 

--- a/sqliterepo/CMakeLists.txt
+++ b/sqliterepo/CMakeLists.txt
@@ -89,7 +89,10 @@ target_link_libraries(sqliterepo metautils
 		sqlitereporemote sqliteutils
 		${GLIB2_LIBRARIES} ${SQLITE3_LIBRARIES} ${ZK_LIBRARIES})
 
-install(TARGETS sqliterepo sqliteutils sqlitereporemote
+install(TARGETS
+			sqliterepo
+			sqliteutils
+			sqlitereporemote
 		LIBRARY DESTINATION ${LD_LIBDIR}
 		RUNTIME DESTINATION bin)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -40,13 +40,21 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-sds.pc.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/oio-bootstrap.py
 	${CMAKE_CURRENT_BINARY_DIR}/oio-bootstrap.py @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc
+install(FILES
+			${CMAKE_CURRENT_BINARY_DIR}/oio-sds.pc
 		DESTINATION ${PKGCONFIG_DIRECTORY}
 		PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install(TARGETS oio-tool DESTINATION bin)
+install(TARGETS
+			oio-tool
+		DESTINATION bin)
 
-install(TARGETS oio-file DESTINATION bin)
+install(TARGETS
+			oio-file
+			oio-lb-benchmark
+			oio-zk-harass
+		DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)
 
 install(PROGRAMS
 			oio-flush-all.sh
@@ -56,4 +64,6 @@ install(PROGRAMS
 			oio-reset.sh
 			oio-dump-buried-events.py
 			oio-webhook-test.py
-		DESTINATION bin)
+		DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -47,11 +47,11 @@ install(FILES
 
 install(TARGETS
 			oio-tool
+			oio-lb-benchmark
 		DESTINATION bin)
 
 install(TARGETS
 			oio-file
-			oio-lb-benchmark
 			oio-zk-harass
 		DESTINATION bin
 		CONFIGURATIONS Debug COMPONENT dev)

--- a/tools/event-benchmark/CMakeLists.txt
+++ b/tools/event-benchmark/CMakeLists.txt
@@ -5,13 +5,12 @@ include_directories(BEFORE . .. ../..)
 
 add_executable(
 	event_benchmark
-	event_benchmark.c event_benchmark.h
-	../../proxy/path_parser.c ../../proxy/path_parser.h
-	../../proxy/transport_http.c ../../proxy/transport_http.h
-	fake_service.c fake_service.h
-	event_worker.c event_worker.h
-	event_sender.c event_sender.h
-)
+	event_benchmark.c
+	../../proxy/path_parser.c
+	../../proxy/transport_http.c
+	fake_service.c
+	event_worker.c
+	event_sender.c)
 
 bin_prefix(event_benchmark -event-benchmark)
 target_link_libraries(event_benchmark
@@ -19,3 +18,8 @@ target_link_libraries(event_benchmark
 		server gridcluster
 		metautils
 		${GLIB2_LIBRARIES} ${JSONC_LIBRARIES} ${CURL_LIBRARIES})
+
+install(TARGETS
+			event_benchmark
+		DESTINATION bin
+		CONFIGURATIONS Debug COMPONENT dev)


### PR DESCRIPTION
##### SUMMARY
The tools related to development tasks is only installed if the suite is built with `CMAKE_BUILD_TYPE=Debug`. It will avoid deploying `oio-reset.sh` (and its friends) with any package.

##### ISSUE TYPE
simplification

##### COMPONENT NAME
cmake

##### SDS VERSION
`openio 5.1.1.dev58`
