### PR TITLE
event-agent: Encode without whitespace when forwarding an event

### DIFF
--- a/oio/event/filters/notify.py
+++ b/oio/event/filters/notify.py
@@ -79,7 +79,10 @@ class NotifyFilter(Filter):
         event = Event(env)
         if self.should_notify(event):
             try:
-                data = json.dumps(env)
+                # Encode without whitespace to make sure not
+                # to exceed the maximum size of the event (default: 65535)
+                data = json.dumps(env,
+                                  separators=(',', ':'))  # compact encoding
                 self.beanstalk.put(data)
             except BeanstalkError as err:
                 msg = 'notify failure: %s' % str(err)


### PR DESCRIPTION
##### SUMMARY

Encode without whitespace when notifying event to make sure not to exceed the maximum size of the event (default: 65535).

Jira: OS-472

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `event-agent`

##### SDS VERSION

```
openio 4.8.2.dev13
```