### PR TITLE
Reduce the number of requests from meta2 to meta1

### DIFF
--- a/core/ext.c
+++ b/core/ext.c
@@ -277,6 +277,15 @@ const char *oio_ext_set_prefixed_random_reqid(const char *prefix) {
 	return oio_ext_set_reqid(hex);
 }
 
+const char *
+oio_ext_ensure_reqid(const char *prefix)
+{
+	const char *reqid = oio_ext_get_reqid();
+	if (reqid)
+		return reqid;
+	return oio_ext_set_prefixed_random_reqid(prefix);
+}
+
 gint64 oio_ext_get_deadline(void) {
 	const struct oio_ext_local_s *l = _local_ensure ();
 	return l->deadline > 0 ? l->deadline : 0;

--- a/core/oioext.h
+++ b/core/oioext.h
@@ -75,6 +75,10 @@ const char *oio_ext_set_random_reqid(void);
  * with the specified prefix. */
 const char *oio_ext_set_prefixed_random_reqid(const char *prefix);
 
+/** If there is no request ID, generate one with the prefix, and return it.
+ * If there is already one, return it. */
+const char *oio_ext_ensure_reqid(const char *prefix);
+
 /* DO NOT FREE ... In facts, DO NOT EVEN CONSIDER USING THIS FUNCTION!
  * Gets the PRNG associated to the local thread, and allocates on if none
  * already present. Returns THE pointer locally stored. Freeing it will break

--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -61,6 +61,12 @@ enum m2v2_open_type_e
 #define M2V2_OPEN_STATUS    0xF00
 };
 
+struct m2_open_args_s
+{
+	enum m2v2_open_type_e how;
+	const gchar *peers;
+};
+
 struct m2_prepare_data
 {
 	gint64 max_versions;
@@ -407,8 +413,8 @@ m2b_destroy(struct sqlx_sqlite3_s *sq3)
 }
 
 static GError *
-m2b_open(struct meta2_backend_s *m2, struct oio_url_s *url,
-		enum m2v2_open_type_e how, struct sqlx_sqlite3_s **result)
+m2b_open_with_args(struct meta2_backend_s *m2, struct oio_url_s *url,
+		struct m2_open_args_s *open_args, struct sqlx_sqlite3_s **result)
 {
 	GError *err = NULL;
 	struct sqlx_sqlite3_s *sq3 = NULL;
@@ -421,8 +427,10 @@ m2b_open(struct meta2_backend_s *m2, struct oio_url_s *url,
 	struct sqlx_name_inline_s n0;
 	sqlx_inline_name_fill (&n0, url, NAME_SRVTYPE_META2, 1);
 	NAME2CONST(n,n0);
+	enum m2v2_open_type_e how = open_args->how;
 
-	err = sqlx_repository_open_and_lock(m2->repo, &n, m2_to_sqlx(how), &sq3, NULL);
+	err = sqlx_repository_timed_open_and_lock(m2->repo, &n, m2_to_sqlx(how),
+		   open_args->peers, &sq3, NULL, oio_ext_get_deadline());
 	if (NULL != err) {
 		if (err->code == CODE_CONTAINER_NOTFOUND)
 			err->domain = GQ();
@@ -482,6 +490,15 @@ m2b_open(struct meta2_backend_s *m2, struct oio_url_s *url,
 	*result = sq3;
 	return NULL;
 }
+
+static GError *
+m2b_open(struct meta2_backend_s *m2, struct oio_url_s *url,
+		enum m2v2_open_type_e how, struct sqlx_sqlite3_s **result)
+{
+	struct m2_open_args_s args = {how, NULL};
+	return m2b_open_with_args(m2, url, &args, result);
+}
+
 
 static GError *
 m2b_open_if_needed(struct meta2_backend_s *m2, struct oio_url_s *url,
@@ -699,10 +716,12 @@ meta2_backend_create_container(struct meta2_backend_s *m2,
 	}
 
 	/* Defer the `m2.init` check to the m2b_open() */
-	enum m2v2_open_type_e open_mode = M2V2_OPEN_AUTOCREATE |
+	struct m2_open_args_s open_args = {0};
+	open_args.how = M2V2_OPEN_AUTOCREATE |
 		(params->local ? M2V2_OPEN_LOCAL : M2V2_OPEN_MASTERONLY);
+	open_args.peers = params->peers;
 
-	err = m2b_open(m2, url, open_mode, &sq3);
+	err = m2b_open_with_args(m2, url, &open_args, &sq3);
 	EXTRA_ASSERT((sq3 != NULL) ^ (err != NULL));
 	if (err)
 		return err;

--- a/meta2v2/meta2_filters.h
+++ b/meta2v2/meta2_filters.h
@@ -67,6 +67,7 @@ M2V2_DECLARE_FILTER(meta2_filter_extract_header_url);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_chunk_beans);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_storage_policy);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_version_policy);
+M2V2_DECLARE_FILTER(meta2_filter_extract_header_peers);
 M2V2_DECLARE_FILTER(meta2_filter_extract_header_spare);
 M2V2_DECLARE_FILTER(meta2_filter_extract_body_beans);
 M2V2_DECLARE_FILTER(meta2_filter_extract_body_strings);

