### PR TITLE
sqliterepo: fix the snapshot feature

### DIFF
--- a/core/oiostr.h
+++ b/core/oiostr.h
@@ -59,6 +59,10 @@ size_t oio_constptrv_length (const void * const *v);
 /* Reallocs <dst> and appends it <s>. <s> is reused and is not duplicated */
 gchar ** oio_strv_append(gchar **dst, gchar *s);
 
+/* Filter out (and free) all occurrences of needle.
+ * Returns the same array pointer. */
+gchar ** oio_strv_filter(gchar **array, const char *needle);
+
 /** frees *s and set it to NULL */
 void oio_str_clean(gchar **s);
 

--- a/core/str.c
+++ b/core/str.c
@@ -758,3 +758,28 @@ oio_strv_has(register const gchar * const * p, register const gchar *needle)
 	}
 	return FALSE;
 }
+
+gchar **
+oio_strv_filter(gchar **array, const char *needle)
+{
+	gint last = g_strv_length(array) - 1;
+	for (gchar **cur = array; array && *cur;) {
+		if (!g_strcmp0(*cur, needle)) {
+			g_free(*cur);
+			if (cur == array + last) {
+				// Last element, just set it to NULL.
+				*cur = NULL;
+				break;
+			} else {
+				// Middle element, exchange with last.
+				*cur = array[last];
+				array[last] = NULL;
+				last--;
+				// Do not increment cur, we have to check it.
+				continue;
+			}
+		}
+		cur++;
+	}
+	return array;
+}

--- a/oio/directory/admin.py
+++ b/oio/directory/admin.py
@@ -371,3 +371,9 @@ class AdminClient(ProxyClient):
         _resp, body = self.forwarder._request(
             'POST', '/balance-masters', params=params, **kwargs)
         return _resp.status, body
+
+    def service_reload_lb(self, svc_id, **kwargs):
+        """
+        Force the service to reload its internal load balancer.
+        """
+        self._forward_service_action(svc_id, '/reload', **kwargs)

--- a/sqliterepo/election.c
+++ b/sqliterepo/election.c
@@ -2074,25 +2074,7 @@ static void
 _manager_filter_peers(struct election_manager_s *m, gchar **peers)
 {
 	const gchar *self = election_manager_get_local(m);
-	gint last = g_strv_length(peers) - 1;
-	for (gchar **peer = peers; peers && *peer;) {
-		if (!g_strcmp0(*peer, self)) {
-			g_free(*peer);
-			if (peer == peers + last) {
-				// Last element, just set it to NULL.
-				*peer = NULL;
-				break;
-			} else {
-				// Middle element, exchange with last.
-				*peer = peers[last];
-				peers[last] = NULL;
-				last--;
-				// Do not increment peer, we have to check it.
-				continue;
-			}
-		}
-		peer++;
-	}
+	oio_strv_filter(peers, self);
 }
 
 static GError *

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -472,37 +472,24 @@ _restore_snapshot(struct sqlx_repository_s *repo, struct sqlx_name_s *name,
 	if (stat(path, &bstats) != 0) {
 		return NEWERROR(errno, "Failed to read snapshot: %s", strerror(errno));
 	}
-	/* Synchronous replication is only possible if the file is "small".
-	 * If it is not, do not start a transaction, write only in the local base,
-	 * and rely on asynchronous replication mechanisms. */
-	gboolean sync_repli = bstats.st_size < sqliterepo_dump_max_size;
 	struct sqlx_sqlite3_s *sq3 = NULL;
 	/* The database snapshot file is here, open the base locally to avoid
-	 * a redirection, in case the local service does not become the master. */
+	 * a redirection, in case the local service does not become the master.
+	 * TODO(FVE): find a way to force the local peer to be the master.
+	 * This would allow synchronous replication of the snapshot (provided
+	 * it is small enough). */
 	GError *err = sqlx_repository_timed_open_and_lock(repo, name,
 			SQLX_OPEN_LOCAL|SQLX_OPEN_NOREFCHECK|SQLX_OPEN_CREATE, peers,
 			&sq3, NULL, oio_ext_get_deadline());
 	if (!err) {
-		struct sqlx_repctx_s *repctx = NULL;
-		if (sync_repli)
-			err = sqlx_transaction_begin(sq3, &repctx);
+		err = sqlx_repository_restore_from_file(sq3, path);
 		if (!err) {
-			err = sqlx_repository_restore_from_file(sq3, path);
-			if (!err) {
-				sqlx_repository_call_change_callback(sq3);
-				/* Set the new set of peers, avoid a lookup from meta1. */
-				sqlx_admin_set_str(sq3, SQLX_ADMIN_PEERS, peers);
-				sqlx_admin_save_lazy(sq3);
-				/* The slaves do not have the base, trigger synchronous
-				 * replication and prevent "Remote diff missed" errors. */
-				if (sync_repli)
-					sqlx_transaction_notify_huge_changes(repctx);
-			}
+			/* Set the new set of peers, avoid a lookup from meta1. */
+			sqlx_admin_set_str(sq3, SQLX_ADMIN_PEERS, peers);
+			sqlx_admin_save_lazy(sq3);
+			sqlx_repository_call_change_callback(sq3);
 		}
-		if (sync_repli)
-			err = sqlx_transaction_end(repctx, err);
 	}
-
 	sqlx_repository_unlock_and_close_noerror(sq3);
 	return err;
 }
