### PR TITLE
client: allow https for proxy url

### DIFF
--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -60,12 +60,15 @@ class ProxyClient(HttpApi):
             endpoint = self.conf.get('proxyd_url', None)
 
         ep_parts = list()
+        self.proxy_scheme = 'http'
         if endpoint:
-            self.proxy_netloc = endpoint.lstrip("http://")
+            if endpoint.startswith('https://'):
+                self.proxy_scheme = 'https'
+            self.proxy_netloc = endpoint.lstrip('%s://' % self.proxy_scheme)
         else:
             ns_conf = load_namespace_conf(self.ns)
             self.proxy_netloc = ns_conf.get('proxy')
-        ep_parts.append("http:/")
+        ep_parts.append('%s:/' % self.proxy_scheme)
         ep_parts.append(self.proxy_netloc)
 
         ep_parts.append("v3.0")

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -113,7 +113,8 @@ class ContainerClient(ProxyClient):
         Build URIs for request that don't use the same prefix as the one
         set in this class' constructor.
         """
-        uri = 'http://%s/v3.0/%s/%s' % (self.proxy_netloc, self.ns, target)
+        uri = '%s://%s/v3.0/%s/%s' % (self.proxy_scheme, self.proxy_netloc,
+                                      self.ns, target)
         return uri
 
     def _make_params(self, account=None, reference=None, path=None, cid=None,


### PR DESCRIPTION
Do not assume the proxy url is plain text http

##### SUMMARY
We want to use https from the swift proxy to the oio proxy, but using an `https://` url as `sds_proxy_url` in `proxy-server.conf` does not work. This appears to fix the issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio client common

##### SDS VERSION
whatever it is master is? tested on 5.2.2



##### ADDITIONAL INFORMATION
Reproducer steps:
 - setup an https frontend to oioproxy (whatever reverse proxy that supports ssl terminaison) and configure `sds_proxy_url` to `https://<ip>:<port>` in `oioswift`'s `proxy-server.conf`
 - try to run a request, fails with internal error `No address found`, probably because the https is not stripped properly from the netloc and it cannot resolve it.
 - try again with patch, it should work.

Note: there is no SSL certificate validation, I would have assumed that change to fail a bit further.  
I would also like to validate the server certificate matches the one given in the url, any hint on where to change that would be appreciated before I start looking at the code.