--- a/meta2v2/meta2_filters_action_container.c
+++ b/meta2v2/meta2_filters_action_container.c
@@ -41,7 +41,7 @@ int
 meta2_filter_action_create_container(struct gridd_filter_ctx_s *ctx,
 		struct gridd_reply_ctx_s *reply)
 {
-	struct m2v2_create_params_s params = {NULL,NULL,NULL,0};
+	struct m2v2_create_params_s params = {NULL,NULL,NULL,NULL,0};
 	struct meta2_backend_s *m2b = meta2_filter_ctx_get_backend(ctx);
 	struct oio_url_s *url = meta2_filter_ctx_get_url(ctx);
 	GError *err = NULL;
@@ -50,6 +50,7 @@ meta2_filter_action_create_container(struct gridd_filter_ctx_s *ctx,
 	params.storage_policy = meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_STGPOLICY);
 	params.version_policy = meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_VERPOLICY);
 	params.local = (meta2_filter_ctx_get_param(ctx, NAME_MSGKEY_LOCAL) != NULL);
+	params.peers = meta2_filter_ctx_get_param(ctx, SQLX_ADMIN_PEERS);
 
 	gsize len = 0;
 	void *buf = metautils_message_get_BODY(reply->request, &len);

--- a/meta2v2/meta2_filters_extract.c
+++ b/meta2v2/meta2_filters_extract.c
@@ -168,6 +168,18 @@ meta2_filter_extract_header_append(struct gridd_filter_ctx_s *ctx,
 }
 
 int
+meta2_filter_extract_header_peers(struct gridd_filter_ctx_s *ctx,
+		struct gridd_reply_ctx_s *reply)
+{
+	GError *e = NULL;
+	gchar buf[512];
+
+	TRACE_FILTER();
+	EXTRACT_OPT(SQLX_ADMIN_PEERS);
+	return FILTER_OK;
+}
+
+int
 meta2_filter_extract_header_spare(struct gridd_filter_ctx_s *ctx,
 		struct gridd_reply_ctx_s *reply)
 {

--- a/meta2v2/meta2_gridd_dispatcher.c
+++ b/meta2v2/meta2_gridd_dispatcher.c
@@ -107,6 +107,7 @@ static gridd_filter M2V2_CREATE_FILTERS[] =
 	meta2_filter_extract_header_storage_policy,
 	meta2_filter_extract_header_version_policy,
 	meta2_filter_extract_header_localflag,
+	meta2_filter_extract_header_peers,
 	meta2_filter_action_create_container,
 	meta2_filter_reply_success,
 	NULL

--- a/meta2v2/meta2_macros.h
+++ b/meta2v2/meta2_macros.h
@@ -148,9 +148,12 @@ struct m2v2_create_params_s
 {
 	const char *storage_policy; /**< Will override the (maybe present) stgpol property. */
 	const char *version_policy; /**< idem for the verpol property. */
-	gchar **properties; /**< A NULL-terminated sequence of strings where:
-						  * properties[i*2] is the i-th key and
-						  * properties[(i*2)+1] is the i-th value */
+	const char *peers; /**< Peers to replicate the database to. */
+
+	/** A NULL-terminated sequence of strings where:
+	 * properties[i*2] is the i-th key and
+	 * properties[(i*2)+1] is the i-th value */
+	gchar **properties;
 	gboolean local; /**< Do not try to replicate, do not call get_peers() */
 };
 

--- a/meta2v2/meta2_server.c
+++ b/meta2v2/meta2_server.c
@@ -128,7 +128,10 @@ main(int argc, char **argv)
 		NAME_SRVTYPE_META2, "m2v2",
 		"el/" NAME_SRVTYPE_META2, 2, 2,
 		schema, 1, 3,
-		sqlx_service_resolve_peers, _post_config, NULL
+		// FIXME(FVE): create a parameter to allow or deny peer requests.
+		//sqlx_service_reply_no_peers,
+		sqlx_service_resolve_peers,
+		_post_config, NULL
 	};
 
 	int rc = sqlite_service_main (argc, argv, &cfg);

--- a/metautils/lib/comm_message.c
+++ b/metautils/lib/comm_message.c
@@ -370,6 +370,14 @@ metautils_message_add_field_str(MESSAGE m, const char *name, const char *value)
 }
 
 void
