### PR TITLE
Pass options for `ca_certs` and `cert_reqs`

### DIFF
--- a/oio/api/base.py
+++ b/oio/api/base.py
@@ -20,19 +20,12 @@ from oio.common.easy_value import true_value
 from oio.common.json import json as jsonlib
 
 from oio.common.http_urllib3 import urllib3, get_pool_manager, \
-    oio_exception_from_httperror
+    oio_exception_from_httperror, URLLIB3_REQUESTS_KWARGS
 from oio.common import exceptions
 from oio.common.utils import deadline_to_timeout, monotonic_time
 from oio.common.constants import ADMIN_HEADER, \
     TIMEOUT_HEADER, PERFDATA_HEADER, FORCEMASTER_HEADER, \
     CONNECTION_TIMEOUT, READ_TIMEOUT, REQID_HEADER, STRLEN_REQID
-
-_POOL_MANAGER_OPTIONS_KEYS = ["pool_connections", "pool_maxsize",
-                              "max_retries"]
-
-URLLIB3_REQUESTS_KWARGS = ('fields', 'headers', 'body', 'retries', 'redirect',
-                           'assert_same_host', 'timeout', 'pool_timeout',
-                           'release_conn', 'chunked')
 
 
 class HttpApi(object):
@@ -61,10 +54,8 @@ class HttpApi(object):
         self.endpoint = endpoint
 
         if not pool_manager:
-            pool_manager_conf = {k: int(v)
-                                 for k, v in iteritems(kwargs)
-                                 if k in _POOL_MANAGER_OPTIONS_KEYS}
-            pool_manager = get_pool_manager(**pool_manager_conf)
+            # get_pool_manager filters its args
+            pool_manager = get_pool_manager(**kwargs)
         self.pool_manager = pool_manager
 
         self.admin_mode = true_value(kwargs.get('admin_mode', False))

--- a/oio/cli/common/clientmanager.py
+++ b/oio/cli/common/clientmanager.py
@@ -179,8 +179,8 @@ class ClientManager(object):
     def pool_manager(self):
         if self._pool_manager is None:
             from oio.common.http_urllib3 import get_pool_manager
-            # TODO(FVE): load parameters from self._options or self.ns_conf
-            self._pool_manager = get_pool_manager()
+            # get_pool_manager already filters arguments it cares about
+            self._pool_manager = get_pool_manager(**self._options)
         return self._pool_manager
 
     @property

--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -60,12 +60,15 @@ class ProxyClient(HttpApi):
             endpoint = self.conf.get('proxyd_url', None)
 
         ep_parts = list()
+        self.proxy_scheme = 'http'
         if endpoint:
-            self.proxy_netloc = endpoint.lstrip("http://")
+            if endpoint.startswith('https://'):
+                self.proxy_scheme = 'https'
+            self.proxy_netloc = endpoint.lstrip('%s://' % self.proxy_scheme)
         else:
             ns_conf = load_namespace_conf(self.ns)
             self.proxy_netloc = ns_conf.get('proxy')
-        ep_parts.append("http:/")
+        ep_parts.append('%s:/' % self.proxy_scheme)
         ep_parts.append(self.proxy_netloc)
 
         ep_parts.append("v3.0")

--- a/oio/common/http_urllib3.py
+++ b/oio/common/http_urllib3.py
@@ -33,12 +33,10 @@ URLLIB3_REQUESTS_KWARGS = ('fields', 'headers', 'body', 'retries', 'redirect',
                            'assert_same_host', 'timeout', 'pool_timeout',
                            'release_conn', 'chunked')
 URLLIB3_POOLMANAGER_KWARGS = (
-    # Integers
+    # default values overriden by get_pool_manager
     'pool_connections', 'pool_maxsize', 'max_retries', 'backoff_factor',
-    # List or tuple
-    'socket_options',
-    # Tuple
-    'source_address'
+    # passed directly to SafePoolManager's init
+    'socket_options', 'source_address', 'cert_reqs', 'ca_certs'
 )
 
 

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -113,7 +113,8 @@ class ContainerClient(ProxyClient):
         Build URIs for request that don't use the same prefix as the one
         set in this class' constructor.
         """
-        uri = 'http://%s/v3.0/%s/%s' % (self.proxy_netloc, self.ns, target)
+        uri = '%s://%s/v3.0/%s/%s' % (self.proxy_scheme, self.proxy_netloc,
+                                      self.ns, target)
         return uri
 
     def _make_params(self, account=None, reference=None, path=None, cid=None,


### PR DESCRIPTION
##### SUMMARY
urllib3 request pool does not validate server certificate by default for https connections until version 1.25 (at which point we would want to specify ca_certs anyway)

This just allows infrastructure to pass the option through and add `ca_certs` and `cert_reqs` to parameter whitelist.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
common?

##### ADDITIONAL INFORMATION
This builds on top of #1948, so should only be merged after that.
There is no way to do https without anyway so it won't be missed :)

(also note I didn't test the api/base part as gateway swift only uses ClientManager, but figured I might as well try that..)