### PR TITLE
meta1: Fix behavior when reference property with empty value is set

### DIFF
--- a/tests/functional/api/test_directory.py
+++ b/tests/functional/api/test_directory.py
@@ -225,6 +225,15 @@ class TestDirectoryAPI(BaseTestCase):
         data = self._get_properties(name)
         self.assertEqual(data['properties'], metadata)
 
+        # set_properties overwrite key with empty value
+        key = metadata.keys().pop(0)
+        metadata4 = {key: ''}
+
+        del metadata[key]
+        self.api.set_properties(self.account, name, metadata4)
+        data = self._get_properties(name)
+        self.assertEqual(data['properties'], metadata)
+
         # clean
         self._clean(name, True)
 


### PR DESCRIPTION
##### SUMMARY

Fix behavior when reference property with empty value is set

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `meta1`

##### SDS VERSION

```
openio 5.3.0.0b1.dev7
```