### PR TITLE
Prettier election debug

### DIFF
--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS sqliterepo
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -1352,7 +1352,11 @@ member_json (struct election_member_s *m, GString *gs)
 	g_string_append_c (gs, ',');
 	OIO_JSON_append_str (gs, "type", m->inline_name.type);
 	g_string_append_c (gs, ',');
-	OIO_JSON_append_str (gs, "zk", m->key);
+	gchar *full_key = sqlx_sync_zk_full_key_path(m->sync, m->key);
+	OIO_JSON_append_str (gs, "zk", full_key);
+	g_free(full_key);
+	g_string_append_c(gs, ',');
+	OIO_JSON_append_str(gs, "zk_server", sqlx_sync_zk_server(m->sync));
 	g_string_append_static (gs, "},\"#\":{");
 	OIO_JSON_append_int (gs, "refcount", m->refcount);
 	g_string_append_c (gs, ',');

--- a/sqliterepo/synchro.c
+++ b/sqliterepo/synchro.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS sqliterepo
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -563,6 +563,28 @@ int
 sqlx_sync_uses_handle(struct sqlx_sync_s *ss, zhandle_t *zh)
 {
 	return ss? ss->zh == zh: FALSE;
+}
+
+gchar*
+sqlx_sync_zk_full_key_path(struct sqlx_sync_s *ss, const char *key)
+{
+	if (!ss || !key)
+		return NULL;
+	gchar p[PATH_MAXLEN];
+	_realpath(ss, key, p, sizeof(p));
+	return g_strdup(p);
+}
+
+const char*
+sqlx_sync_zk_server(struct sqlx_sync_s *ss)
+{
+	if (!ss || !ss->zh)
+		return NULL;
+#if ZOO_MAJOR_VERSION > 3 || (ZOO_MAJOR_VERSION == 3 && ZOO_MINOR_VERSION >= 5)
+	return zoo_get_current_server(ss->zh);
+#else
+	return "# requires zookeeper>=3.5 #";
+#endif
 }
 
 /* -------------------------------------------------------------------------- */

--- a/sqliterepo/synchro.h
+++ b/sqliterepo/synchro.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS sqliterepo
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -108,6 +108,12 @@ void sqlx_sync_set_hash(struct sqlx_sync_s *ss, guint witdth, guint depth);
 /** Tell if the current synchronizer handle is using the specified
  * Zookeeper handle. */
 int sqlx_sync_uses_handle(struct sqlx_sync_s *ss, zhandle_t *zh);
+
+/** Build to full ZK path to the key. Must be freed with g_free. */
+gchar* sqlx_sync_zk_full_key_path(struct sqlx_sync_s *ss, const char *key);
+
+/** Tell which server this handle is connected to. */
+const char* sqlx_sync_zk_server(struct sqlx_sync_s *ss);
 
 /** Get a string describing one of Zookeeper's state constants. */
 const char * zoo_state2str(int state);


### PR DESCRIPTION
##### SUMMARY
When calling `openio-admin election debug`, the JSON object will now show the full path to the ZooKeeper node, and the server address. And if the `--human` option is specified, full dates will be printed instead of timestamps.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 4.8.2.dev16
```