### PR TITLE
proxy: Allow to force the request on master service

### DIFF
--- a/meta2v2/meta2_backend.c
+++ b/meta2v2/meta2_backend.c
@@ -84,7 +84,7 @@ static void m2b_add_modified_container(struct meta2_backend_s *m2b,
 static enum m2v2_open_type_e
 _mode_masterslave(guint32 flags)
 {
-	if (flags & M2V2_FLAG_MASTER)
+	if ((flags & M2V2_FLAG_MASTER) || oio_ext_has_force_master())
 		return M2V2_OPEN_MASTERONLY;
 	return (flags & M2V2_FLAG_LOCAL)
 		? M2V2_OPEN_LOCAL : M2V2_OPEN_MASTERSLAVE;
@@ -1002,8 +1002,7 @@ meta2_backend_list_aliases(struct meta2_backend_s *m2b, struct oio_url_s *url,
 	EXTRA_ASSERT(url != NULL);
 	EXTRA_ASSERT(lp != NULL);
 
-	guint32 open_mode = oio_ext_has_force_master() ?
-			M2V2_FLAG_MASTER : (lp->flag_local? M2V2_FLAG_LOCAL: 0);
+	guint32 open_mode = lp->flag_local ? M2V2_FLAG_LOCAL: 0;
 	err = m2b_open(m2b, url, _mode_readonly(open_mode), &sq3);
 	if (!err) {
 		err = m2db_list_aliases(sq3, lp, headers, cb, u0);

--- a/meta2v2/meta2_gridd_dispatcher.c
+++ b/meta2v2/meta2_gridd_dispatcher.c
@@ -135,6 +135,7 @@ static gridd_filter M2V2_EMPTY_FILTERS[] =
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_localflag,
 	meta2_filter_extract_admin,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_user_agent,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,
@@ -241,6 +242,7 @@ static gridd_filter M2V2_LCHUNK_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_flags32,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_user_agent,
 	meta2_filter_extract_list_params,
 	meta2_filter_fill_subject,
@@ -255,6 +257,7 @@ static gridd_filter M2V2_LHID_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_flags32,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_user_agent,
 	meta2_filter_extract_list_params,
 	meta2_filter_fill_subject,
@@ -269,6 +272,7 @@ static gridd_filter M2V2_LHHASH_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_flags32,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_user_agent,
 	meta2_filter_extract_list_params,
 	meta2_filter_fill_subject,
@@ -341,6 +345,7 @@ static gridd_filter M2V2_GET_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
 	meta2_filter_extract_header_localflag,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_header_flags32,
 	meta2_filter_extract_user_agent,
 	meta2_filter_fill_subject,
@@ -426,6 +431,7 @@ static gridd_filter M2V2_PROPSET_FILTERS[] =
 static gridd_filter M2V2_PROPGET_FILTERS[] =
 {
 	meta2_filter_extract_header_url,
+	meta2_filter_extract_force_master,
 	meta2_filter_extract_user_agent,
 	meta2_filter_fill_subject,
 	meta2_filter_check_url_cid,

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -1134,8 +1134,7 @@ action_m2_container_destroy (struct req_args_s *args)
 
 	/* 2. Check the base is empty. */
 	if (!err && !force) {
-		guint32 flags = flag_force_master ? M2V2_FLAG_MASTER : 0;
-		PACKER_VOID(_pack) { return m2v2_remote_pack_ISEMPTY (args->url, flags, DL()); }
+		PACKER_VOID(_pack) { return m2v2_remote_pack_ISEMPTY(args->url, DL()); }
 		err = _resolve_meta2(args, _prefer_master(), _pack, NULL, NULL);
 		if (err != NULL) {
 			/* rollback! */
@@ -2004,14 +2003,13 @@ enum http_rc_e action_container_list (struct req_args_s *args) {
 
 	if (!err) {
 		GByteArray* _pack (struct list_params_s *in) {
-			guint32 flags = flag_force_master ? M2V2_FLAG_MASTER : 0;
 			if (chunk_id)
-				return m2v2_remote_pack_LIST_BY_CHUNKID (args->url, flags,
+				return m2v2_remote_pack_LIST_BY_CHUNKID(args->url,
 						in, chunk_id, DL());
 			if (content_hash)
-				return m2v2_remote_pack_LIST_BY_HEADERHASH (args->url, flags,
+				return m2v2_remote_pack_LIST_BY_HEADERHASH(args->url,
 						in, content_hash, DL());
-			return m2v2_remote_pack_LIST (args->url, flags, in, DL());
+			return m2v2_remote_pack_LIST(args->url, in, DL());
 		}
 		err = _list_loop (args, &list_in, &list_out, tree_prefixes, _pack);
 	}
@@ -2573,10 +2571,8 @@ static enum http_rc_e action_m2_content_propdel (struct req_args_s *args,
 
 static enum http_rc_e action_m2_content_propget (struct req_args_s *args,
 		struct json_object *jargs UNUSED) {
-	const guint32 flags = flag_force_master ? M2V2_FLAG_MASTER : 0;
-
 	GSList *beans = NULL;
-	PACKER_VOID(_pack) { return m2v2_remote_pack_PROP_GET (args->url, flags, DL()); }
+	PACKER_VOID(_pack) { return m2v2_remote_pack_PROP_GET(args->url, DL()); }
 	GError *err = _resolve_meta2(args, _prefer_slave(), _pack, &beans, NULL);
 	return _reply_properties (args, err, beans);
 }
@@ -2953,12 +2949,13 @@ enum http_rc_e action_content_prepare_v2(struct req_args_s *args) {
 // }}CONTENT
 enum http_rc_e action_content_show (struct req_args_s *args) {
 	GSList *beans = NULL;
-	guint32 flags = flag_force_master ? M2V2_FLAG_MASTER : 0;
+	guint32 flags = 0;
+
 	/* Historical behaviour is to return properties as headers, but
 	 * if there are too many, the client will fail decoding the request. */
 	if (!oio_str_parse_bool(OPT("properties"), TRUE))
 		flags |= M2V2_FLAG_NOPROPS;
-	PACKER_VOID(_pack) { return m2v2_remote_pack_GET (args->url, flags, DL()); }
+	PACKER_VOID(_pack) { return m2v2_remote_pack_GET(args->url, flags, DL()); }
 	GError *err = _resolve_meta2(args, _prefer_slave(), _pack, &beans, NULL);
 	return _reply_simplified_beans_legacy(args, err, beans);
 }

--- a/proxy/meta2v2_remote.c
+++ b/proxy/meta2v2_remote.c
@@ -180,12 +180,6 @@ m2v2_remote_pack_DESTROY(struct oio_url_s *url, guint32 flags, gint64 dl)
 }
 
 GByteArray*
-m2v2_remote_pack_HAS(struct oio_url_s *url, guint32 flags, gint64 dl)
-{
-	return _m2v2_pack_request_with_flags(NAME_MSGNAME_M2V2_HAS, url, NULL, flags, dl);
-}
-
-GByteArray*
 m2v2_remote_pack_FLUSH(struct oio_url_s *url, gint64 dl)
 {
 	return _m2v2_pack_request(NAME_MSGNAME_M2V2_FLUSH, url, NULL, dl);
@@ -337,8 +331,9 @@ m2v2_remote_pack_GET(struct oio_url_s *url, guint32 flags, gint64 dl)
 }
 
 static void
-_pack_list_params (MESSAGE msg, struct list_params_s *p, guint32 flags)
+_pack_list_params(MESSAGE msg, struct list_params_s *p)
 {
+	guint32 flags = 0;
 	if (p->flag_allversion) flags |= M2V2_FLAG_ALLVERSION;
 	if (p->flag_headers) flags |= M2V2_FLAG_HEADERS;
 	if (p->flag_nodeleted) flags |= M2V2_FLAG_NODELETED;
@@ -354,41 +349,41 @@ _pack_list_params (MESSAGE msg, struct list_params_s *p, guint32 flags)
 }
 
 GByteArray*
-m2v2_remote_pack_LIST(struct oio_url_s *url, guint32 flags,
+m2v2_remote_pack_LIST(struct oio_url_s *url,
 		struct list_params_s *p, gint64 dl)
 {
 	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_LIST, url, NULL, dl);
-	_pack_list_params (msg, p, flags);
+	_pack_list_params(msg, p);
 	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*
-m2v2_remote_pack_LIST_BY_CHUNKID(struct oio_url_s *url, guint32 flags,
+m2v2_remote_pack_LIST_BY_CHUNKID(struct oio_url_s *url,
 		struct list_params_s *p, const char *chunk, gint64 dl)
 {
 	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_LCHUNK, url, NULL, dl);
-	_pack_list_params (msg, p, flags);
+	_pack_list_params(msg, p);
 	metautils_message_add_field_str (msg, NAME_MSGKEY_KEY, chunk);
 	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*
-m2v2_remote_pack_LIST_BY_HEADERHASH(struct oio_url_s *url, guint32 flags,
+m2v2_remote_pack_LIST_BY_HEADERHASH(struct oio_url_s *url,
 		struct list_params_s *p, GBytes *h, gint64 dl)
 {
 	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_LHHASH, url, NULL, dl);
-	_pack_list_params (msg, p, flags);
+	_pack_list_params(msg, p);
 	metautils_message_add_field (msg, NAME_MSGKEY_KEY,
 			g_bytes_get_data(h,NULL), g_bytes_get_size(h));
 	return message_marshall_gba_and_clean(msg);
 }
 
 GByteArray*
-m2v2_remote_pack_LIST_BY_HEADERID(struct oio_url_s *url, guint32 flags,
+m2v2_remote_pack_LIST_BY_HEADERID(struct oio_url_s *url,
 		struct list_params_s *p, GBytes *h, gint64 dl)
 {
 	MESSAGE msg = _m2v2_build_request(NAME_MSGNAME_M2V2_LHID, url, NULL, dl);
-	_pack_list_params (msg, p, flags);
+	_pack_list_params(msg, p);
 	metautils_message_add_field (msg, NAME_MSGKEY_KEY,
 			g_bytes_get_data(h,NULL), g_bytes_get_size(h));
 	return message_marshall_gba_and_clean(msg);
@@ -411,9 +406,9 @@ m2v2_remote_pack_PROP_SET(struct oio_url_s *url, guint32 flags,
 }
 
 GByteArray*
-m2v2_remote_pack_PROP_GET(struct oio_url_s *url, guint32 flags, gint64 dl)
+m2v2_remote_pack_PROP_GET(struct oio_url_s *url, gint64 dl)
 {
-	return _m2v2_pack_request_with_flags(NAME_MSGNAME_M2V2_PROP_GET, url, NULL, flags, dl);
+	return _m2v2_pack_request(NAME_MSGNAME_M2V2_PROP_GET, url, NULL, dl);
 }
 
 GByteArray*
@@ -441,9 +436,9 @@ m2v2_remote_pack_TOUCHB(struct oio_url_s *url, guint32 flags, gint64 dl,
 }
 
 GByteArray*
-m2v2_remote_pack_ISEMPTY (struct oio_url_s *url, guint32 flags, gint64 dl)
+m2v2_remote_pack_ISEMPTY (struct oio_url_s *url, gint64 dl)
 {
-	return _m2v2_pack_request_with_flags(NAME_MSGNAME_M2V2_ISEMPTY, url, NULL, flags, dl);
+	return _m2v2_pack_request(NAME_MSGNAME_M2V2_ISEMPTY, url, NULL, dl);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/proxy/meta2v2_remote.h
+++ b/proxy/meta2v2_remote.h
@@ -69,16 +69,8 @@ GByteArray* m2v2_remote_pack_DESTROY(
 		guint32 flags,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
-GByteArray* m2v2_remote_pack_HAS(
-		struct oio_url_s *url,
-		guint32 flags,
-		gint64 deadline);
-
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_ISEMPTY(
 		struct oio_url_s *url,
-		guint32 flags,
 		gint64 deadline);
 
 GByteArray* m2v2_remote_pack_FLUSH(
@@ -139,39 +131,30 @@ GByteArray* m2v2_remote_pack_TRUNC(
 		gint64 size,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_GET(
 		struct oio_url_s *url,
 		guint32 flags,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_LIST(
 		struct oio_url_s *url,
-		guint32 flags,
 		struct list_params_s *p,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_LIST_BY_CHUNKID(
 		struct oio_url_s *url,
-		guint32 flags,
 		struct list_params_s *p,
 		const char *chunk,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_LIST_BY_HEADERHASH(
 		struct oio_url_s *url,
-		guint32 flags,
 		struct list_params_s *p,
 		GBytes *h,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_LIST_BY_HEADERID(
 		struct oio_url_s *url,
-		guint32 flags,
 		struct list_params_s *p,
 		GBytes *h,
 		gint64 deadline);
@@ -206,10 +189,8 @@ GByteArray* m2v2_remote_pack_PROP_SET(
 		GSList *beans,
 		gint64 deadline);
 
-/* accepts M2V2_FLAG_MASTER */
 GByteArray* m2v2_remote_pack_PROP_GET(
 		struct oio_url_s *url,
-		guint32 flags,
 		gint64 deadline);
 
 GByteArray* m2v2_remote_pack_TOUCHB(

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -232,7 +232,8 @@ handler_action (struct http_request_s *rq, struct http_reply_ctx_s *rp)
 	/* Load the optional 'force_master' flag */
 	const char *force_master = g_tree_lookup(
 			rq->tree_headers, PROXYD_HEADER_FORCE_MASTER);
-	oio_ext_set_force_master(oio_str_parse_bool(force_master, FALSE));
+	oio_ext_set_force_master(
+			flag_force_master || oio_str_parse_bool(force_master, FALSE));
 
 	/* Load the User-Agent */
 	const char *user_agent = g_tree_lookup(rq->tree_headers, USER_AGENT_HEADER);


### PR DESCRIPTION
##### SUMMARY

Allow to force the request on master service.

It was already possible to do this by adding 'proxy.force.master'
in the proxy configuration. But this was applied to all requests.

If we wanted to force the master only on a specific request,
we can add the 'x-oio-force-master' header in the request.
But this header was only used to list the objects in a container.

Now, it is possible to specifically force the master on all meta2 requests.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `proxy`
- `meta2`

##### SDS VERSION

```
openio 5.2.4.dev1
```