@@ -637,6 +624,18 @@ _snapshot_from(const gchar *source, struct sqlx_repository_s *repo,
 	err = _pipe_base_from(source, repo, source_name, &ctx);
 	if (!err)
 		err = _restore_snapshot(repo, dest_name, ctx->path, peers);
+
+	/* The snapshot exists locally, but there is still no election.
+	 * Trigger one, forcing the other peers to download the database.
+	 * We use sqlx_repository_status_base rather than sqlx_repository_use_base
+	 * to wait for the election to establish before returning. */
+	if (!err) {
+		NAME2CONST(n0, *dest_name);
+		err = sqlx_repository_status_base(repo, &n0, peers,
+				oio_ext_get_deadline());
+		if (err && CODE_IS_REDIRECT(err->code))
+			g_clear_error(&err);
+	}
 
 	restore_ctx_clear(&ctx);
 	return err;
@@ -873,7 +872,7 @@ _handler_STATUS(struct gridd_reply_ctx_s *reply,
 		return TRUE;
 	}
 
-	if (NULL != (err = sqlx_repository_status_base(repo, &n0, reply->deadline)))
+	if ((err = sqlx_repository_status_base(repo, &n0, NULL, reply->deadline)))
 		reply->send_error(0, err);
 	else
 		reply->send_reply(CODE_FINAL_OK, "MASTER");
@@ -896,7 +895,7 @@ _handler_ISMASTER(struct gridd_reply_ctx_s *reply,
 		return TRUE;
 	}
 
-	err = sqlx_repository_status_base(repo, &n0, reply->deadline);
+	err = sqlx_repository_status_base(repo, &n0, NULL, reply->deadline);
 	if (NULL == err)
 		reply->send_reply(CODE_FINAL_OK, "MASTER");
 	else {

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1267,7 +1267,7 @@ end_sqlx_cache_close:
 
 GError*
 sqlx_repository_status_base(sqlx_repository_t *repo,
-		const struct sqlx_name_s *n, gint64 deadline)
+		const struct sqlx_name_s *n, const gchar *peers, gint64 deadline)
 {
 	REPO_CHECK(repo);
 	SQLXNAME_CHECK(n);
@@ -1277,7 +1277,7 @@ sqlx_repository_status_base(sqlx_repository_t *repo,
 	/* Kick the election off */
 	gboolean replicated = FALSE;
 	GError *err = sqlx_repository_use_base(
-			repo, n, NULL, FALSE, TRUE, &replicated);
+			repo, n, peers, FALSE, TRUE, &replicated);
 	if (err)
 		return err;
 	if (!replicated)

--- a/sqliterepo/sqliterepo.h
+++ b/sqliterepo/sqliterepo.h
@@ -299,7 +299,7 @@ GError* sqlx_repository_use_base(sqlx_repository_t *repo,
  * @return NULL if master, an error with code CODE_REDIRECT if slave, an error with
  *         another code if the election failed. */
 GError* sqlx_repository_status_base(sqlx_repository_t *repo,
-		const struct sqlx_name_s *n, gint64 deadline);
+		const struct sqlx_name_s *n, const gchar *peers, gint64 deadline);
 
 /** Collect into a buffer the binary dump of the base (i.e. the content
  *  of a valid sqlite3 file, with only the meaningful pages). */

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -1331,8 +1331,38 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         res = self.api.object_delete_many(self.account, container, ["dahu"])
         self.assertFalse(res[0][1])
 
+    def test_container_snapshot_failure(self):
+        cname = 'container-' + random_str(6)
+        cname2 = cname + '.snapshot'
+
+        # Creating a snapshot on non existing container should fail
+        self.assertRaises(exc.NoSuchContainer,
+                          self.api.container_snapshot,
+                          self.account, cname,
+                          self.account, cname2)
+
+        self._create(cname)
+        # Snapshot cannot have same name and same account
+        self.assertRaises(exc.ClientException,
+                          self.api.container_snapshot,
+                          self.account, cname,
+                          self.account, cname)
+
+        # Snapshots need to have an account name
+        self.assertRaises(exc.ClientException,
+                          self.api.container_snapshot,
+                          self.account, cname,
+                          None, cname2)
+
+        # Snapshots need to have a name
+        self.assertRaises(exc.ClientException,
+                          self.api.container_snapshot,
+                          self.account, cname,
+                          cname2, None)
+
     def test_container_snapshot(self):
-        container = random_str(16)
+        container = 'container-' + random_str(6)
+        snapshot = container + '.snapshot'
         self.api.container_create(self.account, container)
         test_object = "test_object_%d"
         for i in range(10):
@@ -1340,25 +1370,20 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
                                    obj_name=test_object % i,
                                    chunk_checksum_algo=None)
 
-        # Snapshot cannot have same name and same account
-        self.assertRaises(exc.ClientException,
-                          self.api.container_snapshot,
-                          self.account, container, self.account, container)
-        snapshot = random_str(16)
-        self.assertNotEqual(snapshot, container)
         # Non existing snapshot should work
-        self.api.container_snapshot(self.account, container, self.account,
-                                    snapshot, read_timeout=60.0)
+        self.api.container_snapshot(self.account, container,
+                                    self.account, snapshot)
         # Check sys.user.name is correct
         ret = self.api.container_get_properties(self.account, snapshot)
         self.assertEqual(snapshot, ret['system']['sys.user.name'])
         self.assertEqual(self.account, ret['system']['sys.account'])
 
-        # Already taken snapshot name should failed
+        # Already taken snapshot name should fail
         self.assertRaises(exc.ClientException,
                           self.api.container_snapshot,
                           self.account, container, self.account, snapshot)
-        # Check Container Frozen so create should failed
+
+        # Check Container Frozen so create should fail
         self.assertRaises(exc.ServiceBusy,
                           self.api.object_create,
                           self.account, snapshot,
@@ -1399,20 +1424,6 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
         # check target can be used
         self.api.object_create(self.account, container, data="0"*128,
                                obj_name="should_be_created")
-
-        # Snapshot on non existing container should failed
-        self.assertRaises(exc.NoSuchContainer,
-                          self.api.container_snapshot,
-                          random_str(16), random_str(16),
-                          random_str(16), random_str(16))
-        # Snapshot need to have a account
-        self.assertRaises(exc.ClientException,
-                          self.api.container_snapshot,
-                          self.account, container, None, random_str(16))
-        # Snapshot need to have a name
-        self.assertRaises(exc.ClientException,
-                          self.api.container_snapshot,
-                          self.account, container, random_str(16), None)
 
     def test_object_create_long_name(self):
         """Create an objet whose name has the maximum length allowed"""

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -123,11 +123,11 @@ class ContainerTest(CliTestCase):
         # Snapshot should reply the name of the snapshot on success
         opts = self.get_format_opts('json')
         cid_opt = ''
-        name = self.NAME
+        cname = self.NAME
         if with_cid:
             cid_opt = '--cid '
-            name = self.CID
-        output = self.openio('container snapshot ' + cid_opt + name + opts)
+            cname = self.CID
+        output = self.openio('container snapshot ' + cid_opt + cname + opts)
         output = self.json_loads(output)[0]
         self.assertEqual(output['Status'], "OK")
         # Snapshot should reply Missing container on non existant container
@@ -135,11 +135,11 @@ class ContainerTest(CliTestCase):
                           self.openio,
                           ('container snapshot Should_not_exist' + opts))
         # Use specified name
-        dst_account = random_str(16)
-        dst_container = random_str(16)
+        dst_account = 'acct-' + random_str(6)
+        dst_container = cname + '.snapshot-' + random_str(6)
         opts += " --dst-account " + dst_account
         opts += " --dst-container " + dst_container
-        output = self.openio('container snapshot ' + cid_opt + name + opts)
+        output = self.openio('container snapshot ' + cid_opt + cname + opts)
         output = self.json_loads(output)[0]
         self.assertEqual(output['Account'], dst_account)
         self.assertEqual(output['Container'], dst_container)
@@ -148,7 +148,7 @@ class ContainerTest(CliTestCase):
         #   specified name
         self.assertRaises(CommandFailed,
                           self.openio,
-                          ('container snapshot ' + cid_opt + name + opts))
+                          ('container snapshot ' + cid_opt + cname + opts))
 
     def test_container_snapshot(self):
         self._test_container_snapshot()

