### PR TITLE
rawx: log bad requests, enhance log format

### DIFF
--- a/rawx-apache2/src/rawx_chunk_update.c
+++ b/rawx-apache2/src/rawx_chunk_update.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS rawx-apache2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -238,9 +238,15 @@ __build_chunk_full_path(const dav_resource *resource, char **full_path)
 	const request_rec *r = resource->info->request;
 	dav_rawx_server_conf *conf = request_get_server_config(r);
 
-	if(strlen(r->uri) < 65)
-		return server_create_and_stat_error(request_get_server_config(r), r->pool,
-				HTTP_BAD_REQUEST, 0, apr_pstrcat(r->pool, "Cannot parse request uri ", r->uri, NULL));
+	if (strlen(r->uri) < 65) {
+		dav_error *err = server_create_and_stat_error(
+				request_get_server_config(r), r->pool,
+				HTTP_BAD_REQUEST, 0,
+				apr_pstrcat(r->pool, "Cannot parse request uri ", r->uri, NULL)
+		);
+		DAV_ERROR_RES(resource, HTTP_BAD_REQUEST, "%s", err->desc);
+		return err;
+	}
 	char *p = NULL;
 
 	uint i_p = 1;

--- a/rawx-apache2/src/rawx_repo_core.c
+++ b/rawx-apache2/src/rawx_repo_core.c
@@ -724,9 +724,12 @@ rawx_repo_commit_upload(dav_stream *stream)
 			/* A checksum has been provided, let's check it matches the checksum
 			 * computed over the input */
 			if (0 != strcasecmp(fake.chunk_hash, hex)) {
-				return server_create_and_stat_error(
+				dav_error *err = server_create_and_stat_error(
 						conf, stream->p, HTTP_BAD_REQUEST, 0,
-						apr_pstrcat(stream->p, "MD5 mismatch hdr=", fake.chunk_hash, " body=", hex, NULL));
+						apr_pstrcat(stream->p, "MD5 mismatch hdr=",
+						fake.chunk_hash, " body=", hex, NULL));
+				DAV_ERROR_POOL(stream->p, HTTP_BAD_REQUEST, "%s", err->desc);
+				return err;
 			} else {
 				DAV_DEBUG_REQ(stream->r->info->request, 0, "MD5 match for %s",
 						stream->final_pathname);

--- a/rawx-apache2/src/rawx_repository.c
+++ b/rawx-apache2/src/rawx_repository.c
@@ -478,11 +478,13 @@ dav_rawx_get_resource(request_rec *r, const char *root_dir, const char *label,
 		const char *missing = check_chunk_content_fullpath(
 				r->pool, &resource->info->chunk);
 		if (missing != NULL) {
-			return server_create_and_stat_error(
+			e = server_create_and_stat_error(
 					request_get_server_config(r), r->pool,
 					HTTP_BAD_REQUEST, 0,
 					apr_pstrcat(r->pool, "missing or invalid header ", missing,
 							NULL));
+			DAV_ERROR_REQ(r, HTTP_BAD_REQUEST, "%s", e->desc);
+			return e;
 		}
 	}
 
@@ -493,19 +495,24 @@ dav_rawx_get_resource(request_rec *r, const char *root_dir, const char *label,
 		const char *missing = check_chunk_info(
 				r->pool, &resource->info->chunk);
 		if (missing != NULL) {
-			return server_create_and_stat_error(
+			e = server_create_and_stat_error(
 					request_get_server_config(r), r->pool,
 					HTTP_BAD_REQUEST, 0,
 					apr_pstrcat(r->pool, "missing or invalid header ", missing,
 							NULL));
+			DAV_ERROR_REQ(r, HTTP_BAD_REQUEST, "%s", e->desc);
+			return e;
 		}
 	}
 
 	if (r->method_number == M_POST || r->method_number == M_PUT) {
 		if (resource->info->chunk.chunk_id) {
-			if (0 != apr_strnatcasecmp(resource->info->chunk.chunk_id, resource->info->hex_chunkid))
-				return server_create_and_stat_error(request_get_server_config(r), r->pool,
+			if (apr_strnatcasecmp(resource->info->chunk.chunk_id, resource->info->hex_chunkid)) {
+				e = server_create_and_stat_error(request_get_server_config(r), r->pool,
 						HTTP_BAD_REQUEST, 0, "chunk-id mismatch");
+				DAV_ERROR_REQ(r, HTTP_BAD_REQUEST, "%s", e->desc);
+				return e;
+			}
 		} else {
 			resource->info->chunk.chunk_id = apr_pstrdup(
 					r->pool, resource->info->hex_chunkid);

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -203,8 +203,8 @@ SetEnvIf Request_Method "PUT" log-cid-in=1
 SetEnvIf Request_Method "PUT" !log-cid-out
 SetEnvIf log-cid-in 0 !log-cid-in
 
-LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %{${META_HEADER}-container-id}i %{x-oio-req-id}i %U" log/cid-in
-LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %{${META_HEADER}-container-id}o %{x-oio-req-id}i %U" log/cid-out
+LogFormat "%{end:%b %d %T}t.%{end:usec_frac}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %{${META_HEADER}-container-id}i %{x-oio-req-id}i %U" log/cid-in
+LogFormat "%{end:%b %d %T}t.%{end:usec_frac}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %{${META_HEADER}-container-id}o %{x-oio-req-id}i %U" log/cid-out
 
 ErrorLog ${SDSDIR}/logs/${NS}-${SRVTYPE}-${SRVNUM}-errors.log
 SetEnvIf Request_URI "/(stat|info)$" nolog=1


### PR DESCRIPTION
##### SUMMARY
When an error occurs after the rawx has already sent the first response, only this error response appears in the access log. To help debugging these cases, display the first error in the main log file.

Instead of logging the time the request started, be consistent with all other OpenIO SDS services, and log the time the request ended. Also, to help matching log lines that do not carry a request ID, display the time with microseconds.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- rawx

##### SDS VERSION
```
5.2.2
```


##### ADDITIONAL INFORMATION

