### PR TITLE
xcute: Send the tasks by batch

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -287,7 +287,7 @@ class AccountBackend(RedisConnection):
             'bytes': 0,
             'damaged_objects': 0,
             'missing_chunks': 0,
-            'ctime': Timestamp(time()).normal
+            'ctime': Timestamp().normal
         })
         pipeline.execute()
         self.release_lock('account:%s' % account_id, lock)
@@ -394,11 +394,11 @@ class AccountBackend(RedisConnection):
         if mtime is None:
             mtime = '0'
         else:
-            mtime = Timestamp(float(mtime)).normal
+            mtime = Timestamp(mtime).normal
         if dtime is None:
             dtime = '0'
         else:
-            dtime = Timestamp(float(dtime)).normal
+            dtime = Timestamp(dtime).normal
         if object_count is None:
             object_count = 0
         if bytes_used is None:
@@ -413,7 +413,7 @@ class AccountBackend(RedisConnection):
                 ("account:%s" % (account_id))]
         args = [name, mtime, dtime, object_count, bytes_used,
                 damaged_objects, missing_chunks,
-                str(autocreate_account), Timestamp(time()).normal, EXPIRE_TIME,
+                str(autocreate_account), Timestamp().normal, EXPIRE_TIME,
                 str(autocreate_container)]
         try:
             self.script_update_container(keys=keys, args=args, client=conn)

--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-from time import time
 from urlparse import urlparse
 
 import re

--- a/oio/blob/converter.py
+++ b/oio/blob/converter.py
@@ -54,8 +54,8 @@ class BlobConverter(object):
         self.volume = volume
         self.namespace, self.volume_id = check_volume(self.volume)
         # cache
