### PR TITLE
server: display better messages after IO errors

### DIFF
--- a/server/transport_gridd.h
+++ b/server/transport_gridd.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS server
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -133,8 +133,13 @@ void grid_daemon_bind_host(struct network_server_s *server, const gchar *url,
 		struct gridd_request_dispatcher_s *dispatcher);
 
 void grid_daemon_notify_io_status(
-		struct gridd_request_dispatcher_s *disp, gboolean ok);
+		struct gridd_request_dispatcher_s *disp, gboolean ok,
+		const gchar *msg);
 
 gboolean grid_daemon_is_io_ok(struct gridd_request_dispatcher_s *disp);
+
+/* When grid_daemon_is_io_ok() returns false, calling this will report the
+ * last message emitted by the IO checking thread. */
+const gchar* grid_daemon_last_io_msg(struct gridd_request_dispatcher_s *disp);
 
 #endif /*OIO_SDS__server__transport_gridd_h*/

--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -1077,8 +1077,11 @@ _task_probe_repository(gpointer p)
 	errsav = errno;
 	(void) g_rmdir(path);
 	if (rc != 0) {
-		GRID_WARN("I/O error on %s: (%d) %s", path, errsav, strerror(errsav));
-		grid_daemon_notify_io_status(ss->dispatcher, FALSE);
+		gchar *msg = g_strdup_printf("IO error on %s %s: (%d) %s",
+				ss->service_id->str, path, errsav, strerror(errsav));
+		GRID_WARN("%s", msg);
+		grid_daemon_notify_io_status(ss->dispatcher, FALSE, msg);
+		g_free(msg);
 		return;
 	}
 
@@ -1090,13 +1093,15 @@ _task_probe_repository(gpointer p)
 	rc = g_file_set_contents(path, "", 0, &err);
 	(void) g_unlink(path);
 	if (!rc) {
-		GRID_WARN("I/O error on %s: (%d) %s", path, err->code, err->message);
+		gchar *msg = g_strdup_printf("IO error on %s %s: (%d) %s",
+				ss->service_id->str, path, err->code, err->message);
+		GRID_WARN("%s", msg);
 		g_clear_error(&err);
-		grid_daemon_notify_io_status(ss->dispatcher, FALSE);
+		grid_daemon_notify_io_status(ss->dispatcher, FALSE, msg);
 		return;
 	}
 
-	grid_daemon_notify_io_status(ss->dispatcher, TRUE);
+	grid_daemon_notify_io_status(ss->dispatcher, TRUE, NULL);
 }
 
 static void


### PR DESCRIPTION
##### SUMMARY
The error messages emitted after IO errors were detected had different syntaxes, making it difficult to search for them in the logs. This is now fixed.

Also, a new message will now tell is the IO error checking thread is stalled for a long time.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- main server code
- sqliterepo

##### SDS VERSION
```
openio 5.2.3
```