### PR TITLE
xcute: locks feature

### DIFF
--- a/oio/cli/admin/xcute/lock.py
+++ b/oio/cli/admin/xcute/lock.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from oio.cli import Lister
+from operator import itemgetter
+
+from oio.cli import Lister, ShowOne
 from oio.cli.admin.xcute import XcuteCommand
 
 
@@ -22,14 +24,35 @@ class LockList(XcuteCommand, Lister):
     List all locks.
     """
 
-    columns = ('Lock',)
+    columns = ('Lock', 'Job ID')
 
     def _take_action(self, parsed_args):
         locks = self.xcute.lock_list()
         for lock in locks:
-            yield (lock,)
+            yield itemgetter('lock', 'job_id')(lock)
 
     def take_action(self, parsed_args):
         self.logger.debug('take_action(%s)', parsed_args)
 
         return self.columns, self._take_action(parsed_args)
+
+
+class LockShow(XcuteCommand, ShowOne):
+    """
+    Get all information about one lock.
+    """
+
+    def get_parser(self, prog_name):
+        parser = super(LockShow, self).get_parser(prog_name)
+        parser.add_argument(
+            'lock',
+            metavar='<lock>',
+            help=("Lock to show"))
+        return parser
+
+    def take_action(self, parsed_args):
+        self.logger.debug('take_action(%s)', parsed_args)
+
+        lock_info = self.xcute.lock_show(parsed_args.lock)
+
+        return [('lock', 'job_id'), itemgetter('lock', 'job_id')(lock_info)]

--- a/oio/cli/admin/xcute/lock.py
+++ b/oio/cli/admin/xcute/lock.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2019 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from oio.cli import Lister
+from oio.cli.admin.xcute import XcuteCommand
+
+
+class LockList(XcuteCommand, Lister):
+    """
+    List all locks.
+    """
+
+    columns = ('Lock',)
+
+    def _take_action(self, parsed_args):
+        locks = self.xcute.lock_list()
+        for lock in locks:
+            yield (lock,)
+
+    def take_action(self, parsed_args):
+        self.logger.debug('take_action(%s)', parsed_args)
+
+        return self.columns, self._take_action(parsed_args)

--- a/oio/xcute/client.py
+++ b/oio/xcute/client.py
@@ -134,3 +134,8 @@ class XcuteClient(HttpApi):
         _, data = self.xcute_request(
             'GET', '/lock/list')
         return data
+
+    def lock_show(self, lock):
+        _, data = self.xcute_request(
+            'GET', '/lock/show', params={'lock': lock})
+        return data

--- a/oio/xcute/client.py
+++ b/oio/xcute/client.py
@@ -129,3 +129,8 @@ class XcuteClient(HttpApi):
     def job_delete(self, job_id):
         self.xcute_request(
             'DELETE', '/job/delete', params={'id': job_id})
+
+    def lock_list(self):
+        _, data = self.xcute_request(
+            'GET', '/lock/list')
+        return data

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -49,6 +49,9 @@ class XcuteBackend(RedisConnection):
         'job_exists': (
             Forbidden,
             'The job already exists'),
+        'lock_exists': (
+            Forbidden,
+            'A job with the same lock is already in progress'),
         'no_job': (
             NotFound,
             'The job does\'nt exist'),
@@ -90,11 +93,19 @@ class XcuteBackend(RedisConnection):
         local job_id = KEYS[2];
         local job_type = KEYS[3];
         local job_config = KEYS[4];
+        local lock = KEYS[5];
 
         local job_exists = redis.call('EXISTS', 'xcute:job:info:' .. job_id);
         if job_exists == 1 then
             return redis.error_reply('job_exists');
         end;
+
+        local lock_exists = redis.call('ZRANK', 'xcute:locks', lock);
+        if lock_exists ~= false then
+            return redis.error_reply('lock_exists');
+        end;
+
+        redis.call('ZADD', 'xcute:locks', 0, lock);
 
         redis.call('ZADD', 'xcute:job:ids', 0, job_id);
         redis.call(
@@ -103,6 +114,7 @@ class XcuteBackend(RedisConnection):
             'job.type', job_type,
             'job.status', 'WAITING',
             'job.request_pause', 'False',
+            'job.lock', lock,
             'tasks.all_sent', 'False',
             'tasks.sent', '0',
             'tasks.processed', '0',
@@ -158,8 +170,10 @@ class XcuteBackend(RedisConnection):
         local mtime = KEYS[1];
         local job_id = KEYS[2];
 
-        local status = redis.call('HGET', 'xcute:job:info:' .. job_id,
-                                  'job.status');
+        local info = redis.call('HMGET', 'xcute:job:info:' .. job_id,
+                                'job.status', 'job.lock');
+        local status = info[1];
+        local lock = info[2];
         if status == nil or status == false then
             return redis.error_reply('no_job');
         end;
@@ -170,6 +184,7 @@ class XcuteBackend(RedisConnection):
 
         redis.call('HSET', 'xcute:job:info:' .. job_id,
                    'job.status', 'FAILED');
+        redis.call('ZREM', 'xcute:locks', lock);
         -- remove the job of the orchestrator
         local orchestrator_id = redis.call(
             'HGET', 'xcute:job:info:' .. job_id, 'orchestrator.id');
@@ -272,8 +287,9 @@ class XcuteBackend(RedisConnection):
         local tasks_sent_length = #tasks_sent;
         local info_key = 'xcute:job:info:' .. job_id;
 
-        local status = redis.call('HGET', info_key,
-                                  'job.status');
+        local info = redis.call('HMGET', info_key, 'job.status', 'job.lock');
+        local status = info[1];
+        local lock = info[2];
         if status == nil or status == false then
             return redis.error_reply('no_job');
         end;
@@ -307,6 +323,7 @@ class XcuteBackend(RedisConnection):
                     total_tasks_sent) then
                 redis.call('HSET', 'xcute:job:info:' .. job_id,
                            'job.status', 'FINISHED');
+                redis.call('ZREM', 'xcute:locks', lock);
             end;
         else
             local request_pause = redis.call(
@@ -341,8 +358,10 @@ class XcuteBackend(RedisConnection):
         local counters = get_counters(KEYS, 3, nil);
         local tasks_processed = ARGV;
 
-        local status = redis.call('HGET', 'xcute:job:info:' .. job_id,
-                                  'job.status');
+        local info = redis.call('HMGET', 'xcute:job:info:' .. job_id,
+                                'job.status', 'job.lock');
+        local status = info[1];
+        local lock = info[2];
         if status == nil or status == false then
             return redis.error_reply('no_job');
         end;
@@ -368,6 +387,7 @@ class XcuteBackend(RedisConnection):
                     total_tasks_sent) then
                 redis.call('HSET', 'xcute:job:info:' .. job_id,
                            'job.status', 'FINISHED');
+                redis.call('ZREM', 'xcute:locks', lock);
                 finished = true;
             end;
         end;
@@ -428,8 +448,10 @@ class XcuteBackend(RedisConnection):
     lua_delete = """
         local job_id = KEYS[1];
 