-        self.name_by_cid = CacheDict(size=262144)
-        self.content_id_by_name = CacheDict(size=262144)
+        self.name_by_cid = CacheDict()
+        self.content_id_by_name = CacheDict()
         # client
         self.container_client = ContainerClient(conf, **kwargs)
         self.content_factory = ContentFactory(conf, self.container_client,

--- a/oio/cli/admin/service_decommission.py
+++ b/oio/cli/admin/service_decommission.py
@@ -67,8 +67,7 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
         return parser
 
     def _take_action(self, parsed_args):
-        job_config = {
-            'tasks_per_second': parsed_args.chunks_per_second,
+        job_params = {
             'rdir_fetch_limit': parsed_args.rdir_fetch_limit,
             'rdir_timeout': parsed_args.rdir_timeout,
             'rawx_timeout': parsed_args.rawx_timeout,
@@ -76,9 +75,13 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
             'max_chunk_size': parsed_args.max_chunk_size,
             'excluded_rawx': parsed_args.excluded_rawx
         }
+        job_config = {
+            'tasks_per_second': parsed_args.chunks_per_second,
+            'params': job_params
+        }
 
         for service_id in parsed_args.services:
-            job_config['service_id'] = service_id
+            job_params['service_id'] = service_id
             try:
                 job_info = self.xcute.job_create(
                     RawxDecommissionJob.JOB_TYPE, job_config=job_config)

--- a/oio/cli/admin/service_decommission.py
+++ b/oio/cli/admin/service_decommission.py
@@ -68,7 +68,7 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
 
     def _take_action(self, parsed_args):
         job_config = {
-            'chunks_per_second': parsed_args.chunks_per_second,
+            'tasks_per_second': parsed_args.chunks_per_second,
             'rdir_fetch_limit': parsed_args.rdir_fetch_limit,
             'rdir_timeout': parsed_args.rdir_timeout,
             'rawx_timeout': parsed_args.rawx_timeout,

--- a/oio/cli/admin/service_decommission.py
+++ b/oio/cli/admin/service_decommission.py
@@ -37,6 +37,11 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
         MultipleServicesCommandMixin.patch_parser(self, parser)
 
         parser.add_argument(
+            '--chunks-per-second', type=int,
+            help='Max chunks per second. '
+                 '(default=%d)'
+                 % RawxDecommissionJob.DEFAULT_TASKS_PER_SECOND)
+        parser.add_argument(
             '--rdir-fetch-limit', type=int,
             help='Maximum number of entries returned in each rdir response. '
                  '(default=%d)'
@@ -63,6 +68,7 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
 
     def _take_action(self, parsed_args):
         job_config = {
+            'chunks_per_second': parsed_args.chunks_per_second,
             'rdir_fetch_limit': parsed_args.rdir_fetch_limit,
             'rdir_timeout': parsed_args.rdir_timeout,
             'rawx_timeout': parsed_args.rawx_timeout,

--- a/oio/cli/admin/service_decommission.py
+++ b/oio/cli/admin/service_decommission.py
@@ -62,7 +62,7 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
         return parser
 
     def _take_action(self, parsed_args):
-        job_params = {
+        job_config = {
             'rdir_fetch_limit': parsed_args.rdir_fetch_limit,
             'rdir_timeout': parsed_args.rdir_timeout,
             'rawx_timeout': parsed_args.rawx_timeout,
@@ -72,11 +72,11 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
         }
 
         for service_id in parsed_args.services:
-            job_params['service_id'] = service_id
+            job_config['service_id'] = service_id
             try:
                 job_info_ = self.xcute.job_create(
-                    RawxDecommissionJob.JOB_TYPE, job_params=job_params)
-                res = job_info_['job.id']
+                    RawxDecommissionJob.JOB_TYPE, job_config=job_config)
+                res = job_info_['id']
             except Exception as exc:
                 res = str(exc)
             yield (service_id, res)

--- a/oio/cli/admin/service_decommission.py
+++ b/oio/cli/admin/service_decommission.py
@@ -80,9 +80,9 @@ class RawxDecommission(MultipleServicesCommandMixin, lister.Lister):
         for service_id in parsed_args.services:
             job_config['service_id'] = service_id
             try:
-                job_info_ = self.xcute.job_create(
+                job_info = self.xcute.job_create(
                     RawxDecommissionJob.JOB_TYPE, job_config=job_config)
-                res = job_info_['id']
+                res = job_info['id']
             except Exception as exc:
                 res = str(exc)
             yield (service_id, res)

--- a/oio/cli/admin/xcute.py
+++ b/oio/cli/admin/xcute.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from oio.cli import Command, Lister, ShowOne
+from oio.cli import Lister, ShowOne
 
 
 class XcuteCommand(object):
@@ -37,8 +37,9 @@ class XcuteJobList(XcuteCommand, Lister):
     def _take_action(self, parsed_args):
         jobs = self.xcute.job_list()
         for job_info in jobs:
-            yield (job_info['job.id'], job_info['job.status'], job_info['job.type'],
-                   job_info['job.ctime'], job_info['job.mtime'])
+            yield (job_info['job.id'], job_info['job.status'],
+                   job_info['job.type'], job_info['job.ctime'],
+                   job_info['job.mtime'])
 
     def take_action(self, parsed_args):
         self.logger.debug('take_action(%s)', parsed_args)

--- a/oio/cli/admin/xcute.py
+++ b/oio/cli/admin/xcute.py
@@ -37,8 +37,8 @@ class XcuteJobList(XcuteCommand, Lister):
     def _take_action(self, parsed_args):
         jobs = self.xcute.job_list()
         for job_info in jobs:
-            yield (job_info['job_id'], job_info['status'], job_info['job_type'],
-                   job_info['ctime'], float(job_info['mtime']))
+            yield (job_info['job.id'], job_info['job.status'], job_info['job.type'],
+                   job_info['job.ctime'], job_info['job.mtime'])
 
     def take_action(self, parsed_args):
         self.logger.debug('take_action(%s)', parsed_args)

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -16,7 +16,6 @@
 """Container-related commands"""
 
 from logging import getLogger
-from time import time
 
 from oio.cli import Command, Lister, ShowOne
 from oio.common.timestamp import Timestamp

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -734,7 +734,7 @@ class SnapshotContainer(ContainerCommandMixin, Lister):
         deadline = timeout_to_deadline(parsed_args.timeout)
         dst_account = parsed_args.dst_account or account
         dst_container = (parsed_args.dst_container or
-                         (container + "-" + Timestamp(time()).normal))
+                         (container + "-" + Timestamp().normal))
         batch_size = parsed_args.chunk_batch_size
 
         self.app.client_manager.storage.container_snapshot(

--- a/oio/common/green.py
+++ b/oio/common/green.py
@@ -79,7 +79,7 @@ def ratelimit(run_time, max_rate, increment=1, rate_buffer=5, time_time=None):
     time_per_request = clock_accuracy * (float(increment) / max_rate)
     if now - run_time > rate_buffer * clock_accuracy:
         run_time = now
-    elif run_time - now > time_per_request:
+    elif run_time - now > 0:
         sleep((run_time - now) / clock_accuracy)
     return run_time + time_per_request
 

--- a/oio/common/timestamp.py
+++ b/oio/common/timestamp.py
@@ -13,18 +13,21 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-from datetime import datetime
+from oio.common.green import datetime, time
 
 
 TIMESTAMP_FORMAT = "%016.05f"
 
 
 class Timestamp(object):
-    def __init__(self, timestamp):
-        self.timestamp = float(timestamp)
-        # More than year 1000000?! We got microseconds.
-        if self.timestamp > 31494784780800.0:
-            self.timestamp /= 1000000.0
+    def __init__(self, timestamp=None):
+        if timestamp is None:
+            self.timestamp = time.time()
+        else:
+            self.timestamp = float(timestamp)
+            # More than year 1000000?! We got microseconds.
+            if self.timestamp > 31494784780800.0:
+                self.timestamp /= 1000000.0
 
     def __repr__(self):
         return self.normal

--- a/oio/common/utils.py
+++ b/oio/common/utils.py
@@ -17,7 +17,6 @@ import os
 import grp
 import pwd
 import fcntl
-import time
 from collections import OrderedDict
 from hashlib import sha256
 from random import getrandbits
@@ -118,35 +117,17 @@ class CacheDict(OrderedDict):
     OrderedDict subclass which holds a limited number of items.
     """
 
-    def __init__(self, size=None, timeout=None):
+    def __init__(self, size=262144):
         super(CacheDict, self).__init__()
         self.size = size
-        self.timeout = timeout
 
     def __setitem__(self, key, value):
-        deadline = None
-        if self.timeout:
-            deadline = time.time() + self.timeout
-        super(CacheDict, self).__setitem__(key, (value, deadline))
-        if self.size:
-            while len(self) > self.size:
-                try:
-                    self.popitem(last=False)
-                except KeyError:
-                    # Maybe remove with an other thread in the same time
-                    # or with the timeout
-                    pass
+        super(CacheDict, self).__setitem__(key, value)
+        self._check_size()
 
-    def __getitem__(self, key):
-        value, deadline = super(CacheDict, self).__getitem__(key)
-        if deadline and time.time() > deadline:
-            try:
-                self.__delitem__(key)
-            except KeyError:
-                # Maybe remove with an other thread in the same time
-                pass
-            raise KeyError(key)
-        return value
+    def _check_size(self):
+        while len(self) > self.size:
+            self.popitem(last=False)
 
 
 class RingBuffer(list):

--- a/oio/crawler/integrity.py
+++ b/oio/crawler/integrity.py
@@ -247,7 +247,7 @@ class Checker(object):
         self.object_exceptions = 0
         self.chunk_exceptions = 0
 
-        self.list_cache = CacheDict(size=cache_size)
+        self.list_cache = CacheDict(cache_size)
         self.running_tasks = {}
         self.running_lock = Semaphore(1)
         self.result_queue = LightQueue(concurrency)
@@ -959,7 +959,7 @@ class Checker(object):
         for result in self.fetch_results():
             self.log_result(result)
             yield result
-        self.list_cache = CacheDict(size=self.list_cache.size)
+        self.list_cache = CacheDict(self.list_cache.size)
 
     def stop(self):
         self.logger.info("Stopping")

--- a/oio/xcute/client.py
+++ b/oio/xcute/client.py
@@ -109,10 +109,10 @@ class XcuteClient(HttpApi):
         _, data = self.xcute_request('GET', '/jobs', params=params)
         return data
 
-    def job_create(self, job_type, job_params=None):
+    def job_create(self, job_type, job_config=None):
         job_info = {
             'type': job_type,
-            'params': job_params or dict()
+            'config': job_config
         }
         _, data = self.xcute_request('POST', '/jobs', json=job_info)
         return data

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -20,8 +20,7 @@ import random
 
 from oio.common.easy_value import true_value
 from oio.common.exceptions import Forbidden, NotFound
-from oio.common.green import datetime, time
-from oio.common.json import json
+from oio.common.green import datetime
 from oio.common.redis_conn import RedisConnection
 from oio.common.timestamp import Timestamp
 
@@ -45,18 +44,24 @@ class XcuteBackend(RedisConnection):
     DEFAULT_LIMIT = 1000
 
     _lua_errors = {
-        'job_exists': (Forbidden,
-                       'The job already exists'),
-        'no_job': (NotFound,
-                   'The job does\'nt exist'),
-        'lock_exists': (Forbidden,
-                        'The lock already exists'),
-        'must_be_running': (Forbidden,
-                            'The job must be running'),
-        'must_be_paused': (Forbidden,
-                           'The job must be paused'),
-        'must_be_waiting_paused_finished': (Forbidden,
-                                            'The job must be waiting or paused or finished')
+        'job_exists': (
+            Forbidden,
+            'The job already exists'),
+        'no_job': (
+            NotFound,
+            'The job does\'nt exist'),
+        'lock_exists': (
+            Forbidden,
+            'The lock already exists'),
+        'must_be_running': (
+            Forbidden,
+            'The job must be running'),
+        'must_be_paused': (
+            Forbidden,
+            'The job must be paused'),
+        'must_be_waiting_paused_finished': (
+            Forbidden,
+            'The job must be waiting or paused or finished')
         }
 
     key_job_conf = 'xcute:job:config:%s'
@@ -112,7 +117,8 @@ class XcuteBackend(RedisConnection):
                    job_id);
     """ + _lua_update_mtime + """
         local job_info = redis.call('HGETALL', 'xcute:job:info:' .. job_id);
-        local job_config = redis.call('HGETALL', 'xcute:job:config:' .. job_id);
+        local job_config = redis.call(
+            'HGETALL', 'xcute:job:config:' .. job_id);
         return {job_id, job_info, job_config};
     """
 
@@ -299,8 +305,9 @@ class XcuteBackend(RedisConnection):
                         'job.status', 'PAUSED');
                 local orchestrator_id = redis.call(
                     'HGET', 'xcute:job:info:' .. job_id, 'orchestrator.id');
-                redis.call('SREM', 'xcute:orchestrator:jobs:' .. orchestrator_id,
-                        job_id);
+                redis.call(
+                    'SREM', 'xcute:orchestrator:jobs:' .. orchestrator_id,
+                    job_id);
                 stopped = true;
             end;
         end;
@@ -347,7 +354,8 @@ class XcuteBackend(RedisConnection):
         if all_tasks_sent == 'True' and status ~= 'FINISHED' then
             local total_tasks_sent = redis.call(
                 'HGET', 'xcute:job:info:' .. job_id, 'tasks.sent');
-            if tonumber(total_tasks_processed) >= tonumber(total_tasks_sent) then
+            if tonumber(total_tasks_processed) >= tonumber(
+                    total_tasks_sent) then
                 redis.call('HSET', 'xcute:job:info:' .. job_id,
                            'job.status', 'FINISHED');
                 finished = true;
@@ -526,7 +534,8 @@ class XcuteBackend(RedisConnection):
     def update_tasks_sent(self, job_id, task_ids, total_tasks,
                           all_tasks_sent=False):
         return self.script_update_tasks_sent(
-            keys=[self._get_timestamp(), job_id, total_tasks, str(all_tasks_sent)],
+            keys=[self._get_timestamp(), job_id, total_tasks,
+                  str(all_tasks_sent)],
             args=task_ids, client=self.conn)
 
     @handle_redis_exceptions
@@ -543,7 +552,8 @@ class XcuteBackend(RedisConnection):
             for key, value in task_results.items():
                 counters['results.' + key] = value
         return self.script_update_tasks_processed(
-            keys=[self._get_timestamp(), job_id] + self._dict_to_lua_array(counters),
+            keys=[self._get_timestamp(),
+                  job_id] + self._dict_to_lua_array(counters),
             args=task_ids,
             client=self.conn)
 
@@ -592,7 +602,8 @@ class XcuteBackend(RedisConnection):
         job_info = marshalled_job_info.copy()
 
         all_sent = true_value(job_info['tasks.all_sent'])
-        total = int(job_info['tasks.total']) if 'tasks.total' in job_info else None
+        total = int(job_info['tasks.total']) if 'tasks.total' \
+            in job_info else None
 
         job_info['tasks.sent'] = int(job_info['tasks.sent'])
         job_info['tasks.all_sent'] = all_sent

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -516,7 +516,7 @@ class XcuteBackend(RedisConnection):
                                task_errors, task_results):
         counters = dict()
         if task_errors:
-            counters['errors.total'] = len(task_errors)
+            counters['errors.total'] = task_errors
         if task_results:
             for key, value in task_results.items():
                 counters['results.' + key] = value

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -255,9 +255,8 @@ class XcuteBackend(RedisConnection):
             return redis.error_reply('no_job');
         end;
 
-        local total_tasks_sent = redis.call(
-            'HINCRBY', 'xcute:job:info:' .. job_id,
-            'total', total_tasks);
+        redis.call('HSET', 'xcute:job:info:' .. job_id,
+                   'total', total_tasks);
 
         local total_tasks_sent = redis.call(
             'HINCRBY', 'xcute:job:info:' .. job_id,
@@ -373,6 +372,7 @@ class XcuteBackend(RedisConnection):
         redis.call('ZREM', 'xcute:job:ids', job_id);
         redis.call('DEL', 'xcute:job:info:' .. job_id);
         redis.call('DEL', 'xcute:job:config:' .. job_id);
+        redis.call('DEL', 'xcute:tasks:running:' .. job_id);
         """
 
     def __init__(self, conf):

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -447,7 +447,7 @@ class XcuteBackend(RedisConnection):
 
         self.script_create(
             keys=[job_id, job_type],
-            args=self._dict_to_lua_array(self._marshal_job_conf(job_config)),
+            args=self._dict_to_lua_array(job_config),
             client=self.conn)
         return job_id
 
@@ -471,7 +471,7 @@ class XcuteBackend(RedisConnection):
         job_config_infos = pipeline.execute()
 
         return (
-            (job_id, self._unmarshal_job_conf(job_conf), self._unmarshal_job_info(job_info))
+            (job_id, job_conf, self._unmarshal_job_info(job_info))
             for job_conf, job_info in zip(*([iter(job_config_infos)] * 2))
         )
 
@@ -484,8 +484,7 @@ class XcuteBackend(RedisConnection):
         job_id, job_info, job_config = next_job
         job_info = self._unmarshal_job_info(
             self._lua_array_to_dict(job_info))
-        job_config = self._unmarshal_job_conf(
-            self._lua_array_to_dict(job_config))
+        job_config = self._lua_array_to_dict(job_config)
         return (job_id, job_info['job_type'], job_info.get('last_sent'),
                 job_config)
 
@@ -531,9 +530,7 @@ class XcuteBackend(RedisConnection):
         self.script_delete(keys=[job_id])
 
     def get_job_conf(self, job_id):
-        job_conf = self._get_job_conf(job_id, client=self.conn)
-
-        return self._unmarshal_job_conf(job_conf)
+        return self._get_job_conf(job_id, client=self.conn)
 
     def get_job_info(self, job_id):
         job_info = self._get_job_info(job_id, client=self.conn)
@@ -557,25 +554,7 @@ class XcuteBackend(RedisConnection):
         return client.hmset(self.key_job_info % job_id, marshalled_updates)
 
     def _update_job_conf(self, job_id, updates, client):
-        marshalled_updates = self._marshal_job_conf(updates)
-        return client.hmset(self.key_job_conf % job_id, marshalled_updates)
-
-    @staticmethod
-    def _marshal_job_conf(job_conf):
-        marshalled_job_conf = job_conf.copy()
-
-        if 'params' in job_conf:
-            marshalled_job_conf['params'] = json.dumps(job_conf['params'])
-
-        return marshalled_job_conf
-
-    @staticmethod
-    def _unmarshal_job_conf(marshalled_job_conf):
-        job_conf = marshalled_job_conf.copy()
-
-        job_conf['params'] = json.loads(job_conf['params'])
-
-        return job_conf
+        return client.hmset(self.key_job_conf % job_id, updates)
 
     @staticmethod
     def _marshal_job_info(job_info):

--- a/oio/xcute/common/exceptions.py
+++ b/oio/xcute/common/exceptions.py
@@ -1,2 +1,18 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+
 class UnknownJobTypeException(Exception):
     message = 'Unknown job type'

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -21,6 +21,9 @@ class XcuteJob(object):
 
     JOB_TYPE = None
 
+    DEFAULT_TASKS_BATCH_SIZE = 32
+    MAX_TASKS_BATCH_SIZE = 512
+
     def __init__(self, conf, logger=None):
         self.conf = conf
         self.logger = logger or get_logger(self.conf)
@@ -32,6 +35,16 @@ class XcuteJob(object):
             Also return the lock id if there is one
         """
         sanitized_job_config = dict()
+
+        self.tasks_batch_size = int_value(
+            job_config.get('tasks_batch_size'),
+            self.DEFAULT_TASKS_BATCH_SIZE)
+        if self.tasks_batch_size < 1:
+            raise ValueError('Tasks batch size should positive')
+        if self.tasks_batch_size > self.MAX_TASKS_BATCH_SIZE:
+            raise ValueError('Tasks batch size should less than %d' %
+                             self.MAX_TASKS_BATCH_SIZE)
+        sanitized_job_config['tasks_batch_size'] = self.tasks_batch_size
 
         return sanitized_job_config, None
 

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-import math
-
 from oio.common.easy_value import int_value
 from oio.common.logger import get_logger
 

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+import math
+
 from oio.common.easy_value import int_value
 from oio.common.logger import get_logger
 
@@ -21,7 +23,7 @@ class XcuteJob(object):
 
     JOB_TYPE = None
 
-    DEFAULT_TASKS_BATCH_SIZE = 32
+    DEFAULT_TASKS_PER_SECOND = 32
     MAX_TASKS_BATCH_SIZE = 512
 
     def __init__(self, conf, logger=None):
@@ -36,12 +38,22 @@ class XcuteJob(object):
         """
         sanitized_job_config = dict()
 
+        self.tasks_per_second = int_value(
+            job_config.get('tasks_per_second'),
+            self.DEFAULT_TASKS_PER_SECOND)
+        sanitized_job_config['tasks_per_second'] = self.tasks_per_second
+
         self.tasks_batch_size = int_value(
-            job_config.get('tasks_batch_size'),
-            self.DEFAULT_TASKS_BATCH_SIZE)
-        if self.tasks_batch_size < 1:
+            job_config.get('tasks_batch_size'), None)
+        if self.tasks_batch_size is None:
+            if self.tasks_per_second > 0:
+                self.tasks_batch_size = min(
+                    self.tasks_per_second, self.MAX_TASKS_BATCH_SIZE)
+            else:
+                self.tasks_batch_size = self.MAX_TASKS_BATCH_SIZE
+        elif self.tasks_batch_size < 1:
             raise ValueError('Tasks batch size should positive')
-        if self.tasks_batch_size > self.MAX_TASKS_BATCH_SIZE:
+        elif self.tasks_batch_size > self.MAX_TASKS_BATCH_SIZE:
             raise ValueError('Tasks batch size should less than %d' %
                              self.MAX_TASKS_BATCH_SIZE)
         sanitized_job_config['tasks_batch_size'] = self.tasks_batch_size

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -16,20 +16,13 @@
 from oio.common.logger import get_logger
 
 
-class XcuteTask(object):
-    """Serialisable wrapper for an task submitted in the xcute hub."""
+class XcuteJob(object):
+
+    JOB_TYPE = None
 
     def __init__(self, conf, logger=None):
         self.conf = conf
         self.logger = logger or get_logger(self.conf)
-
-    def process(self, task_id, task_payload):
-        raise NotImplementedError()
-
-
-class XcuteJob(object):
-
-    JOB_TYPE = None
 
     @staticmethod
     def sanitize_params(params):
@@ -49,4 +42,7 @@ class XcuteJob(object):
             task_id must be a string and can be used as a marker
         """
 
+        raise NotImplementedError()
+
+    def process_task(self, task_id, task_payload):
         raise NotImplementedError()

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+from oio.common.easy_value import int_value
 from oio.common.logger import get_logger
 
 
@@ -24,24 +25,25 @@ class XcuteJob(object):
         self.conf = conf
         self.logger = logger or get_logger(self.conf)
 
-    @staticmethod
-    def sanitize_params(params):
+    def load_config(self, job_config):
         """
-            Validate and sanitize the job parameters
+            Validate and sanitize the job congiguration
             Ex: cast a string as integer, set a default
             Also return the lock id if there is one
         """
+        sanitized_job_config = dict()
 
-        raise NotImplementedError()
+        return sanitized_job_config, None
 
-    @staticmethod
-    def get_tasks(conf, logger, params, marker=None):
+    def get_tasks(self, marker=None):
         """
             Yields the job tasks as
             (TaskClass, task_id, task_payload, total_tasks)
             task_id must be a string and can be used as a marker
         """
+        raise NotImplementedError()
 
+    def init_process_task(self):
         raise NotImplementedError()
 
     def process_task(self, task_id, task_payload):

--- a/oio/xcute/common/manager.py
+++ b/oio/xcute/common/manager.py
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-import random
-
 from oio.xcute.common.backend import XcuteBackend
-from oio.common.green import datetime, time
+from oio.common.green import time
 from oio.common.logger import get_logger
 
 

--- a/oio/xcute/common/worker.py
+++ b/oio/xcute/common/worker.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-import traceback
-
 from collections import Counter
 
 from oio.common.green import ratelimit, sleep

--- a/oio/xcute/common/worker.py
+++ b/oio/xcute/common/worker.py
@@ -33,6 +33,7 @@ class XcuteWorker(object):
         job_id = beanstalkd_job['job_id']
         job_type = beanstalkd_job['job_type']
         job_class = JOB_TYPES[job_type]
+        job_config = beanstalkd_job['job_config']
         task_id = beanstalkd_job['task_id']
         task_payload = beanstalkd_job['task_payload']
         reply_addr = beanstalkd_job['beanstalkd_reply']['addr']
@@ -41,6 +42,8 @@ class XcuteWorker(object):
         task_ok, task_result = (False, None)
         try:
             job = job_class(self.conf, logger=self.logger)
+            job.load_config(job_config)
+            job.init_process_task()
             task_ok, task_result = job.process_task(task_id, task_payload)
             if not task_ok:
                 self.logger.debug('Task was not processed: %s', beanstalkd_job)

--- a/oio/xcute/common/worker.py
+++ b/oio/xcute/common/worker.py
@@ -56,13 +56,16 @@ class XcuteWorker(object):
                 task_errors[type(exc).__name__] += 1
 
         self._reply(reply_addr, reply_tube,
-                    beanstalkd_job, task_results, task_errors)
+                    job_id, tasks.keys(), task_results, task_errors)
 
     def _reply(self, reply_addr, reply_tube,
-               beanstalkd_job, task_results, task_errors):
-        beanstalkd_job['task_results'] = task_results
-        beanstalkd_job['task_errors'] = task_errors
-        reply_payload = json.dumps(beanstalkd_job)
+               job_id, task_ids, task_results, task_errors):
+        reply_payload = json.dumps({
+            'job_id': job_id,
+            'task_ids': task_ids,
+            'task_results': task_results,
+            'task_errors': task_errors
+        })
 
         sender_key = (reply_addr, reply_tube)
         if sender_key not in self.beanstalkd_senders:

--- a/oio/xcute/jobs/__init__.py
+++ b/oio/xcute/jobs/__init__.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
 from .mover import RawxDecommissionJob
 from .tester import TesterJob
 

--- a/oio/xcute/jobs/mover.py
+++ b/oio/xcute/jobs/mover.py
@@ -127,11 +127,11 @@ class RawxDecommissionJob(XcuteJob):
         if chunk_size < self.min_chunk_size:
             self.logger.debug("SKIP %s too small", chunk_url)
             results['skipped'] += 1
-            return True, results
+            return results
         if self.max_chunk_size > 0 and chunk_size > self.max_chunk_size:
             self.logger.debug("SKIP %s too big", chunk_url)
             results['skipped'] += 1
-            return True, results
+            return results
 
         # Start moving the chunk
         try:
@@ -140,9 +140,8 @@ class RawxDecommissionJob(XcuteJob):
                 chunk_id, fake_excluded_chunks=fake_excluded_chunks)
         except (ContentNotFound, OrphanChunk):
             results['orphan'] += 1
-            return True, results
+            return results
 
         results['moved_chunks'] += 1
         results['total_size'] += chunk_size
-
-        return True, results
+        return results

--- a/oio/xcute/jobs/mover.py
+++ b/oio/xcute/jobs/mover.py
@@ -35,9 +35,16 @@ class RawxDecommissionJob(XcuteJob):
     DEFAULT_MAX_CHUNK_SIZE = 0
 
     def load_config(self, job_config):
+        # common configuration
+        job_config = job_config.copy()
+        job_config['tasks_per_second'] = job_config.pop(
+            'chunks_per_second', None)
         sanitized_job_config, _ = super(
             RawxDecommissionJob, self).load_config(job_config)
+        sanitized_job_config['chunks_per_second'] = sanitized_job_config.pop(
+            'tasks_per_second')
 
+        # specific configuration
         self.service_id = job_config.get('service_id')
         if not self.service_id:
             raise ValueError('Missing service ID')

--- a/oio/xcute/jobs/mover.py
+++ b/oio/xcute/jobs/mover.py
@@ -14,7 +14,6 @@
 # License along with this library.
 
 from collections import Counter
-from itertools import izip_longest
 
 from oio.blob.client import BlobClient
 from oio.common.easy_value import float_value, int_value
@@ -22,7 +21,7 @@ from oio.common.exceptions import ContentNotFound, OrphanChunk
 from oio.conscience.client import ConscienceClient
 from oio.content.factory import ContentFactory
 from oio.rdir.client import RdirClient
-from oio.xcute.common.job import XcuteJob   
+from oio.xcute.common.job import XcuteJob
 
 
 class RawxDecommissionJob(XcuteJob):
@@ -114,7 +113,8 @@ class RawxDecommissionJob(XcuteJob):
             chunk['size'] = 1
             chunk['score'] = 1
             chunk['url'] = 'http://{}/{}'.format(service_id, fake_chunk_id)
-            chunk['real_url'] = 'http://{}/{}'.format(service_addr, fake_chunk_id)
+            chunk['real_url'] = 'http://{}/{}'.format(service_addr,
+                                                      fake_chunk_id)
             fake_excluded_chunks.append(chunk)
         return fake_excluded_chunks
 
@@ -125,7 +125,8 @@ class RawxDecommissionJob(XcuteJob):
         results = Counter()
 
         chunk_url = 'http://{}/{}'.format(self.service_id, chunk_id)
-        meta = self.blob_client.chunk_head(chunk_url, timeout=self.rawx_timeout)
+        meta = self.blob_client.chunk_head(chunk_url,
+                                           timeout=self.rawx_timeout)
         container_id = meta['container_id']
         content_id = meta['content_id']
         chunk_size = int(meta['chunk_size'])

--- a/oio/xcute/jobs/tester.py
+++ b/oio/xcute/jobs/tester.py
@@ -33,11 +33,11 @@ EXCEPTIONS = [exc.BadRequest,
 
 class TesterTask(XcuteTask):
 
-    def __init__(self, conf, job_config, logger=None):
+    def __init__(self, conf, job_params, logger=None):
         super(TesterTask, self).__init__(
-            conf, job_config, logger=logger)
+            conf, job_params, logger=logger)
 
-        self.error_percentage = int(job_config['error_percentage'])
+        self.error_percentage = job_params['error_percentage']
 
     def process(self, task_id, task_payload):
         first = task_payload['first']
@@ -63,31 +63,32 @@ class TesterJob(XcuteJob):
     DEFAULT_END = 5
     DEFAULT_ERROR_PERCENTAGE = 0
 
-    def sanitize_params(self, job_config):
-        sanitized_job_config, _ = super(
-            TesterJob, self).sanitize_params(job_config)
+    def sanitize_params(self, job_params):
+        sanitized_job_params, _ = super(
+            TesterJob, self).sanitize_params(job_params)
 
-        self.start = int_value(job_config.get('start'), self.DEFAULT_START)
-        sanitized_job_config['start'] = self.start
+        sanitized_job_params['start'] = int_value(
+            job_params.get('start'), self.DEFAULT_START)
 
-        self.end = int_value(job_config.get('end'), self.DEFAULT_END)
-        sanitized_job_config['end'] = self.end
+        sanitized_job_params['end'] = int_value(
+            job_params.get('end'), self.DEFAULT_END)
 
-        sanitized_job_config['error_percentage'] = int_value(
-            job_config.get('error_percentage'),
+        sanitized_job_params['error_percentage'] = int_value(
+            job_params.get('error_percentage'),
             self.DEFAULT_ERROR_PERCENTAGE)
 
-        return sanitized_job_config, job_config.get('lock')
+        return sanitized_job_params, job_params.get('lock')
 
-    def get_tasks(self, marker=None):
-        start = self.start
+    def get_tasks(self, job_params, marker=None):
+        start = job_params['start']
+        end = job_params['end']
 
-        total_tasks = self.end - start
+        total_tasks = end - start
 
         if marker:
             start = int(marker) + 1
 
-        for i in range(start, self.end):
+        for i in range(start, end):
             if i < 2:
                 task_payload = {'first': True, 'msg': 'coucou-%d' % i}
             else:

--- a/oio/xcute/jobs/tester.py
+++ b/oio/xcute/jobs/tester.py
@@ -13,21 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-from oio.xcute.common.job import XcuteJob, XcuteTask
-
-
-class TesterFirstTask(XcuteTask):
-
-    def process(self, task_id, payload):
-        self.logger.info('First task: %s', payload['msg'])
-        return True, 1
-
-
-class TesterSecondTask(XcuteTask):
-
-    def process(self, task_id, payload):
-        self.logger.info('Second task: %s', payload['msg'])
-        return True, None
+from oio.xcute.common.job import XcuteJob
 
 
 class TesterJob(XcuteJob):
@@ -54,12 +40,20 @@ class TesterJob(XcuteJob):
 
         for i in range(start, end):
             if i < 2:
-                task_class = TesterFirstTask
-                task_payload = {'msg': 'coucou-%d' % i}
+                task_payload = {'first': True, 'msg': 'coucou-%d' % i}
             else:
-                task_class = TesterSecondTask
-                task_payload = {'msg': 'hibou-%d' % i}
+                task_payload = {'first': False, 'msg': 'hibou-%d' % i}
 
             task_id = str(i)
 
-            yield (task_class, task_id, task_payload, total_tasks)
+            yield (task_id, task_payload, total_tasks)
+
+    def process_task(self, task_id, task_payload):
+        first = task_payload['first']
+        msg = task_payload['msg']
+
+        if first:
+            self.logger.info('First task: %s', msg)
+        else:
+            self.logger.info('Second task: %s', msg)
+        return True, None

--- a/oio/xcute/jobs/tester.py
+++ b/oio/xcute/jobs/tester.py
@@ -85,6 +85,7 @@ class TesterJob(XcuteJob):
         else:
             self.logger.info('Second task: %s', msg)
 
-        if self.error_percentage and random.randrange(100) < self.error_percentage:
+        if self.error_percentage \
+                and random.randrange(100) < self.error_percentage:
             exc_class = random.choice(EXCEPTIONS)
             raise exc_class()

--- a/oio/xcute/orchestrator.py
+++ b/oio/xcute/orchestrator.py
@@ -149,9 +149,8 @@ class XcuteOrchestrator(object):
         if job_info['all_sent']:
             return
 
-        job_type = job_info['job_type']
-        last_task_id = None
-        last_task_id = job_info.get('last_sent')
+        job_type = job_info['job.type']
+        last_task_id = job_info.get('job.last_sent')
         job_class = JOB_TYPES[job_type]
         job = job_class(self.conf, logger=self.logger)
         job.load_config(job_config)

--- a/oio/xcute/orchestrator.py
+++ b/oio/xcute/orchestrator.py
@@ -339,16 +339,15 @@ class XcuteOrchestrator(object):
         reply = json.loads(encoded_reply)
 
         job_id = reply['job_id']
-        tasks = reply['tasks']
+        task_ids = reply['task_ids']
         task_results = reply['task_results']
         task_errors = reply['task_errors']
 
-        self.logger.debug('Task processed (job_id=%s): %s', job_id, tasks)
+        self.logger.debug('Tasks processed (job_id=%s): %s', job_id, task_ids)
 
         try:
-
             finished = self.manager.update_tasks_processed(
-                job_id, tasks.keys(), task_errors, task_results)
+                job_id, task_ids, task_errors, task_results)
             if finished:
                 self.logger.info('Job %s is finished', job_id)
         except Exception:

--- a/oio/xcute/orchestrator.py
+++ b/oio/xcute/orchestrator.py
@@ -135,7 +135,7 @@ class XcuteOrchestrator(object):
 
         job_class = JOB_TYPES[job_type]
         job = job_class(self.conf, logger=self.logger)
-        job.load_config(job_config)
+        job.sanitize_params(job_config)
         job_tasks = job.get_tasks(marker=last_task_id)
 
         self.handle_job(job_id, job_type, job_config, job, job_tasks)
@@ -153,7 +153,7 @@ class XcuteOrchestrator(object):
         last_task_id = job_info.get('job.last_sent')
         job_class = JOB_TYPES[job_type]
         job = job_class(self.conf, logger=self.logger)
-        job.load_config(job_config)
+        job.sanitize_params(job_config)
         job_tasks = job.get_tasks(marker=last_task_id)
 
         self.manager.start_job(job_id, job_config)

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -61,7 +61,7 @@ class Xcute(WerkzeugApp):
             job = job_class(self.conf, logger=self.logger)
             job_config = data.get('config')
             # TODO: use lock
-            job_config, lock = job.sanitize_params(job_config)
+            job_config, lock = job.sanitize_config(job_config)
 
             job_id = self.manager.create(job_type, job_config)
             return Response(json.dumps({'id': job_id}), status=202)

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from werkzeug.exceptions import BadRequest as HTTPBadRequest
 from werkzeug.exceptions import NotFound as HTTPNotFound
 from werkzeug.routing import Map, Rule, Submount

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -3,7 +3,7 @@ from werkzeug.exceptions import NotFound as HTTPNotFound
 from werkzeug.routing import Map, Rule, Submount
 from werkzeug.wrappers import Response
 
-from oio.common.easy_value import int_value, true_value
+from oio.common.easy_value import int_value
 from oio.common.exceptions import NotFound
 from oio.common.json import json
 from oio.common.logger import get_logger

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -61,7 +61,7 @@ class Xcute(WerkzeugApp):
             job = job_class(self.conf, logger=self.logger)
             job_config = data.get('config')
             # TODO: use lock
-            job_config, lock = job.load_config(job_config)
+            job_config, lock = job.sanitize_params(job_config)
 
             job_id = self.manager.create(job_type, job_config)
             return Response(json.dumps({'id': job_id}), status=202)

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -58,16 +58,13 @@ class Xcute(WerkzeugApp):
             if job_class is None:
                 return HTTPBadRequest(UnknownJobTypeException.message)
 
-            job_config = data.get('conf', {})
-            job_params = data.get('params', {})
-
+            job = job_class(self.conf, logger=self.logger)
+            job_config = data.get('config')
             # TODO: use lock
-            sanitized_params, lock = job_class.sanitize_params(job_params)
-            job_config['params'] = sanitized_params
+            job_config, lock = job.load_config(job_config)
 
             job_id = self.manager.create(job_type, job_config)
-
-            return Response(json.dumps({'job.id': job_id}), status=202)
+            return Response(json.dumps({'id': job_id}), status=202)
 
     def on_job(self, req, job_id):
         if req.method == 'GET':

--- a/tests/functional/account/test_backend.py
+++ b/tests/functional/account/test_backend.py
@@ -102,7 +102,7 @@ class TestAccountBackend(BaseTestCase):
 
         # first container
         self.backend.update_container(
-            account_id, 'c1', Timestamp(time()).normal, 0, 1, 1, 1, 1)
+            account_id, 'c1', Timestamp().normal, 0, 1, 1, 1, 1)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
@@ -113,7 +113,7 @@ class TestAccountBackend(BaseTestCase):
         # second container
         sleep(.00001)
         self.backend.update_container(
-            account_id, 'c2', Timestamp(time()).normal, 0, 0, 0, 0, 0)
+            account_id, 'c2', Timestamp().normal, 0, 0, 0, 0, 0)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 1)
@@ -124,7 +124,7 @@ class TestAccountBackend(BaseTestCase):
         # update second container
         sleep(.00001)
         self.backend.update_container(
-            account_id, 'c2', Timestamp(time()).normal, 0, 1, 1, 1, 2)
+            account_id, 'c2', Timestamp().normal, 0, 1, 1, 1, 2)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 2)
         self.assertEqual(info['objects'], 2)
