### PR TITLE
Prevent from writing simultaneously on same socket

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -15,7 +15,7 @@
 
 from oio.common.green import ChunkReadTimeout, ChunkWriteTimeout, \
     ContextPool, ConnectionTimeout, Empty, GreenPile, LightQueue, \
-    SourceReadTimeout, Timeout, eventlet_yield
+    SourceReadTimeout, Timeout, Queue, eventlet_yield
 
 import collections
 import math
@@ -562,7 +562,7 @@ class EcChunkWriter(object):
             self.checksum = None
         self.write_timeout = write_timeout or io.CHUNK_TIMEOUT
         # we use eventlet Queue to pass data to the send coroutine
-        self.queue = LightQueue(io.PUT_QUEUE_DEPTH)
+        self.queue = Queue(io.PUT_QUEUE_DEPTH)
         self.reqid = kwargs.get('reqid')
         self.perfdata = perfdata
         self.logger = kwargs.get('logger', LOGGER)
@@ -641,11 +641,14 @@ class EcChunkWriter(object):
                 self.logger.warn("Failed to write to %s (%s, reqid=%s)",
                                  self.chunk, msg, self.reqid)
                 self.chunk['error'] = 'write: %s' % msg
+            # Indicate that the data is completely sent
+            self.queue.task_done()
 
         # Drain the queue before quitting
         while True:
             try:
                 self.queue.get_nowait()
+                self.queue.task_done()
             except Empty:
                 break
 
@@ -655,8 +658,8 @@ class EcChunkWriter(object):
         has been processed by the send coroutine
         """
         self.logger.debug("Waiting for %s to receive data", self.chunk['url'])
-        while self.queue.qsize() and not self.failed:
-            eventlet_yield()
+        # Wait until the data is completely sent to continue
+        self.queue.join()
 
     def send(self, data):
         # do not send empty data because


### PR DESCRIPTION
##### SUMMARY

Prevent from writing simultaneously on same socket

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.8.2.dev8
```

##### ADDITIONAL INFORMATION

```
Failed to upload /home/test in test-perf: RAWX write failure, quorum not reached (4/5): {"finish: Second simultaneous write on fileno 18 detected.  Unless you really know what you're doing, make sure that only one greenthread can write any particular socket.  Consider using a pools.Pool. If you do know what you're doing and want to disable this error, call eventlet.debug.hub_prevent_multiple_readers(False) - MY THREAD=<built-in method switch of GreenThread object at 0x7fd7420b2550>; THAT THREAD=FdListener('write', 18, <built-in method switch of GreenThread object at 0x7fd7420b20f0>, <built-in method throw of GreenThread object at 0x7fd7420b20f0>)": ['http://127.0.0.1:6201/74231FD2A4F9E4F8B5BEF948F706C0C30844C30ABEBBF9AC691E79587BC27719'], "finish: Second simultaneous write on fileno 16 detected.  Unless you really know what you're doing, make sure that only one greenthread can write any particular socket.  Consider using a pools.Pool. If you do know what you're doing and want to disable this error, call eventlet.debug.hub_prevent_multiple_readers(False) - MY THREAD=<built-in method switch of GreenThread object at 0x7fd7420b2410>; THAT THREAD=FdListener('write', 16, <built-in method switch of GreenThread object at 0x7fd7420b2230>, <built-in method throw of GreenThread object at 0x7fd7420b2230>)": ['http://127.0.0.1:6201/E879630118CED18876E88D8D6DE8CC2DA9BDDF62008BAE92584F91D5983F26E3'], 'success': ['http://127.0.0.1:6202/3C44F5F0425C855F3CD2195B195CEB98C042E9E3D052D33ED36FC951BDDF2D66', 'http://127.0.0.1:6203/F15B7F0134F9888E01BC1E37D503AC0BF5C1229B88AC3821414874861C03CB47', 'http://127.0.0.1:6204/A9E8A2F90D47A864114EA1B47A65B70BDDBBB92F123D64055907A734DA72AAA6', 'http://127.0.0.1:6205/F481046C9B95B8C18328124FF968003AC50549EB2951FE91C512B445784B6AE0']} (HTTP 503)
```