+metautils_message_add_fields_str(MESSAGE m, const char **fields)
+{
+	for (const char **cur = fields; fields && *cur; cur += 2) {
+		metautils_message_add_field_str(m, *cur, *(cur+1));
+	}
+}
+
+void
 metautils_message_add_field_gba(MESSAGE m, const char *name, GByteArray *gba)
 {
 	if (gba)

--- a/metautils/lib/metacomm.h
+++ b/metautils/lib/metacomm.h
@@ -91,6 +91,7 @@ void metautils_message_add_body_unref (MESSAGE m, GByteArray *body);
 void metautils_message_add_field_gba(MESSAGE m, const char *name, GByteArray *gba);
 
 void metautils_message_add_field_str(MESSAGE m, const char *name, const char *value);
+void metautils_message_add_fields_str(MESSAGE m, const char **fields);
 
 void metautils_message_add_field_strint64(MESSAGE m, const char *n, gint64 v);
 

--- a/oio/event/beanstalk.py
+++ b/oio/event/beanstalk.py
@@ -537,16 +537,24 @@ class Beanstalk(object):
     def delete(self, job_id):
         self.execute_command('delete', job_id)
 
-    def drain_tube(self, tube):
-        """Delete all jobs from the specified tube."""
-        self.watch(tube)
+    def _drain(self, fetch_func):
         try:
             job_id = True
             while job_id is not None:
-                job_id, _ = self.reserve(timeout=0)
+                job_id, _ = fetch_func()
                 self.delete(job_id)
         except ResponseError:
             pass
+
+    def drain_buried(self, tube):
+        self.use(tube)
+        return self._drain(self.peek_buried)
+
+    def drain_tube(self, tube):
+        """Delete all jobs from the specified tube."""
+        self.watch(tube)
+        from functools import partial
+        return self._drain(partial(self.reserve, timeout=0))
 
     def kick_job(self, job_id):
         """
@@ -569,17 +577,27 @@ class Beanstalk(object):
         kicked = int(self.execute_command('kick', str(bound))[1][0])
         return kicked
 
-    def peek_ready(self):
-        """
-        Read the next ready job without reserving it.
-        """
+    def _peek_generic(self, command_suffix=''):
+        command = 'peek' + command_suffix
         try:
-            return self.execute_command('peek-ready')
+            return self.execute_command(command)
         except ResponseError as err:
-            if err.args[0] == 'peek-ready' and err.args[1] == 'NOT_FOUND':
+            if err.args[0] == command and err.args[1] == 'NOT_FOUND':
                 return None, None
             else:
                 raise
+
+    def peek_buried(self):
+        """
+        Read the next buried job without kicking it.
+        """
+        return self._peek_generic('-buried')
+
+    def peek_ready(self):
+        """
+        read the next ready job without reserving it.
+        """
+        return self._peek_generic('-ready')
 
     def wait_until_empty(self, tube, timeout=float('inf'), poll_interval=0.2,
                          initial_delay=0.0):

--- a/proxy/common.h
+++ b/proxy/common.h
@@ -263,9 +263,11 @@ enum proxy_preference_e _prefer_master (void);
 GError * _m1_locate_and_action (struct oio_url_s *url,
 		GError * (*hook) (const char *m1addr));
 
-typedef GByteArray * (request_packer_f) (const struct sqlx_name_s *);
+typedef GByteArray * (request_packer_f) (const struct sqlx_name_s *,
+		const gchar **headers);
 
-#define PACKER_VOID(N) GByteArray * N (const struct sqlx_name_s *_u UNUSED)
+#define PACKER_VOID(N) GByteArray * N (const struct sqlx_name_s *_u UNUSED, \
+		const gchar **headers UNUSED)
 
 GError * gridd_request_replicated_with_retry (struct req_args_s *args,
 		struct client_ctx_s *ctx, request_packer_f pack);

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1025,11 +1025,14 @@ _m2_container_create_with_properties (struct req_args_s *args, char **props,
 	 * of the account. This is how we do NOW, by letting the meta2 find the best
 	 * value when necessary. */
 	struct m2v2_create_params_s param = {
-			container_stgpol, container_verpol, props, FALSE
+			container_stgpol, container_verpol, NULL, props, FALSE
 	};
 
 	GError *err = NULL;
-	PACKER_VOID (_pack) { return m2v2_remote_pack_CREATE (args->url, &param, DL()); }
+	GByteArray *_pack(const struct sqlx_name_s *_u UNUSED,
+			const gchar **headers) {
+		return m2v2_remote_pack_CREATE(args->url, &param, headers, DL());
+	}
 
 retry:
 	GRID_TRACE("Container creation %s", oio_url_get (args->url, OIOURL_WHOLE));
@@ -1459,8 +1462,6 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 		GError *err2 = meta1v2_remote_link_service(
 				m1, args->url, NAME_SRVTYPE_META2, FALSE, TRUE, &urlv_snapshot,
 				oio_ext_get_deadline());
-		/* TODO(FVE): send this list along with the snapshot request.
-		 * This will prevent the meta2 from looking up in the meta1. */
 		if (urlv_snapshot) {
 			g_strfreev(urlv_snapshot);
 			urlv_snapshot = NULL;
@@ -1474,8 +1475,9 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 	meta1_urlv_shift_addr(urlv);
 	CLIENT_CTX(ctx, args, NAME_SRVTYPE_META2, 1);
 	gchar *url = _resolve_service_id(urlv[0]);
-	GByteArray * _pack_snapshot(const struct sqlx_name_s *n) {
-		return sqlx_pack_SNAPSHOT(n, url, target_cid, seq_num, DL());
+	GByteArray * _pack_snapshot(const struct sqlx_name_s *n,
+			const gchar **headers) {
+		return sqlx_pack_SNAPSHOT(n, url, target_cid, seq_num, headers, DL());
 	}
 	err = _resolve_meta2(args, CLIENT_PREFER_MASTER,
 			_pack_snapshot, NULL, NULL);
@@ -1488,7 +1490,8 @@ _m2_container_snapshot(struct req_args_s *args, struct json_object *jargs)
 			SQLX_ADMIN_USERNAME, (gchar*)container,
 			NULL
 		};
-		GByteArray * _pack_propset(const struct sqlx_name_s *n) {
+		GByteArray * _pack_propset(const struct sqlx_name_s *n,
+				const gchar **headers UNUSED) {
 			return sqlx_pack_PROPSET_tab(args->url, n, FALSE, props, DL());
 		}
 		err = _resolve_meta2(args, CLIENT_PREFER_MASTER,

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -31,17 +31,26 @@ License along with this library.
 #include "common.h"
 
 static MESSAGE
-_m2v2_build_request(const char *name, struct oio_url_s *url, GByteArray *body,
-		gint64 deadline)
+_m2v2_build_request_with_extra_fields(const char *name, struct oio_url_s *url,
+		GByteArray *body, const gchar **fields, gint64 deadline)
 {
 	EXTRA_ASSERT(name != NULL);
 	EXTRA_ASSERT(url != NULL);
 
 	MESSAGE msg = metautils_message_create_named(name, deadline);
 	metautils_message_add_url (msg, url);
+	metautils_message_add_fields_str(msg, fields);
 	if (body)
 		metautils_message_add_body_unref (msg, body);
 	return msg;
+}
+
+static MESSAGE
+_m2v2_build_request(const char *name, struct oio_url_s *url,
+		GByteArray *body, gint64 deadline)
+{
+	return _m2v2_build_request_with_extra_fields(
+			name, url, body, NULL, deadline);
 }
 
 static GByteArray *
@@ -140,9 +149,11 @@ m2v2_boolean_truncated_extract(gpointer ctx, MESSAGE reply)
 GByteArray* m2v2_remote_pack_CREATE(
 		struct oio_url_s *url,
 		struct m2v2_create_params_s *pols,
+		const gchar **headers,
 		gint64 dl)
 {
-	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_CREATE, url, NULL, dl);
+	MESSAGE msg = _m2v2_build_request_with_extra_fields(
+			NAME_MSGNAME_M2V2_CREATE, url, NULL, headers, dl);
 	if (pols && pols->storage_policy)
 		metautils_message_add_field_str(msg, NAME_MSGKEY_STGPOLICY, pols->storage_policy);
 	if (pols && pols->version_policy)

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -61,6 +61,7 @@ GError* m2v2_remote_execute_DESTROY_many(
 GByteArray* m2v2_remote_pack_CREATE(
 		struct oio_url_s *url,
 		struct m2v2_create_params_s *pols,
+		const gchar **headers,
 		gint64 deadline);
 
 GByteArray* m2v2_remote_pack_DESTROY(

--- a/proxy/sqlx_actions.c
+++ b/proxy/sqlx_actions.c
@@ -166,7 +166,8 @@ action_sqlx_copyto (struct req_args_s *args, struct json_object *jargs)
 	if (!from) {
 		/* No source, locate services from directory and use DB_PIPETO. */
 		ctx.which = CLIENT_PREFER_MASTER;
-		GByteArray * _pack(const struct sqlx_name_s *n) {
+		GByteArray * _pack(const struct sqlx_name_s *n,
+				const gchar **headers UNUSED) {
 			return sqlx_pack_PIPETO(n, to, DL());
 		}
 		rc = _sqlx_action_noreturn_TAIL(args, &ctx, _pack);
@@ -199,7 +200,8 @@ action_sqlx_propset (struct req_args_s *args, struct json_object *jargs)
 		err = BADREQ("No properties found in JSON object");
 	if (!err) {
 		gboolean flush = _request_get_flag(args, "flush");
-		GByteArray * _pack (const struct sqlx_name_s *n) {
+		GByteArray * _pack (const struct sqlx_name_s *n,
+				const gchar **headers UNUSED) {
 			return sqlx_pack_PROPSET_tab(args->url, n, flush, kv, DL());
 		}
 		rc = _sqlx_action_noreturn(args, CLIENT_PREFER_MASTER, _pack);
@@ -284,7 +286,8 @@ action_sqlx_propdel (struct req_args_s *args, struct json_object *jargs)
 	for (gchar **p = namev; namev && *p; p++)
 		oio_str_reuse(p, g_strconcat("user.", *p, NULL));
 
-	GByteArray * _pack(const struct sqlx_name_s *n) {
+	GByteArray * _pack(const struct sqlx_name_s *n,
+				const gchar **headers UNUSED) {
 		return sqlx_pack_PROPDEL(args->url, n, (const gchar * const * )namev, DL());
 	}
 	enum http_rc_e rc = _sqlx_action_noreturn (args, CLIENT_PREFER_MASTER, _pack);
@@ -295,7 +298,7 @@ action_sqlx_propdel (struct req_args_s *args, struct json_object *jargs)
 enum http_rc_e
 action_admin_ping (struct req_args_s *args)
 {
-	PACKER_VOID(_pack) { return sqlx_pack_USE (_u, FALSE, DL()); }
+	PACKER_VOID(_pack) { return sqlx_pack_USE(_u, NULL, FALSE, DL()); }
 	return _sqlx_action_noreturn (args, CLIENT_RUN_ALL, _pack);
 }
 

--- a/sqliterepo/election.h
+++ b/sqliterepo/election.h
@@ -128,6 +128,7 @@ struct election_manager_vtable_s
 	 * starting the election. Usefull to prepare. */
 	GError* (*election_init) (struct election_manager_s *manager,
 			const struct sqlx_name_s *n,
+			const gchar *peers,
 			enum election_step_e *out_status,
 			gboolean *replicated);
 
@@ -168,8 +169,8 @@ const char * election_manager_get_local (const struct election_manager_s *m);
 GError* election_get_peers (struct election_manager_s *manager,
 		const struct sqlx_name_s *n, guint32 flags, gchar ***peers);
 
-#define election_init(m,n,out,replicated) \
-	((struct abstract_election_manager_s*)m)->vtable->election_init(m,n,out,replicated)
+#define election_init(m,n,peers,out,replicated) \
+	((struct abstract_election_manager_s*)m)->vtable->election_init(m,n,peers,out,replicated)
 
 #define election_start(m,n) \
 	((struct abstract_election_manager_s*)m)->vtable->election_start(m,n)

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -625,6 +625,7 @@ struct open_args_s
 	const char *schema;
 	hashstr_t *realname;
 	gchar *realpath;
+	const char *peers;  /* Used when database is being created. */
 	gint64 deadline;
 
 	guint8 create;
@@ -904,7 +905,8 @@ _open_and_lock_base(struct open_args_s *args, enum election_status_e expected,
 	if (election_configured && !args->no_refcheck) {
 		gboolean replicated = FALSE;
 		enum election_step_e step = STEP_NONE;
-		err = election_init(args->repo->election_manager, &args->name, &step, &replicated);
+		err = election_init(args->repo->election_manager, &args->name,
+				args->peers, &step, &replicated);
 		if (err)
 			return err;
 
@@ -1102,12 +1104,13 @@ sqlx_repository_open_and_lock(sqlx_repository_t *repo,
 		struct sqlx_sqlite3_s **result, gchar **lead)
 {
 	return sqlx_repository_timed_open_and_lock(
-			repo, n, how, result, lead, oio_ext_get_deadline());
+			repo, n, how, NULL, result, lead, oio_ext_get_deadline());
 }
 
 GError*
 sqlx_repository_timed_open_and_lock(sqlx_repository_t *repo,
 		const struct sqlx_name_s *n, enum sqlx_open_type_e how,
+		const gchar *peers,
 		struct sqlx_sqlite3_s **result, gchar **lead,
 		gint64 deadline)
 {
@@ -1130,6 +1133,7 @@ sqlx_repository_timed_open_and_lock(sqlx_repository_t *repo,
 	args.create = BOOL(how & SQLX_OPEN_CREATE);
 	args.urgent = BOOL(how & SQLX_OPEN_URGENT);
 	args.deadline = deadline;
+	args.peers = peers;
 
 	switch (how & SQLX_OPEN_REPLIMODE) {
 		case SQLX_OPEN_LOCAL:
@@ -1266,7 +1270,8 @@ sqlx_repository_status_base(sqlx_repository_t *repo,
 
 	/* Kick the election off */
 	gboolean replicated = FALSE;
-	GError *err = sqlx_repository_use_base(repo, n, FALSE, TRUE, &replicated);
+	GError *err = sqlx_repository_use_base(
+			repo, n, NULL, FALSE, TRUE, &replicated);
 	if (err)
 		return err;
 	if (!replicated)
@@ -1313,7 +1318,7 @@ sqlx_repository_prepare_election(sqlx_repository_t *repo, const struct sqlx_name
 		return NULL;
 	}
 
-	return election_init(repo->election_manager, n, NULL, NULL);
+	return election_init(repo->election_manager, n, NULL, NULL, NULL);
 }
 
 GError*
@@ -1369,7 +1374,7 @@ _base_lazy_recover(sqlx_repository_t *repo, const struct sqlx_name_s *n,
 
 GError*
 sqlx_repository_use_base(sqlx_repository_t *repo, const struct sqlx_name_s *n,
-		gboolean notify_master, gboolean allow_autocreate,
+		const gchar *peers, gboolean notify_master, gboolean allow_autocreate,
 		gboolean *replicated)
 {
 	REPO_CHECK(repo);
@@ -1392,7 +1397,8 @@ sqlx_repository_use_base(sqlx_repository_t *repo, const struct sqlx_name_s *n,
 	/* The initiation of the election will perform the check that the
 	 * election is locally managed. */
 	enum election_step_e status = STEP_NONE;
-	if (!(err = election_init(repo->election_manager, n, &status, replicated))) {
+	if (!(err = election_init(repo->election_manager, n, peers,
+					&status, replicated))) {
 
 		/* Interleave a DB creation (out of the lock) if explicitely
 		 * allowed by both the request type AND the application */
@@ -1798,7 +1804,7 @@ sqlx_repository_restore_base(struct sqlx_sqlite3_s *sq3, guint8 *raw, gsize raws
 }
 
 GError*
-sqlx_repository_retore_from_master(struct sqlx_sqlite3_s *sq3)
+sqlx_repository_restore_from_master(struct sqlx_sqlite3_s *sq3)
 {
 	EXTRA_ASSERT(sq3 != NULL);
 	NAME2CONST(n, sq3->name);

--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -225,6 +225,7 @@ void sqlx_repository_call_db_properties_change_callback(
 
 GError* sqlx_repository_timed_open_and_lock(sqlx_repository_t *repo,
 		const struct sqlx_name_s *n, enum sqlx_open_type_e how,
+		const gchar *peers,
 		struct sqlx_sqlite3_s **sq3, gchar **lead,
 		gint64 deadline);
 
@@ -282,6 +283,7 @@ GError* sqlx_repository_exit_election(sqlx_repository_t *repo,
 /** Triggers the global election mechanism on a base given its name */
 GError* sqlx_repository_use_base(sqlx_repository_t *repo,
 		const struct sqlx_name_s *n,
+		const gchar *peers,
 		gboolean notify_master,
 		gboolean allow_autocreate,
 		gboolean *replicated);
@@ -328,7 +330,7 @@ GError* sqlx_repository_restore_base(struct sqlx_sqlite3_s *sq3,
 GError* sqlx_repository_restore_from_file(struct sqlx_sqlite3_s *sq3,
 		const gchar *path);
 
-GError* sqlx_repository_retore_from_master(struct sqlx_sqlite3_s *sq3);
+GError* sqlx_repository_restore_from_master(struct sqlx_sqlite3_s *sq3);
 
 /* ------------------------------------------------------------------------- */
 

--- a/sqliterepo/sqlx_remote.c
+++ b/sqliterepo/sqlx_remote.c
@@ -75,12 +75,13 @@ sqlx_encode_TableSequence(struct TableSequence *tabseq, GError **err)
 /* ------------------------------------------------------------------------- */
 
 GByteArray*
-sqlx_pack_USE(const struct sqlx_name_s *name, const gboolean master,
-		gint64 deadline)
+sqlx_pack_USE(const struct sqlx_name_s *name, const gchar *peers,
+		const gboolean master, gint64 deadline)
 {
 	MESSAGE req = make_request(NAME_MSGNAME_SQLX_USE, NULL, name, deadline);
 	if (master)
 		metautils_message_add_field_strint(req, NAME_MSGKEY_MASTER, 1);
+	metautils_message_add_field_str(req, SQLX_ADMIN_PEERS, peers);
 	return message_marshall_gba_and_clean(req);
 }
 
@@ -145,12 +146,14 @@ sqlx_pack_EXITELECTION(const struct sqlx_name_s *name, gint64 deadline)
 
 GByteArray*
 sqlx_pack_SNAPSHOT(const struct sqlx_name_s *name, const gchar *source,
-		const gchar *cid, const gchar *seq_num, gint64 deadline)
+		const gchar *cid, const gchar *seq_num, const gchar **fields,
+		gint64 deadline)
 {
 	MESSAGE req = make_request(NAME_MSGNAME_SQLX_SNAPSHOT, NULL, name, deadline);
 	metautils_message_add_field_str(req, NAME_MSGKEY_SRC, source);
 	metautils_message_add_field_str(req, NAME_MSGKEY_CONTAINERID, cid);
 	metautils_message_add_field_str(req, NAME_MSGKEY_SEQNUM, seq_num);
+	metautils_message_add_fields_str(req, fields);
 	return message_marshall_gba_and_clean(req);
 }
 
@@ -205,10 +208,12 @@ sqlx_pack_REPLICATE(const struct sqlx_name_s *name, struct TableSequence *tabseq
 }
 
 GByteArray*
-sqlx_pack_GETVERS(const struct sqlx_name_s *name, gint64 deadline)
+sqlx_pack_GETVERS(const struct sqlx_name_s *name, const gchar *peers,
+		gint64 deadline)
 {
 	EXTRA_ASSERT(name != NULL);
 	MESSAGE req = make_request(NAME_MSGNAME_SQLX_GETVERS, NULL, name, deadline);
+	metautils_message_add_field_str(req, SQLX_ADMIN_PEERS, peers);
 	return message_marshall_gba_and_clean(req);
 }
 

--- a/sqliterepo/sqlx_remote.h
+++ b/sqliterepo/sqlx_remote.h
@@ -90,15 +90,16 @@ GByteArray* sqlx_pack_PROPSET_tab (struct oio_url_s *url,
 		gint64 deadline);
 
 GByteArray* sqlx_pack_EXITELECTION(const struct sqlx_name_s *name, gint64 deadline);
-GByteArray* sqlx_pack_USE(const struct sqlx_name_s *name, const gboolean master,
-		gint64 deadline);
+GByteArray* sqlx_pack_USE(const struct sqlx_name_s *name, const gchar *peers,
+		const gboolean master, gint64 deadline);
 GByteArray* sqlx_pack_HAS(const struct sqlx_name_s *name, gint64 deadline);
 GByteArray* sqlx_pack_DESCR(const struct sqlx_name_s *name, gint64 deadline);
 GByteArray* sqlx_pack_STATUS(const struct sqlx_name_s *name, gint64 deadline);
-GByteArray* sqlx_pack_GETVERS(const struct sqlx_name_s *name, gint64 deadline);
+GByteArray* sqlx_pack_GETVERS(const struct sqlx_name_s *name, const gchar *peers,
+		gint64 deadline);
 
 GByteArray* sqlx_pack_SNAPSHOT(const struct sqlx_name_s *name, const gchar *source,
-		const gchar *cid, const gchar *seq_num, gint64 deadline);
+		const gchar *cid, const gchar *seq_num, const gchar **fields, gint64 deadline);
 GByteArray* sqlx_pack_PIPEFROM(const struct sqlx_name_s *name, const gchar *source, gint64 deadline);
 GByteArray* sqlx_pack_PIPETO(const struct sqlx_name_s *name, const gchar *target, gint64 deadline);
 GByteArray* sqlx_pack_REMOVE(const struct sqlx_name_s *name, gint64 deadline);

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -575,12 +575,14 @@ static gboolean _direct_use (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		const gboolean master);
 
 static gboolean _direct_getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,
@@ -624,13 +626,15 @@ struct use_request_s {
 	struct sockaddr_in6 addr;
 	struct sqlx_name_inline_s name;
 	gboolean master;
+	gchar reqid[LIMIT_LENGTH_REQID];
+	gchar peers[];
 };
 
 static void
 _use_by_udp_no_free(struct use_request_s *req, struct sqlx_peering_direct_s *self)
 {
 	NAME2CONST(n, req->name);
-	GByteArray *msg = sqlx_pack_USE(&n, req->master, req->deadline);
+	GByteArray *msg = sqlx_pack_USE(&n, req->peers, req->master, req->deadline);
 	const ssize_t len = msg->len;
 	const ssize_t sent = sendto(self->fd_udp, msg->data, msg->len,
 			MSG_NOSIGNAL, (struct sockaddr*) &req->addr, req->addr_len);
@@ -645,6 +649,10 @@ _use_by_udp_no_free(struct use_request_s *req, struct sqlx_peering_direct_s *sel
 static void
 _use_by_udp(struct use_request_s *req, struct sqlx_peering_direct_s *self)
 {
+	if (oio_str_is_set(req->reqid))
+		oio_ext_set_reqid(req->reqid);
+	else
+		oio_ext_set_prefixed_random_reqid("udp-use-");
 	_use_by_udp_no_free(req, self);
 	g_free(req);
 }
@@ -690,10 +698,11 @@ _direct_notify (struct sqlx_peering_s *self)
 }
 
 static gboolean
-_direct_use (struct sqlx_peering_s *self,
+_direct_use(struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *ni,
+		const char *peers,
 		const gboolean master)
 {
 	struct sqlx_peering_direct_s *p = (struct sqlx_peering_direct_s*) self;
@@ -707,20 +716,26 @@ _direct_use (struct sqlx_peering_s *self,
 	if (p->fd_udp >= 0) {
 		/* A UDP socket has been configured, so we skip the queue and the pool
 		 * for TCP RPC */
-		struct use_request_s req = {0};
-		req.deadline = deadline;
-		req.addr_len = sizeof(req.addr);
-		memcpy(&req.name, ni, sizeof(req.name));
-		req.master = master;
+		gsize struct_size =
+				sizeof(struct use_request_s) + 1 + (peers? strlen(peers) : 0);
+		struct use_request_s *req = g_alloca(struct_size);
+		req->deadline = deadline;
+		req->addr_len = sizeof(req->addr);
+		memcpy(&(req->name), ni, sizeof(req->name));
+		req->master = master;
 		if (!grid_string_to_sockaddr(url,
-					(struct sockaddr*)&req.addr, &req.addr_len)) {
+					(struct sockaddr*)&(req->addr), &req->addr_len)) {
 			GRID_WARN("Invalid peer addr [%s]", url);
 		} else {
+			g_strlcpy(req->reqid, oio_ext_ensure_reqid("sync-use-"),
+					LIMIT_LENGTH_REQID);
+			if (peers)
+				strcpy(req->peers, peers);
 			if (sqliterepo_udp_deferred) {
 				metautils_gthreadpool_push("UDP", p->pool_udp_use,
-						g_memdup(&req, sizeof(req)));
+						g_memdup(req, struct_size));
 			} else {
-				_use_by_udp_no_free(&req, p);
+				_use_by_udp_no_free(req, p);
 			}
 		}
 		return FALSE;
@@ -743,7 +758,7 @@ _direct_use (struct sqlx_peering_s *self,
 			return FALSE;
 		} else {
 			NAME2CONST(n, *ni);
-			GByteArray *req = sqlx_pack_USE(&n, master, deadline);
+			GByteArray *req = sqlx_pack_USE(&n, peers, master, deadline);
 			err = gridd_client_request (mc->client, req, NULL, NULL);
 			g_byte_array_unref(req);
 			if (err) {
@@ -894,6 +909,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,
@@ -912,7 +928,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 	mc->hook = result;
 	mc->m = m;
 	if (!reqid)
-		reqid = oio_ext_get_reqid();
+		reqid = oio_ext_ensure_reqid("sync-vers-");
 	g_strlcpy(mc->reqid, reqid, LIMIT_LENGTH_REQID);
 	mc->vremote = NULL;
 
@@ -929,7 +945,7 @@ _direct_getvers (struct sqlx_peering_s *self,
 		return FALSE;
 	} else {
 		NAME2CONST(n0, *n);
-		GByteArray *req = sqlx_pack_GETVERS(&n0, deadline);
+		GByteArray *req = sqlx_pack_GETVERS(&n0, peers, deadline);
 		err = gridd_client_request (mc->ec.client, req, mc, on_reply_GETVERS);
 		g_byte_array_unref(req);
 		if (NULL != err) {
@@ -972,12 +988,13 @@ sqlx_peering__use (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		const gboolean master)
 {
 #ifdef HAVE_EXTRA_DEBUG
-	PEER_CALL(self,use)(self, url, n, master);
+	PEER_CALL(self,use)(self, url, n, peers, master);
 #else
-	return _direct_use(self, url, n, master);
+	return _direct_use(self, url, n, peers, master);
 #endif
 }
 
@@ -986,15 +1003,16 @@ sqlx_peering__getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,
 		sqlx_peering_getvers_end_f result)
 {
 #ifdef HAVE_EXTRA_DEBUG
-	PEER_CALL(self,getvers)(self, url, n, m, reqid, result);
+	PEER_CALL(self,getvers)(self, url, n, peers, m, reqid, result);
 #else
-	return _direct_getvers(self, url, n, m, reqid, result);
+	return _direct_getvers(self, url, n, peers, m, reqid, result);
 #endif
 }
 

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -142,6 +142,7 @@ struct sqlx_peering_vtable_s
 			/* in */
 			const char *url,
 			const struct sqlx_name_inline_s *n,
+			const gchar *peers,
 			const gboolean master);
 
 	/** @return FALSE if no notify() is necessary (i.e. no command deferred) */
@@ -149,6 +150,7 @@ struct sqlx_peering_vtable_s
 			/* in */
 			const char *url,
 			const struct sqlx_name_inline_s *n,
+			const gchar *peers,
 			/* out */
 			struct election_member_s *m,
 			const char *reqid,
@@ -179,12 +181,14 @@ gboolean sqlx_peering__use (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		const gboolean master);
 
 gboolean sqlx_peering__getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -485,6 +485,8 @@ filter_services(struct sqlx_service_s *ss, gchar **s, const gchar *type)
 	return NULL;
 }
 
+// TODO(FVE): when this conflicts while merging to master branch,
+// move to meta2v2/meta2_server.c.
 GError *
 sqlx_service_resolve_peers(struct sqlx_service_s *ss,
 		const struct sqlx_name_s *n, gboolean nocache, gchar ***result)
@@ -530,6 +532,16 @@ label_retry:
 	oio_url_pclean (&u);
 	return err;
 }
+
+#if 0
+static GError *
+sqlx_service_reply_no_peers(struct sqlx_service_s *ss UNUSED,
+		const struct sqlx_name_s *n UNUSED, gboolean nocache UNUSED,
+		gchar ***result UNUSED)
+{
+	return NEWERROR(CODE_NOT_ALLOWED, "Refusing to call meta1 to get peers.");
+}
+#endif
 
 // TODO: replace `nocache` by flags
 static GError *

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -378,6 +378,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self.assertEqual(properties['system']['sys.m2.usage'], '0')
         all_objects = self.api.object_list(self.account, cname)
         self.assertEqual(0, len(all_objects['objects']))
+        self.beanstalkd0.drain_buried('oio')
 
     # These tests are numbered to force them to be run in order
     def test_container_flush_0_no_container(self):

--- a/tests/unit/test_sqliterepo_election.c
+++ b/tests/unit/test_sqliterepo_election.c
@@ -111,12 +111,14 @@ static void _peering_notify (struct sqlx_peering_s *self UNUSED) {}
 static gboolean _peering_use (struct sqlx_peering_s *self,
 			const char *url,
 			const struct sqlx_name_inline_s *n,
+		const char *peers UNUSED,
 			const gboolean master);
 
 static gboolean _peering_getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers UNUSED,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,
@@ -144,6 +146,7 @@ static gboolean
 _peering_use (struct sqlx_peering_s *self,
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers UNUSED,
 		const gboolean master)
 {
 	(void) self, (void) url, (void) n, (void) master;
@@ -156,6 +159,7 @@ _peering_getvers (struct sqlx_peering_s *self,
 		/* in */
 		const char *url,
 		const struct sqlx_name_inline_s *n,
+		const char *peers UNUSED,
 		/* out */
 		struct election_member_s *m,
 		const char *reqid,
@@ -485,7 +489,7 @@ test_election_init(void)
 		g_snprintf(n0.base, sizeof(n0.base),
 				"base-%"G_GUINT32_FORMAT, oio_ext_rand_int());
 		NAME2CONST(n, n0);
-		err = election_init(m, &n, NULL, NULL);
+		err = election_init(m, &n, NULL, NULL, NULL);
 		g_assert_no_error(err);
 		err = election_exit(m, &n);
 		g_assert_no_error(err);
@@ -531,7 +535,7 @@ test_create_ok(void)
 	sqliterepo_hash_name(&name, _k, sizeof(_k)); \
 	struct election_member_s *m = manager_get_member (manager, _k); \
 	g_assert_null(m); \
-	g_assert_no_error (_election_init (manager, &name, NULL, NULL)); \
+	g_assert_no_error (_election_init (manager, &name, NULL, NULL, NULL)); \
 	m = manager_get_member (manager, _k); \
 	g_assert_nonnull(m); \
 


### PR DESCRIPTION
##### SUMMARY
Some operations like M2_CREATE, DB_USE and DB_VERS now send the list of peers in the request. In the case where the called service does not have the database already, it is no more forced to call meta1 to get the list.

Jira: OS-374

##### COMPONENT NAME
- oioproxy
- sqliterepo
- meta2

##### SDS VERSION
```
openio 5.1.1.dev47
```


##### ADDITIONAL INFORMATION
When benchmarking this, we should see a decrease of the number of `M1_LIST` calls.
