### PR TITLE
Fix logging issue when /dev/log does not exists in Python 3

### DIFF
--- a/oio/common/logger.py
+++ b/oio/common/logger.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2017-2019 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -18,7 +18,7 @@ import sys
 import socket
 import errno
 import logging
-from logging.handlers import SysLogHandler
+from logging.handlers import SysLogHandler, SocketHandler
 
 
 class StreamToLogger(object):
@@ -29,10 +29,22 @@ class StreamToLogger(object):
     def write(self, value):
         value = value.strip()
         if value:
-            self.logger.error('%s : %s', self.log_type, value)
+            try:
+                self.logger.error('%s: %s', self.log_type, value)
+            except Exception as err:
+                if self.log_type == 'STDERR' and sys.stderr != sys.__stderr__:
+                    msg = ("There was an error (%s) while logging to the "
+                           "wrapped stderr, restoring the real stderr.\n")
+                    sys.stderr = sys.__stderr__
+                    sys.stderr.write(msg % err)
+                    log_handler = self.logger.handlers[0]
+                    if isinstance(log_handler, (SysLogHandler, SocketHandler)):
+                        sys.stderr.write('log_address: %s\n' %
+                                         log_handler.address)
+                raise
 
     def writelines(self, values):
-        self.logger.error('%s : %s', self.log_type, '#012'.join(values))
+        self.logger.error('%s: %s', self.log_type, '#012'.join(values))
 
     def close(self):
         pass
@@ -49,7 +61,9 @@ def redirect_stdio(logger):
     """
     sys.excepthook = lambda * exc_info: \
         logger.critical('UNCAUGHT EXCEPTION', exc_info=exc_info)
-    stdio_fd = [sys.stdin, sys.stdout, sys.stderr]
+    # Do not close stderr. We will replace sys.stderr, but the file
+    # descriptor will still be open an reachable from sys.__stderr__.
+    stdio_fd = (sys.stdin, sys.stdout)
     console_fds = [h.stream.fileno() for _, h in getattr(
         get_logger, 'console_handler4logger', {}).items()]
     stdio_fd = [fd for fd in stdio_fd if fd.fileno() not in console_fds]

--- a/oio/common/logger.py
+++ b/oio/common/logger.py
@@ -106,11 +106,14 @@ def get_logger(
                                 facility=facility)
     else:
         log_address = conf.get('log_address', '/dev/log')
-        try:
-            handler = SysLogHandler(address=log_address, facility=facility)
-        except socket.error as exc:
-            if exc.errno not in [errno.ENOTSOCK, errno.ENOENT]:
-                raise exc
+        if os.path.exists(log_address):
+            try:
+                handler = SysLogHandler(address=log_address, facility=facility)
+            except socket.error as exc:
+                if exc.errno not in [errno.ENOTSOCK, errno.ENOENT]:
+                    raise exc
+                handler = SysLogHandler(facility=facility)
+        else:
             handler = SysLogHandler(facility=facility)
 
     handler.setFormatter(syslog_formatter)

--- a/tools/oio-crash-logger.py
+++ b/tools/oio-crash-logger.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from tempfile import NamedTemporaryFile
+from oio.common.logger import get_logger, redirect_stdio
+
+with NamedTemporaryFile(mode='rb', prefix='nolog-') as tmp:
+    LOGGER = get_logger({'log_address': tmp.name})
+    redirect_stdio(LOGGER)
+    LOGGER.warn('Trying to log something boring.')
+
+sys.exit(0)

--- a/tools/oio-test-suites.sh
+++ b/tools/oio-test-suites.sh
@@ -94,6 +94,16 @@ test_oio_lb_benchmark() {
 	if [ $(grep -qv 'no service polled from' lb-benchmark.log) ]; then exit 1; fi
 }
 
+test_oio_logger() {
+	# Expect the thing to exit with error 1. If it crashes in an uncontrolled
+	# way, it will return 128+.
+	set +e
+	python ${WRKDIR}/tools/oio-crash-logger.py
+	CODE=$?
+	set -e
+	if [ $CODE -ne 1 ]; then exit 1; fi
+}
+
 test_proxy_forward () {
 	proxy=$(oio-test-config.py -t proxy -1)
 
@@ -291,6 +301,7 @@ test_cli () {
 	# This is tested here because we do not need to test it several times,
 	# and for some reason it cannot run with unit tests.
 	test_oio_lb_benchmark
+	test_oio_logger
 }
 
 func_tests_rebuilder_mover () {


### PR DESCRIPTION
<!--- Describe the change, including rationale and design decisions -->
A change in Python 3 (https://bugs.python.org/issue29808)
leads to a stack overflow when /dev/log does not exists.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

<!--- Name of the servicetype -->

<!--- Paste verbatim output from "openio --version" between quotes below -->
```
openio 6.0.0
```

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
