### PR TITLE
Fix ec chunk handling by not trying to recover from the stream

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -162,7 +162,8 @@ class ECChunkDownloadHandler(object):
                                 headers, self.connection_timeout,
                                 self.read_timeout, perfdata=self.perfdata,
                                 align=True, logger=self.logger,
-                                resp_by_chunk=self._resp_by_chunk)
+                                resp_by_chunk=self._resp_by_chunk,
+                                is_ec=True)
         return (reader, reader.get_iter())
 
     def get_stream(self):

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -277,6 +277,7 @@ class ChunkReader(object):
             self._resp_by_chunk = dict()
         self.perfdata = perfdata
         self.logger = _kwargs.get('logger', LOGGER)
+        self.is_ec = _kwargs.get('is_ec', False)
 
     @property
     def reqid(self):
@@ -482,13 +483,14 @@ class ChunkReader(object):
                     count += 1
                     buf += data
             except (green.ChunkReadTimeout, IOError) as crto:
-                try:
-                    self.recover(bytes_consumed)
-                except (exc.UnsatisfiableRange, ValueError):
-                    raise
-                except exc.EmptyByteRange:
-                    # we are done already
-                    break
+                if not self.is_ec:
+                    try:
+                        self.recover(bytes_consumed)
+                    except (exc.UnsatisfiableRange, ValueError):
+                        raise
+                    except exc.EmptyByteRange:
+                        # we are done already
+                        break
                 buf = ''
                 # find a new source to perform recovery
                 new_source, new_chunk = self._get_source()


### PR DESCRIPTION


##### SUMMARY
This patch fixes the EC path in case an exception is raised while downloading
a chunk. Previously the code would augment the range. This code is probably
intended for three copy code path but break EC. Set a flag and check it
before trying to 'recover'.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
OIO

##### SDS VERSION
```
all
```


##### ADDITIONAL INFORMATION
You can reproduce by using tc on a rawx with erasure coded segments