@@ -135,7 +135,7 @@ class TestAccountBackend(BaseTestCase):
         # delete first container
         sleep(.00001)
         self.backend.update_container(
-            account_id, 'c1', 0, Timestamp(time()).normal, 0, 0, 0, 0)
+            account_id, 'c1', 0, Timestamp().normal, 0, 0, 0, 0)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 1)
@@ -146,7 +146,7 @@ class TestAccountBackend(BaseTestCase):
         # delete second container
         sleep(.00001)
         self.backend.update_container(
-            account_id, 'c2', 0, Timestamp(time()).normal, 0, 0, 0, 0)
+            account_id, 'c2', 0, Timestamp().normal, 0, 0, 0, 0)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 0)
         self.assertEqual(info['objects'], 0)
@@ -160,12 +160,12 @@ class TestAccountBackend(BaseTestCase):
 
         # Container create event, sent immediately after creation
         self.backend.update_container(
-            account_id, 'c1', Timestamp(time()).normal,
+            account_id, 'c1', Timestamp().normal,
             None, None, None, None, None)
 
         # Container update event
         self.backend.update_container(
-            account_id, 'c1', Timestamp(time()).normal, None, 3, 30, 7, 5)
+            account_id, 'c1', Timestamp().normal, None, 3, 30, 7, 5)
         info = self.backend.info_account(account_id)
         self.assertEqual(info['containers'], 1)
         self.assertEqual(info['objects'], 3)
