### PR TITLE
CLI: check peer count before actually rebalancing meta1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ openio.rdir =
     rdir_assignments = oio.cli.rdir.rdir:RdirAssignments
 openio.directory =
     directory_bootstrap = oio.cli.directory.directory:DirectoryInit
+    directory_check = oio.cli.directory.directory:DirectoryCheck
     directory_decommission = oio.cli.directory.directory:DirectoryDecommission
     directory_dump = oio.cli.directory.directory:DirectoryList
     directory_rebalance = oio.cli.directory.directory:DirectoryRebalance


### PR DESCRIPTION
##### SUMMARY
During a rebalance operation, check each reference prefix is managed by the right number of meta1 services.

Also implement a new 'openio directory check' command, checking each reference prefix is managed by the right number of meta1 services. This complements 'openio-admin directory check' (which does not check this number).

Jira: OS-470

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 5.3.0.dev3
```


##### ADDITIONAL INFORMATION
