### PR TITLE
Make some tests more reliable

### DIFF
--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -106,6 +106,7 @@ class ContainerTest(CliTestCase):
         self._test_container_refresh(with_cid=True)
 
     def _test_container_snapshot(self, with_cid=False):
+        self.wait_for_score(('meta2', ))
         # Snapshot should reply the name of the snapshot on success
         opts = self.get_opts([], 'json')
         cid_opt = ''

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -500,10 +500,15 @@ class BaseTestCase(CommonTestCase):
             wait = False
             for type_ in types:
                 try:
-                    for service in self.conscience.all_services(type_):
+                    all_svcs = self.conscience.all_services(type_)
+                    for service in all_svcs:
                         if int(service['score']) < score_threshold:
                             wait = True
                             break
+                    else:
+                        # No service registered yet, must wait.
+                        if not all_svcs:
+                            wait = True
                 except Exception as err:
                     logging.warn('Could not check service score: %s', err)
                     wait = True


### PR DESCRIPTION
##### SUMMARY
Fix the behavior of the `wait_for_score` method when no service has registered yet. Call this method in some tests to make them more reliable.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- tests

##### SDS VERSION
```
openio 4.8.1.dev17
```