--- a/tests/functional/content/test_service_id.py
+++ b/tests/functional/content/test_service_id.py
@@ -48,6 +48,8 @@ class BaseServiceIdTest(BaseTestCase):
 
     def tearDown(self):
         super(BaseServiceIdTest, self).tearDown()
+        self.wait_for_score(('meta2', ))
+        self._reload_meta()
 
     def _update_apache(self, port):
         path = HTTPD_CONF % (self.ns, self.name)
@@ -62,7 +64,7 @@ class BaseServiceIdTest(BaseTestCase):
             fp.write('\n'.join(data))
 
     def _cache_flush(self):
-        for item in ['local', 'low', 'high']:
+        for item in ('local', 'low', 'high'):
             r = self.http_pool.request('POST', 'http://%s/v3.0/cache/flush/%s'
                                        % (self.conf['proxy'], item))
             self.assertEqual(r.status, 204)


### PR DESCRIPTION
##### SUMMARY
The tests of the container snapshot feature were flaky. This is because there was a real bug. This pull request aims at fixing this bug. It also reorganizes the tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- sqliterepo

##### SDS VERSION
```
openio 6.0.1.dev2
```


##### ADDITIONAL INFORMATION
The usual error message triggered by the bug was:
```
oio.common.exceptions.ServiceBusy: COMMIT failed: (SQLITE_CONSTRAINT) constraint failed [127.0.0.1:6018/470/Remote diff missed] [127.0.0.1:6017/470/Remote diff missed] Not enough successes, no quorum (1/3) (HTTP 503) (STATUS 503)
```