### PR TITLE
Python API: fix request ID header name

### DIFF
--- a/core/log.c
+++ b/core/log.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS core library
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -225,9 +225,15 @@ _logger_stderr(const gchar *log_domain, GLogLevelFlags log_level,
 	GString *gstr = g_string_sized_new(512);
 
 	if (oio_log_flags & LOG_FLAG_PRETTYTIME) {
+#if GLIB_CHECK_VERSION(2,56,0)
+		GDateTime *tv = g_date_time_new_now_local();
+		gchar *strnow = g_date_time_format_iso8601(tv);
+		g_date_time_unref(tv);
+#else
 		GTimeVal tv;
 		g_get_current_time(&tv);
-		gchar * strnow = g_time_val_to_iso8601 (&tv);
+		gchar *strnow = g_time_val_to_iso8601(&tv);
+#endif
 		g_string_append(gstr, strnow);
 		g_free(strnow);
 	} else {

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -20,7 +20,7 @@ from werkzeug.exceptions import NotFound, BadRequest, Conflict
 from functools import wraps
 
 from oio.account.backend import AccountBackend
-from oio.common.constants import STRLEN_REQID
+from oio.common.constants import STRLEN_REQID, REQID_HEADER
 from oio.common.json import json
 from oio.common.logger import get_logger
 from oio.common.wsgi import WerkzeugApp
@@ -35,7 +35,7 @@ def access_log(func):
         pre = time()
         rc = func(self, req, *args, **kwargs)
         post = time()
-        reqid = req.headers.get('X-oio-req-id', '-')[:STRLEN_REQID]
+        reqid = req.headers.get(REQID_HEADER, '-')[:STRLEN_REQID]
         # func time size user reqid
         self.logger.info("%s %0.6f %s %s %s",
                          func.__name__, post - pre, '-', '-', reqid)

--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -23,7 +23,7 @@ from oio.common import exceptions
 from oio.common.utils import deadline_to_timeout, monotonic_time
 from oio.common.constants import ADMIN_HEADER, \
     TIMEOUT_HEADER, PERFDATA_HEADER, FORCEMASTER_HEADER, \
-    CONNECTION_TIMEOUT, READ_TIMEOUT
+    CONNECTION_TIMEOUT, READ_TIMEOUT, REQID_HEADER
 
 
 class HttpApi(object):
@@ -133,7 +133,7 @@ class HttpApi(object):
 
         # Look for a request ID
         if 'reqid' in kwargs:
-            out_headers['X-oio-req-id'] = str(kwargs['reqid'])
+            out_headers[REQID_HEADER] = str(kwargs['reqid'])
 
         # Convert json and add Content-Type
         if json:
@@ -190,7 +190,7 @@ class HttpApi(object):
                         kv[0], 0.0) + float(kv[1]) / 1000000.0
         except urllib3.exceptions.HTTPError as exc:
             oio_exception_from_httperror(exc,
-                                         reqid=out_headers.get('X-oio-req-id'),
+                                         reqid=out_headers.get(REQID_HEADER),
                                          url=url)
         if resp.status >= 400:
             raise exceptions.from_response(resp, body)

--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -26,13 +26,12 @@ from greenlet import GreenletExit
 
 from oio.api import io
 from oio.common import exceptions
-from oio.common.constants import REQID_HEADER
+from oio.common.constants import CHUNK_HEADERS, REQID_HEADER
 from oio.common.exceptions import SourceReadError
 from oio.common.http import HeadersDict, parse_content_range, \
     ranges_from_http_header, headers_from_object_metadata
-from oio.common.utils import fix_ranges, monotonic_time
-from oio.common.constants import CHUNK_HEADERS
 from oio.common.logger import get_logger
+from oio.common.utils import fix_ranges, monotonic_time
 
 
 LOGGER = get_logger({}, __name__)
@@ -584,7 +583,7 @@ class EcChunkWriter(object):
         chunk_path = parsed.path.split('/')[-1]
         hdrs = headers_from_object_metadata(sysmeta)
         if reqid:
-            hdrs['X-oio-req-id'] = reqid
+            hdrs[REQID_HEADER] = reqid
 
         hdrs[CHUNK_HEADERS["chunk_pos"]] = chunk["pos"]
         hdrs[CHUNK_HEADERS["chunk_id"]] = chunk_path

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -279,7 +279,7 @@ class ChunkReader(object):
         """:returns: the request ID or None"""
         if not self.request_headers:
             return None
-        return self.request_headers.get('X-oio-req-id')
+        return self.request_headers.get(REQID_HEADER)
 
     def recover(self, nb_bytes):
         """

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -25,7 +25,7 @@ from oio.common.http_urllib3 import get_pool_manager, \
     oio_exception_from_httperror, urllib3
 from oio.common import exceptions as exc, utils
 from oio.common.constants import CHUNK_HEADERS, chunk_xattr_keys_optional, \
-        HEADER_PREFIX, OIO_VERSION
+        HEADER_PREFIX, OIO_VERSION, REQID_HEADER
 from oio.common.decorators import ensure_headers, ensure_request_id
 from oio.api.io import ChunkReader
 from oio.api.replication import ReplicatedMetachunkWriter, FakeChecksum
@@ -168,7 +168,7 @@ class BlobClient(object):
             resp = self.http_pool.request(
                 'HEAD', url, headers=headers)
         except urllib3.exceptions.HTTPError as ex:
-            oio_exception_from_httperror(ex, reqid=headers['X-oio-req-id'],
+            oio_exception_from_httperror(ex, reqid=headers[REQID_HEADER],
                                          url=url)
         if resp.status == 200:
             if not _xattr:

--- a/oio/blob/indexer.py
+++ b/oio/blob/indexer.py
@@ -25,7 +25,8 @@ from oio.blob.utils import check_volume, read_chunk_metadata
 from oio.rdir.client import RdirClient
 from oio.common.daemon import Daemon
 from oio.common import exceptions as exc
-from oio.common.constants import STRLEN_CHUNKID, CHUNK_SUFFIX_PENDING
+from oio.common.constants import STRLEN_CHUNKID, CHUNK_SUFFIX_PENDING, \
+    REQID_HEADER
 from oio.common.easy_value import int_value, true_value
 from oio.common.http_urllib3 import get_pool_manager
 from oio.common.logger import get_logger
@@ -182,7 +183,7 @@ class BlobIndexer(Daemon):
 
             data = {'mtime': int(time.time())}
             # TODO(FVE): replace with the improved request_id() function
-            headers = {'X-oio-req-id': 'blob-indexer-' + request_id()[:-13]}
+            headers = {REQID_HEADER: 'blob-indexer-' + request_id()[:-13]}
             self.index_client.chunk_push(self.volume_id,
                                          meta['container_id'],
                                          meta['content_id'],

--- a/oio/common/decorators.py
+++ b/oio/common/decorators.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2017-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,6 +14,7 @@
 # License along with this library.
 
 from functools import wraps
+from oio.common.constants import REQID_HEADER
 from oio.common.utils import request_id, set_deadline_from_read_timeout
 from oio.common.exceptions import NotFound, NoSuchAccount, NoSuchObject, \
     NoSuchContainer, reraise
@@ -32,15 +33,15 @@ def ensure_request_id(func):
     def ensure_request_id_wrapper(*args, **kwargs):
         headers = kwargs.get('headers', dict())
         # Old style request ID
-        if 'X-oio-req-id' not in headers:
+        if REQID_HEADER not in headers:
             if 'reqid' in kwargs:
-                headers['X-oio-req-id'] = kwargs.pop('reqid')
+                headers[REQID_HEADER] = kwargs.pop('reqid')
             else:
-                headers['X-oio-req-id'] = request_id()
+                headers[REQID_HEADER] = request_id()
             kwargs['headers'] = headers
         # New style request ID
         if 'reqid' not in kwargs:
-            kwargs['reqid'] = kwargs['headers']['X-oio-req-id']
+            kwargs['reqid'] = kwargs['headers'][REQID_HEADER]
         return func(*args, **kwargs)
     return ensure_request_id_wrapper
 

--- a/oio/common/wsgi.py
+++ b/oio/common/wsgi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ from oio.common.logger import get_logger
 
 class Application(BaseApplication):
     access_log_fmt = '%(bind0)s %(h)s:%({remote}p)s %(m)s %(s)s %(D)s ' + \
-                     '%(B)s %(l)s %({X-oio-req-id}i)s %(U)s?%(q)s'
+                     '%(B)s %(l)s %({x-oio-req-id}i)s %(U)s?%(q)s'
 
     def __init__(self, app, conf, logger_class=None):
         self.conf = conf

--- a/oio/event/filters/content_cleaner.py
+++ b/oio/event/filters/content_cleaner.py
@@ -20,6 +20,7 @@ from oio.event.filters.base import Filter
 from oio.common.exceptions import OioException
 from oio.api.backblaze import BackblazeDeleteHandler
 from oio.api.backblaze_http import BackblazeUtils
+from oio.common.constants import REQID_HEADER
 from oio.common.http_urllib3 import URLLIB3_POOLMANAGER_KWARGS
 from oio.common.storage_method import STORAGE_METHODS, guess_storage_method
 from oio.common.utils import request_id
@@ -43,7 +44,7 @@ class ContentReaperFilter(Filter):
     def _handle_rawx(self, url, chunks, content_headers,
                      storage_method, reqid):
         cid = url.get('id')
-        headers = {'X-oio-req-id': reqid,
+        headers = {REQID_HEADER: reqid,
                    'Connection': 'close'}
 
         resps = self.blob_client.chunk_delete_many(

--- a/oio/event/filters/volume_index.py
+++ b/oio/event/filters/volume_index.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+from oio.common.constants import REQID_HEADER
 from oio.event.evob import Event, EventError, EventTypes
 from oio.event.filters.base import Filter
 from oio.common.exceptions import OioException, VolumeException
@@ -35,7 +35,7 @@ class VolumeIndexFilter(Filter):
 
     def _chunk_delete(self, reqid,
                       volume_id, container_id, content_id, chunk_id):
-        headers = {'X-oio-req-id': reqid}
+        headers = {REQID_HEADER: reqid}
         try:
             return self.rdir.chunk_delete(
                     volume_id, container_id, content_id, chunk_id,
@@ -49,7 +49,7 @@ class VolumeIndexFilter(Filter):
     def _chunk_push(self, reqid,
                     volume_id, container_id, content_id, chunk_id,
                     args):
-        headers = {'X-oio-req-id': reqid}
+        headers = {REQID_HEADER: reqid}
         try:
             return self.rdir.chunk_push(
                     volume_id, container_id, content_id, chunk_id,
@@ -66,7 +66,7 @@ class VolumeIndexFilter(Filter):
             self.logger.debug(
                 'Indexing services of type %s is not supported', type_)
             return
-        headers = {'X-oio-req-id': reqid}
+        headers = {REQID_HEADER: reqid}
         try:
             return self.rdir.meta2_index_push(
                 volume_id, url, cid, mtime, headers=headers)
@@ -80,7 +80,7 @@ class VolumeIndexFilter(Filter):
             self.logger.debug(
                 'Indexing services of type %s is not supported', type_)
             return
-        headers = {'X-oio-req-id': reqid}
+        headers = {REQID_HEADER: reqid}
         try:
             return self.rdir.meta2_index_delete(
                 volume_id, url, cid, headers=headers)

--- a/oio/rdir/client.py
+++ b/oio/rdir/client.py
@@ -29,7 +29,7 @@ from oio.directory.client import DirectoryClient
 from oio.common.utils import depaginate, cid_from_name
 from oio.common.green import sleep
 from oio.common.easy_value import true_value
-from oio.common.constants import HEADER_PREFIX
+from oio.common.constants import HEADER_PREFIX, REQID_HEADER
 
 RDIR_ACCT = '_RDIR'
 
@@ -340,7 +340,7 @@ class RdirClient(HttpApi):
             return self._addr_cache[volume_id]
         # Not cached, try a direct lookup
         try:
-            headers = {'X-oio-req-id': reqid or request_id()}
+            headers = {REQID_HEADER: reqid or request_id()}
             resp = self.directory.list(RDIR_ACCT, volume_id,
                                        service_type='rdir',
                                        headers=headers)
@@ -367,7 +367,7 @@ class RdirClient(HttpApi):
         if create:
             params['create'] = '1'
         uri = self._make_uri(action, volume,
-                             reqid=kwargs['headers']['X-oio-req-id'],
+                             reqid=kwargs['headers'][REQID_HEADER],
                              service_type=service_type)
         try:
             resp, body = self._direct_request(method, uri, params=params,

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -22,6 +22,7 @@ from urllib3 import HTTPResponse
 from oio.api.object_storage import ObjectStorageApi, _sort_chunks
 from oio.common.storage_functions import _sort_chunks as sort_chunks
 from oio.common import exceptions as exc
+from oio.common.constants import REQID_HEADER
 from oio.common.utils import cid_from_name, request_id, depaginate
 from oio.common.fullpath import encode_fullpath
 from oio.common.storage_method import STORAGE_METHODS
@@ -91,7 +92,7 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         self._create(name)
         # container_show on existing container
         res = self.api.container_show(self.account, name,
-                                      headers={'X-oio-req-id': 'Salut!'})
+                                      headers={REQID_HEADER: 'Salut!'})
         self.assertIsNot(res['properties'], None)
 
         self._delete(name)

--- a/tests/functional/content/test_content_perfectible.py
+++ b/tests/functional/content/test_content_perfectible.py
@@ -27,6 +27,7 @@ from collections import defaultdict
 from tests.utils import BaseTestCase
 
 from oio.api.object_storage import ObjectStorageApi
+from oio.common.constants import REQID_HEADER
 from oio.common.utils import request_id
 from oio.event.beanstalk import ResponseError
 from oio.rebuilder.blob_improver import DEFAULT_IMPROVER_TUBE
@@ -103,7 +104,7 @@ class TestPerfectibleContent(BaseTestCase):
                                obj_name='perfect',
                                data='whatever',
                                policy='THREECOPIES',
-                               headers={'X-oio-req-id': reqid})
+                               headers={REQID_HEADER: reqid})
 
         # Wait on the oio-improve beanstalk tube.
         self.beanstalkd.watch(DEFAULT_IMPROVER_TUBE)
@@ -133,7 +134,7 @@ class TestPerfectibleContent(BaseTestCase):
                                obj_name='perfectible',
                                data='whatever',
                                policy='THREECOPIES',
-                               headers={'X-oio-req-id': reqid})
+                               headers={REQID_HEADER: reqid})
 
         # Wait on the oio-improve beanstalk tube.
         event = self._wait_for_event()
@@ -177,7 +178,7 @@ class TestPerfectibleContent(BaseTestCase):
                                obj_name='perfectible',
                                data='whatever',
                                policy='THREECOPIES',
-                               headers={'X-oio-req-id': reqid})
+                               headers={REQID_HEADER: reqid})
 
         # Wait on the oio-improve beanstalk tube.
         event = self._wait_for_event()

--- a/tests/unit/api/test_objectstorage.py
+++ b/tests/unit/api/test_objectstorage.py
@@ -24,7 +24,8 @@ from mock import MagicMock as Mock, ANY
 
 
 from oio.common import exceptions
-from oio.common.constants import container_headers, object_headers
+from oio.common.constants import container_headers, object_headers, \
+    REQID_HEADER
 from oio.common.decorators import handle_container_not_found, \
     handle_object_not_found
 from oio.common.storage_functions import _sort_chunks
@@ -50,7 +51,7 @@ class ObjectStorageTest(unittest.TestCase):
         self.account = "test"
         self.container = "fake"
         reqid = random_str(32)
-        self.headers = {"X-oio-req-id": reqid}
+        self.headers = {REQID_HEADER: reqid}
         self.common_kwargs = {'headers': self.headers, 'reqid': reqid}
         self.policy = "THREECOPIES"
         self.uri_base = self.fake_endpoint + "/v3.0/NS"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,6 +29,7 @@ from urllib import urlencode
 import yaml
 import testtools
 
+from oio.common.constants import REQID_HEADER
 from oio.common.configuration import load_namespace_conf, set_namespace_options
 from oio.common.http_urllib3 import get_pool_manager
 from oio.common.json import json as jsonlib
@@ -116,7 +117,7 @@ def get_config(defaults=None):
 
 class CommonTestCase(testtools.TestCase):
 
-    TEST_HEADERS = {'X-oio-req-id': '7E571D0000000000'}
+    TEST_HEADERS = {REQID_HEADER: '7E571D0000000000'}
 
     def is_running_on_public_ci(self):
         from os import getenv


### PR DESCRIPTION
##### SUMMARY
The request ID header name was sometimes written with an upper case 'X', sometimes with a lower case one, until the introduction a constant. Unfortunately, this constant was not used everywhere...

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API
- account

##### SDS VERSION
```
openio 4.8.2.dev3
```