### PR TITLE
Avoid prefixing http path if / is already set

### DIFF
--- a/oio/common/http_eventlet.py
+++ b/oio/common/http_eventlet.py
@@ -108,7 +108,10 @@ def http_connect(host, method, path, headers=None, query_string=None):
             path = path.encode('utf-8')
         except UnicodeError as e:
             logger.exception('ERROR encoding to UTF-8: %s', text_type(e))
-    path = quote(b'/' + path)
+    if path.startswith(b'/'):
+        path = quote(path)
+    else:
+        path = quote(b'/' + path)
     conn = CustomHttpConnection(host)
     if query_string:
         path += b'?' + query_string


### PR DESCRIPTION
##### SUMMARY

When a HTTP request is made from Python API, path is always prefixed by `/`:
it has raised an issue when adding package prometheus into rawx where the request
returns a 301 with proper path.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Python internals

##### SDS VERSION
```
master
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
