### PR TITLE
Fix lock deletion on job deletion

### DIFF
--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -473,7 +473,12 @@ class XcuteBackend(RedisConnection):
         redis.call('ZREM', 'xcute:job:ids', job_id);
         redis.call('DEL', 'xcute:job:info:' .. job_id);
         redis.call('DEL', 'xcute:tasks:running:' .. job_id);
-        redis.call('HDEL', 'xcute:locks', lock);
+
+        local lock_job_id = redis.call('HGET', 'xcute:locks', lock);
+
+        if lock_job_id == job_id then
+            redis.call('HDEL', 'xcute:locks', lock);
+        end;
         """
 
     def __init__(self, conf, logger=None):


### PR DESCRIPTION
##### SUMMARY
When deleting an xcute job, we were deleting its associated lock without checking that the lock was actually held by that job. If a running job had the same associated lock, the lock would wrongly be deleted.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
xcute
