### PR TITLE
Improve return code and output of some commands

### DIFF
--- a/oio/zk/client.py
+++ b/oio/zk/client.py
@@ -41,8 +41,9 @@ def get_meta0_paths(zh, ns):
 
 
 class ZkHandle(object):
-    def __init__(self, zh):
+    def __init__(self, zh, cnxstr=None):
         self._zh = zh
+        self.cnxstr = cnxstr
 
     def get(self):
         return self._zh
@@ -58,7 +59,7 @@ def get_connected_handles(cnxstr):
         return
     for shard in cnxstr.split(";"):
         zh = zookeeper.init(shard)
-        yield ZkHandle(zh)
+        yield ZkHandle(zh, cnxstr)
 
 
 def _batch_split(nodes, N):


### PR DESCRIPTION
##### SUMMARY
Make `openio zk` commands return 1 after an error.
And for several C language commands:
- do not print the usage help twice;
- do not print the usage help when parameters are valid;
- provide tips to find the error log.

Jira: OB-475

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
- CLI
- meta0
- meta1
- meta2

##### SDS VERSION
```
6.0.0.0a1
```