-        local status = redis.call('HGET', 'xcute:job:info:' .. job_id,
-                                  'job.status');
+        local info = redis.call('HMGET', 'xcute:job:info:' .. job_id,
+                                'job.status', 'job.lock');
+        local status = info[1];
+        local lock = info[2];
         if status == nil or status == false then
             return redis.error_reply('no_job');
         end;
@@ -445,6 +467,7 @@ class XcuteBackend(RedisConnection):
         redis.call('ZREM', 'xcute:job:ids', job_id);
         redis.call('DEL', 'xcute:job:info:' .. job_id);
         redis.call('DEL', 'xcute:tasks:running:' .. job_id);
+        redis.call('ZREM', 'xcute:locks', lock);
         """
 
     def __init__(self, conf, logger=None):
@@ -522,14 +545,14 @@ class XcuteBackend(RedisConnection):
         return Timestamp().normal
 
     @handle_redis_exceptions
-    def create(self, job_type, job_config):
+    def create(self, job_type, job_config, lock):
         job_id = datetime.utcnow().strftime('%Y%m%d%H%M%S%f') \
             + '-%011x' % random.randrange(16**11)
 
         job_config = json.dumps(job_config)
 
         self.script_create(
-            keys=[self._get_timestamp(), job_id, job_type, job_config],
+            keys=[self._get_timestamp(), job_id, job_type, job_config, lock],
             client=self.conn)
         return job_id
 

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -33,11 +33,15 @@ def handle_redis_exceptions(func):
         try:
             return func(self, *args, **kwargs)
         except redis.exceptions.ResponseError as exc:
-            error = self._lua_errors.get(str(exc))
+            error_parts = exc.message.split(':')
+            error_type = error_parts[0]
+            error_params = error_parts[1:]
+
+            error = self._lua_errors.get(error_type)
             if error is None:
                 raise
             error_cls, error_msg = error
-            raise error_cls(message=error_msg)
+            raise error_cls(message=error_msg.format(*error_params))
     return handle_redis_exceptions
 
 
@@ -51,7 +55,7 @@ class XcuteBackend(RedisConnection):
             'The job already exists'),
         'lock_exists': (
             Forbidden,
-            'A job with the same lock is already in progress'),
+            'A job with the same lock ({}) is already in progress'),
         'no_job': (
             NotFound,
             'The job does\'nt exist'),
@@ -101,12 +105,12 @@ class XcuteBackend(RedisConnection):
             return redis.error_reply('job_exists');
         end;
 
-        local lock_exists = redis.call('ZRANK', 'xcute:locks', lock);
-        if lock_exists ~= false then
-            return redis.error_reply('lock_exists');
+        local lock_exists = redis.call('HEXISTS', 'xcute:locks', lock);
+        if lock_exists ~= 0 then
+            return redis.error_reply('lock_exists:' .. lock);
         end;
 
-        redis.call('ZADD', 'xcute:locks', 0, lock);
+        redis.call('HSET', 'xcute:locks', lock, job_id);
 
         redis.call('ZADD', 'xcute:job:ids', 0, job_id);
         redis.call(
@@ -185,7 +189,7 @@ class XcuteBackend(RedisConnection):
 
         redis.call('HSET', 'xcute:job:info:' .. job_id,
                    'job.status', 'FAILED');
-        redis.call('ZREM', 'xcute:locks', lock);
+        redis.call('HDEL', 'xcute:locks', lock);
         -- remove the job of the orchestrator
         local orchestrator_id = redis.call(
             'HGET', 'xcute:job:info:' .. job_id, 'orchestrator.id');
@@ -324,7 +328,7 @@ class XcuteBackend(RedisConnection):
                     total_tasks_sent) then
                 redis.call('HSET', 'xcute:job:info:' .. job_id,
                            'job.status', 'FINISHED');
-                redis.call('ZREM', 'xcute:locks', lock);
+                redis.call('HDEL', 'xcute:locks', lock);
             end;
         else
             local request_pause = redis.call(
@@ -388,7 +392,7 @@ class XcuteBackend(RedisConnection):
                     total_tasks_sent) then
                 redis.call('HSET', 'xcute:job:info:' .. job_id,
                            'job.status', 'FINISHED');
-                redis.call('ZREM', 'xcute:locks', lock);
+                redis.call('HDEL', 'xcute:locks', lock);
                 finished = true;
             end;
         end;
@@ -468,7 +472,7 @@ class XcuteBackend(RedisConnection):
         redis.call('ZREM', 'xcute:job:ids', job_id);
         redis.call('DEL', 'xcute:job:info:' .. job_id);
         redis.call('DEL', 'xcute:tasks:running:' .. job_id);
-        redis.call('ZREM', 'xcute:locks', lock);
+        redis.call('HDEL', 'xcute:locks', lock);
         """
 
     def __init__(self, conf, logger=None):