@@ -174,12 +174,12 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(info['missing_chunks'], 5)
 
         # Container is flushed, but the event is deferred
-        flush_timestamp = Timestamp(time()).normal
+        flush_timestamp = Timestamp().normal
 
         sleep(.00001)
         # Container delete event, sent immediately after deletion
         self.backend.update_container(
-            account_id, 'c1', None, Timestamp(time()).normal,
+            account_id, 'c1', None, Timestamp().normal,
             None, None, None, None)
 
         # Deferred container update event (with lower timestamp)
@@ -197,7 +197,7 @@ class TestAccountBackend(BaseTestCase):
         self.assertEqual(self.backend.create_account(account_id), account_id)
         name = 'c'
         old_mtime = Timestamp(time() - 1).normal
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
 
         # initial container
         self.backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
@@ -207,7 +207,7 @@ class TestAccountBackend(BaseTestCase):
 
         # delete event
         sleep(.00001)
-        dtime = Timestamp(time()).normal
+        dtime = Timestamp().normal
         self.backend.update_container(
             account_id, name, mtime, dtime, 0, 0, 0, 0)
         res = self.backend.conn.zrangebylex(
@@ -240,7 +240,7 @@ class TestAccountBackend(BaseTestCase):
         account_id = 'test'
         self.assertEqual(self.backend.create_account(account_id), account_id)
         name = u'La fête à la maison'
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
 
         # create container
         self.backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
@@ -255,7 +255,7 @@ class TestAccountBackend(BaseTestCase):
 
         # delete container
         sleep(.00001)
-        dtime = Timestamp(time()).normal
+        dtime = Timestamp().normal
         self.backend.update_container(account_id, name, 0, dtime, 0, 0, 0, 0)
         res = self.backend.conn.zrangebylex(
             'containers:%s' % account_id, '-', '+')
@@ -279,7 +279,7 @@ class TestAccountBackend(BaseTestCase):
 
         # initial container
         name = '"{<container \'&\' name>}"'
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
         self.backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.backend.conn.zrangebylex(
@@ -303,7 +303,7 @@ class TestAccountBackend(BaseTestCase):
 
         # New event
         sleep(.00001)
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
         self.backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
 
         res = self.backend.conn.zrangebylex(
@@ -339,7 +339,7 @@ class TestAccountBackend(BaseTestCase):
 
         # New delete event
         sleep(.00001)
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
         self.backend.update_container(account_id, name, 0, mtime, 0, 0, 0, 0)
         res = self.backend.conn.zrangebylex(
             'containers:%s' % account_id, '-', '+')
@@ -349,7 +349,7 @@ class TestAccountBackend(BaseTestCase):
 
         # New event
         sleep(.00001)
-        mtime = Timestamp(time()).normal
+        mtime = Timestamp().normal
         self.backend.update_container(account_id, name, mtime, 0, 0, 0, 0, 0)
         res = self.backend.conn.zrangebylex(
             'containers:%s' % account_id, '-', '+')
@@ -368,17 +368,17 @@ class TestAccountBackend(BaseTestCase):
             for cont2 in xrange(125):
                 name = '%d-%04d' % (cont1, cont2)
                 self.backend.update_container(
-                    account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
+                    account_id, name, Timestamp().normal, 0, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '2-0051-%04d' % cont
             self.backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
+                account_id, name, Timestamp().normal, 0, 0, 0, 0, 0)
 
         for cont in xrange(125):
             name = '3-%04d-0049' % cont
             self.backend.update_container(
-                account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
+                account_id, name, Timestamp().normal, 0, 0, 0, 0, 0)
 
         listing = self.backend.list_containers(
             account_id, marker='', delimiter='', limit=100)
@@ -457,7 +457,7 @@ class TestAccountBackend(BaseTestCase):
 
         name = '3-0049-'
         self.backend.update_container(
-            account_id, name, Timestamp(time()).normal, 0, 0, 0, 0, 0)
+            account_id, name, Timestamp().normal, 0, 0, 0, 0, 0)
         listing = self.backend.list_containers(
             account_id, marker='3-0048', limit=10)
         self.assertEqual(len(listing), 10)
@@ -494,7 +494,7 @@ class TestAccountBackend(BaseTestCase):
         # 10 containers with bytes and objects
         for i in range(10):
             name = "container%d" % i
-            mtime = Timestamp(time()).normal
+            mtime = Timestamp().normal
             nb_bytes = random.randrange(100)
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)
@@ -627,7 +627,7 @@ class TestAccountBackend(BaseTestCase):
         # 10 containers with bytes and objects
         for i in range(10):
             name = "container%d" % i
-            mtime = Timestamp(time()).normal
+            mtime = Timestamp().normal
             nb_bytes = random.randrange(100)
             total_bytes += nb_bytes
             nb_objets = random.randrange(100)

--- a/tests/functional/account/test_server.py
+++ b/tests/functional/account/test_server.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
-from time import time
 import simplejson as json
 
 from werkzeug.test import Client

--- a/tests/functional/account/test_server.py
+++ b/tests/functional/account/test_server.py
@@ -70,7 +70,7 @@ class TestAccountServer(BaseTestCase):
         self.assertEqual(resp.status_code, 204)
 
     def test_account_container_update(self):
-        data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
+        data = {'name': 'foo', 'mtime': Timestamp().normal,
                 'objects': 0, 'bytes': 0}
         data = json.dumps(data)
         resp = self.app.put('/v1.0/account/container/update',
@@ -91,13 +91,13 @@ class TestAccountServer(BaseTestCase):
         self.assertTrue(data['bytes'] >= 0)
 
     def test_account_container_reset(self):
-        data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
+        data = {'name': 'foo', 'mtime': Timestamp().normal,
                 'objects': 12, 'bytes': 42}
         dataj = json.dumps(data)
         resp = self.app.put('/v1.0/account/container/update',
                             data=dataj, query_string={'id': self.account_id})
 
-        data = {'name': 'foo', 'mtime': Timestamp(time()).normal}
+        data = {'name': 'foo', 'mtime': Timestamp().normal}
         dataj = json.dumps(data)
         resp = self.app.put('/v1.0/account/container/reset',
                             data=dataj, query_string={'id': self.account_id})
@@ -119,7 +119,7 @@ class TestAccountServer(BaseTestCase):
         self.fail("No container foo")
 
     def test_account_refresh(self):
-        data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
+        data = {'name': 'foo', 'mtime': Timestamp().normal,
                 'objects': 12, 'bytes': 42}
         data = json.dumps(data)
         resp = self.app.put('/v1.0/account/container/update',
@@ -136,7 +136,7 @@ class TestAccountServer(BaseTestCase):
         self.assertEqual(resp["objects"], 12)
 
     def test_account_flush(self):
-        data = {'name': 'foo', 'mtime': Timestamp(time()).normal,
+        data = {'name': 'foo', 'mtime': Timestamp().normal,
                 'objects': 12, 'bytes': 42}
         data = json.dumps(data)
         resp = self.app.put('/v1.0/account/container/update',

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -1023,7 +1023,7 @@ queue_url=${QUEUE_URL}
 """
 
 template_xcute_event_agent_handlers = """
-[handler:xcute.task]
+[handler:xcute.tasks]
 pipeline = xcute
 
 [filter:xcute]


### PR DESCRIPTION
##### SUMMARY

- Stop using pickle
- Send the tasks by batch
- Allow to use ratelimit
- Count the errors by type
- Use python time instead of redis time
- Keep the job in the workers' cache

##### ISSUE TYPE

 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME

- `xcute`

##### SDS VERSION

```
openio 5.2.2
```