### PR TITLE
xcute: fix total tasks estimation for the blob mover

### DIFF
--- a/oio/xcute/jobs/blob_mover.py
+++ b/oio/xcute/jobs/blob_mover.py
@@ -231,7 +231,7 @@ class RawxDecommissionJob(XcuteJob):
                 yield ('|'.join((container_id, content_id, chunk_id)),
                        int(math.ceil(1000 * kept_chunks_ratio)))
 
-        remaining = int(math.ceil(i * kept_chunks_ratio))
+        remaining = int(math.ceil(i % 1000 * kept_chunks_ratio))
         if remaining > 0:
             yield '|'.join((container_id, content_id, chunk_id)), remaining
 


### PR DESCRIPTION
##### SUMMARY
The total task estimation for the xcute task blob mover is approximately twice what it should be.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
xcute