### PR TITLE
xcute: Keep tasks order to update tasks sent

### DIFF
--- a/oio/xcute/orchestrator.py
+++ b/oio/xcute/orchestrator.py
@@ -185,7 +185,9 @@ class XcuteOrchestrator(object):
             tasks_run_time = 0
             batch_per_second = tasks_per_second / float(
                 tasks_batch_size)
-            tasks = dict()
+            # The backend must have the tasks in order
+            # to know the last task sent
+            tasks = OrderedDict()
             for task_id, task_payload in job_tasks:
                 if not self.running:
                     break


### PR DESCRIPTION
##### SUMMARY

Keep tasks order to update tasks sent, because the backend must have the tasks in order to know the last task sent

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `xcute`

##### SDS VERSION

```
openio 5.2.2
```