### PR TITLE
xcute: Improve job information display

### DIFF
--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -659,6 +659,8 @@ class XcuteBackend(RedisConnection):
                 job_info[split_key[0]][split_key[1]] = value
 
         job_main_info = job_info['job']
+        job_main_info['ctime'] = float(job_main_info['ctime'])
+        job_main_info['mtime'] = float(job_main_info['mtime'])
         job_main_info['request_pause'] = true_value(
             job_main_info['request_pause'])
 


### PR DESCRIPTION
##### SUMMARY

Improve job information display

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- `xcute`

##### SDS VERSION

```
openio 5.2.5.dev124
```

##### ADDITIONAL INFORMATION

```
$ openio-admin xcute job show 20200107131129138805-7cd19983bb0
+--------------------------------+----------------------------------+
| Field                          | Value                            |
+--------------------------------+----------------------------------+
| config.params.end              | 10000                            |
| config.params.error_percentage | 0                                |
| config.params.start            | 0                                |
| config.tasks_batch_size        | 32                               |
| config.tasks_per_second        | 32                               |
| errors.total                   | 0                                |
| job.ctime                      | 1578402689.14                    |
| job.duration                   | 12.2709701061                    |
| job.id                         | 20200107131129138805-7cd19983bb0 |
| job.mtime                      | 1578402701.41                    |
| job.status                     | RUNNING                          |
| job.type                       | tester                           |
| results.counter                | 3346                             |
| tasks.processed                | 384                              |
| tasks.processed_per_second     | 31.2933693652                    |
| tasks.processed_percent        | 3.84                             |
| tasks.sent                     | 416                              |
| tasks.sent_percent             | 4.16                             |
| tasks.total                    | 10000 (estimated)                |
+--------------------------------+----------------------------------+
$ openio-admin xcute job show 20200107131129138805-7cd19983bb0 --raw
+--------------------------------+----------------------------------+
| Field                          | Value                            |
+--------------------------------+----------------------------------+
| config.params.end              | 10000                            |
| config.params.error_percentage | 0                                |
| config.params.start            | 0                                |
| config.tasks_batch_size        | 32                               |
| config.tasks_per_second        | 32                               |
| errors.total                   | 0                                |
| job.ctime                      | 1578402689.14                    |
| job.id                         | 20200107131129138805-7cd19983bb0 |
| job.mtime                      | 1578402704.41                    |
| job.request_pause              | False                            |
| job.status                     | RUNNING                          |
| job.type                       | tester                           |
| orchestrator.id                | orchestrator-1                   |
| results.counter                | 4210                             |
| tasks.all_sent                 | False                            |
| tasks.is_total_temp            | False                            |
| tasks.last_sent                | 511                              |
| tasks.processed                | 480                              |
| tasks.sent                     | 512                              |
| tasks.total                    | 10000                            |
| tasks.total_marker             | 9999                             |
+--------------------------------+----------------------------------+
```