### PR TITLE
CLI: fix container list with non-ASCII characters

### DIFF
--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -174,6 +174,8 @@ def cid_from_name(account, ref):
     """
     hash_ = sha256()
     for v in [account, '\0', ref]:
+        if isinstance(v, unicode):
+            v = v.encode('utf-8')
         hash_.update(v)
     return hash_.hexdigest().upper()
 

--- a/oio/directory/indexer.py
+++ b/oio/directory/indexer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2018-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -156,6 +156,10 @@ class Meta2IndexingWorker(object):
 
             container_id = db_id.rsplit(".")[0]
 
+            if isinstance(account, unicode):
+                account = account.encode('utf-8')
+            if isinstance(container, unicode):
+                container = container.encode('utf-8')
             cont_url = "{0}/{1}/{2}".format(self.namespace, account, container)
 
             if not is_peer:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -527,6 +527,9 @@ class BaseTestCase(CommonTestCase):
         Wait for an event in the specified tube.
         If reqid, types and/or fields are specified, drain events until the
         specified event is found.
+
+        :param fields: dict of fields to look for in the event's URL
+        :param types: list of types of events the method should look for
         """
         self.beanstalkd0.wait_for_ready_job(tube, timeout=timeout)
         self.beanstalkd0.watch(tube)


### PR DESCRIPTION
##### SUMMARY
Fix an issue with container list and non-ASCII characters.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API
- CLI

##### SDS VERSION
```
openio 4.8.2.dev12
```


##### ADDITIONAL INFORMATION
The bug manifested itself with something like:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cliff/app.py", line 401, in run_subcommand
    result = cmd.run(parsed_args)
  File "/home/fvennetier/src/public_git/oio-sds/oio/cli/__init__.py", line 126, in run
    super(Lister, self).run(parsed_args)
  File "/usr/lib/python2.7/site-packages/cliff/display.py", line 119, in run
    self.produce_output(parsed_args, column_names, data)
  File "/usr/lib/python2.7/site-packages/cliff/lister.py", line 82, in produce_output
    parsed_args,
  File "/usr/lib/python2.7/site-packages/cliff/formatters/table.py", line 101, in emit_list
    self.add_rows(x, column_names, data)
  File "/usr/lib/python2.7/site-packages/cliff/formatters/table.py", line 80, in add_rows
    first_row = next(data_iter)
  File "/home/fvennetier/src/public_git/oio-sds/oio/cli/container/container.py", line 463, in <genexpr>
    for v in listing)
  File "/home/fvennetier/src/public_git/oio-sds/oio/common/utils.py", line 177, in cid_from_name
    hash_.update(v)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 3: ordinal not in range(128)
```