### PR TITLE
proxy: Get the score of a single service registered in ConsciousGrid

### DIFF
--- a/proxy/actions.h
+++ b/proxy/actions.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS proxy
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -54,6 +54,7 @@ enum http_rc_e action_local_list (struct req_args_s *args);
 
 enum http_rc_e action_conscience_info (struct req_args_s *args);
 enum http_rc_e action_conscience_list (struct req_args_s *args);
+enum http_rc_e action_conscience_score (struct req_args_s *args);
 enum http_rc_e action_conscience_register (struct req_args_s *args);
 enum http_rc_e action_conscience_deregister (struct req_args_s *args);
 enum http_rc_e action_conscience_flush (struct req_args_s *args);

--- a/proxy/metacd_http.c
+++ b/proxy/metacd_http.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS proxy
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -1014,6 +1014,7 @@ configure_request_handlers (void)
 	// Conscience
 	SET("/$NS/conscience/info/#GET", action_conscience_info);
 	SET("/$NS/conscience/list/#GET", action_conscience_list);
+	SET("/$NS/conscience/score/#GET", action_conscience_score);
 	SET("/$NS/conscience/register/#POST", action_conscience_register);
 	SET("/$NS/conscience/deregister/#POST", action_conscience_deregister);
 	SET("/$NS/conscience/flush/#POST", action_conscience_flush);

--- a/tests/functional/conscience/test_conscience.py
+++ b/tests/functional/conscience/test_conscience.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
##### SUMMARY
Provide a route to get the score of a single service in `oio-proxy`.

```
# curl -qs 'http://127.0.0.1:6000/v3.0/OPENIO/conscience/score?type=rawx&service_id=127.0.0.1:6010' | python2 -m json.tool
{
    "addr": "127.0.0.1:6010",
    "score": 45
}

```
##### ISSUE TYPE
enhancement

##### COMPONENT NAME
oio-proxy

##### SDS VERSION
`openio 5.3.0.0b1.dev31`