@@ -667,7 +671,18 @@ class XcuteBackend(RedisConnection):
 
     @handle_redis_exceptions
     def list_locks(self):
-        return self.conn.zrangebylex(self.key_locks, '-', '+')
+        locks = self.conn.hgetall(self.key_locks)
+
+        return [
+            dict(lock=lock[0], job_id=lock[1])
+            for lock in sorted(locks.items())
+        ]
+
+    @handle_redis_exceptions
+    def get_lock_info(self, lock):
+        job_id = self.conn.hget(self.key_locks, lock)
+
+        return dict(lock=lock, job_id=job_id)
 
     @staticmethod
     def _unmarshal_job_info(marshalled_job_info):

--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -83,6 +83,7 @@ class XcuteBackend(RedisConnection):
     key_waiting_jobs = 'xcute:waiting:jobs'
     key_tasks_running = 'xcute:tasks:running:%s'
     key_orchestrator_jobs = 'xcute:orchestrator:jobs:%s'
+    key_locks = 'xcute:locks'
 
     _lua_update_mtime = """
         redis.call('HSET', 'xcute:job:info:' .. job_id, 'job.mtime', mtime);
@@ -663,6 +664,10 @@ class XcuteBackend(RedisConnection):
 
     def _get_job_info(self, job_id, client):
         return client.hgetall(self.key_job_info % job_id)
+
+    @handle_redis_exceptions
+    def list_locks(self):
+        return self.conn.zrangebylex(self.key_locks, '-', '+')
 
     @staticmethod
     def _unmarshal_job_info(marshalled_job_info):

--- a/oio/xcute/jobs/tester.py
+++ b/oio/xcute/jobs/tester.py
@@ -60,6 +60,7 @@ class TesterJob(XcuteJob):
     DEFAULT_START = 0
     DEFAULT_END = 5
     DEFAULT_ERROR_PERCENTAGE = 0
+    DEFAULT_LOCK = 'tester_lock'
 
     @classmethod
     def sanitize_params(cls, job_params):
@@ -76,7 +77,7 @@ class TesterJob(XcuteJob):
             job_params.get('error_percentage'),
             cls.DEFAULT_ERROR_PERCENTAGE)
 
-        return sanitized_job_params, job_params.get('lock')
+        return sanitized_job_params, job_params.get('lock', cls.DEFAULT_LOCK)
 
     def get_tasks(self, job_params, marker=None):
         start = job_params['start']

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -90,7 +90,9 @@ class XcuteServer(WerkzeugApp):
                 Rule('/job/resume', endpoint='job_resume',
                      methods=['POST']),
                 Rule('/job/delete', endpoint='job_delete',
-                     methods=['DELETE'])
+                     methods=['DELETE']),
+                Rule('/lock/list', endpoint='lock_list',
+                     methods=['GET']),
             ])
         ])
 
@@ -167,6 +169,12 @@ class XcuteServer(WerkzeugApp):
         job_id = self._get_job_id(req)
         self.backend.delete(job_id)
         return Response(status=204)
+
+    @access_log
+    @handle_exceptions
+    def on_lock_list(self, req):
+        locks = self.backend.list_locks()
+        return Response(json.dumps(locks), mimetype='application/json')
 
 
 def create_app(conf):

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -121,11 +121,10 @@ class XcuteServer(WerkzeugApp):
         if job_class is None:
             raise HTTPBadRequest('Unknown job type')
 
-        # TODO: use lock
         job_config, lock = job_class.sanitize_config(
             json.loads(req.data or '{}'))
 
-        job_id = self.backend.create(job_type, job_config)
+        job_id = self.backend.create(job_type, job_config, lock)
         job_info = self.backend.get_job_info(job_id)
         return Response(
             json.dumps(job_info), mimetype='application/json', status=202)

--- a/oio/xcute/server.py
+++ b/oio/xcute/server.py
@@ -93,6 +93,8 @@ class XcuteServer(WerkzeugApp):
                      methods=['DELETE']),
                 Rule('/lock/list', endpoint='lock_list',
                      methods=['GET']),
+                Rule('/lock/show', endpoint='lock_show',
+                     methods=['GET']),
             ])
         ])
 
@@ -175,6 +177,15 @@ class XcuteServer(WerkzeugApp):
     def on_lock_list(self, req):
         locks = self.backend.list_locks()
         return Response(json.dumps(locks), mimetype='application/json')
+
+    @access_log
+    @handle_exceptions
+    def on_lock_show(self, req):
+        lock = req.args.get('lock')
+        if not lock:
+            raise HTTPBadRequest('Missing lock')
+        lock_info = self.backend.get_lock_info(lock)
+        return Response(json.dumps(lock_info), mimetype='application/json')
 
 
 def create_app(conf):

--- a/setup.cfg
+++ b/setup.cfg
@@ -196,9 +196,10 @@ openio.admin =
     xcute_job_pause = oio.cli.admin.xcute.job:JobPause
     xcute_job_resume = oio.cli.admin.xcute.job:JobResume
     xcute_job_show = oio.cli.admin.xcute.job:JobShow
+    xcute_lock_list = oio.cli.admin.xcute.lock:LockList
+    xcute_lock_show = oio.cli.admin.xcute.lock:LockShow
     xcute_rawx_decommission = oio.cli.admin.xcute.rawx:RawxDecommission
     xcute_rawx_rebuild = oio.cli.admin.xcute.rawx:RawxRebuild
-    xcute_lock_list = oio.cli.admin.xcute.lock:LockList
 
 oio.conscience.checker =
     asn1 = oio.conscience.checker.asn1:Asn1PingChecker

--- a/setup.cfg
+++ b/setup.cfg
@@ -198,6 +198,7 @@ openio.admin =
     xcute_job_show = oio.cli.admin.xcute.job:JobShow
     xcute_rawx_decommission = oio.cli.admin.xcute.rawx:RawxDecommission
     xcute_rawx_rebuild = oio.cli.admin.xcute.rawx:RawxRebuild
+    xcute_lock_list = oio.cli.admin.xcute.lock:LockList
 
 oio.conscience.checker =
     asn1 = oio.conscience.checker.asn1:Asn1PingChecker


### PR DESCRIPTION
##### SUMMARY
Add a lock system to xcute to avoid collisions between jobs.
Each job type defines its lock based on its parameters. The lock is taken when the job is created, and released when it finishes or fails.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
xcute


##### ADDITIONAL INFORMATION
Results of the CLI commands:
```
(venv) openio@f12651ea56b2:/tmp/src/oio-sds$ openio-admin xcute lock list
+------+----------------------------------+
| Lock | Job ID                           |
+------+----------------------------------+
| a    | 20200120074545861743-802a3d50197 |
| aa   | 20200120074838579195-f4d429568d3 |
| abb  | 20200120074937560447-51af50063c5 |
| b    | 20200120074547476397-d5c7e58d0af |
+------+----------------------------------+
(venv) openio@f12651ea56b2:/tmp/src/oio-sds$ openio-admin xcute lock show abb
+--------+----------------------------------+
| Field  | Value                            |
+--------+----------------------------------+
| lock   | abb                              |
| job_id | 20200120074937560447-51af50063c5 |
+--------+----------------------------------+
```

Error message when trying to create a job which lock is already taken:

```
jcurl -s localhost:8002/v1.0/xcute/job/create\?type=tester -d '{"tasks_per_second": 1, "params": {"end": 100, "lock
": "aab"}}'
A job with the same lock (aab) is already in progress
```
