### PR TITLE
Python API: Allow to cache object metadata and location

### DIFF
--- a/oio/common/cache.py
+++ b/oio/common/cache.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2020 OpenIO SAS, as part of OpenIO SDS
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+from oio.common.utils import cid_from_name
+
+
+def _get_metadata_cache_key(account=None, reference=None, path=None, cid=None):
+    if not path:
+        raise ValueError('Missing object name to use the cache')
+    cid = cid or cid_from_name(account, reference)
+    cid = cid.upper()
+    return '/'.join(("meta", cid, path))
+
+
+def get_cached_metadata(account=None, reference=None, path=None, cid=None,
+                        version=None, properties=False, cache=None, **kwargs):
+    """
+    Get the object metadata and location from the cache (if there is one)
+    """
+    if cache is None or version:
+        # Cache isn't compatible with versionning
+        return None, None
+
+    cache_key = _get_metadata_cache_key(
+        account=account, reference=reference, path=path, cid=cid)
+    cache_value = cache.get(cache_key)
+    if cache_value is None:
+        return None, None
+
+    content_meta = cache_value.get('meta')
+    if content_meta is None:
+        return None, None
+    if properties:
+        content_properties = cache_value.get('properties')
+        if content_properties is None:
+            return None, None
+        content_meta = content_meta.copy()
+        content_meta['properties'] = content_properties
+    content_chunks = cache_value.get('chunks')
+    return content_meta, content_chunks
+
+
+def set_cached_metadata(content_meta, content_chunks,
+                        account=None, reference=None, path=None, cid=None,
+                        version=None, properties=False, cache=None, **kwargs):
+    """
+    Set the object metadata and location in the cache (if there is one)
+    """
+    if cache is None or version:
+        # Cache isn't compatible with versionning
+        return
+
+    if content_meta is None:
+        return
+    cache_value = dict()
+    content_meta = content_meta.copy()
+    if properties:
+        cache_value['properties'] = content_meta['properties']
+    content_meta['properties'] = dict()
+    cache_value['meta'] = content_meta
+    if content_chunks is not None:
+        cache_value['chunks'] = content_chunks
+
+    cache_key = _get_metadata_cache_key(
+        account=account, reference=reference, path=path, cid=cid)
+    cache[cache_key] = cache_value
+
+
+def del_cached_metadata(account=None, reference=None, path=None, cid=None,
+                        version=None, cache=None, **kwargs):
+    """
+    Delete the object metadata and location from the cache (if there is one)
+    """
+    if cache is None:
+        return
+
+    cache_key = _get_metadata_cache_key(
+        account=account, reference=reference, path=path, cid=cid)
+    try:
+        del cache[cache_key]
+    except KeyError:
+        pass

--- a/oio/common/storage_functions.py
+++ b/oio/common/storage_functions.py
@@ -235,7 +235,16 @@ def fetch_stream_ec(chunks, ranges, storage_method, **kwargs):
             handler = ECChunkDownloadHandler(
                 storage_method, chunks[pos],
                 meta_start, meta_end, **kwargs)
-            stream = handler.get_stream()
+            try:
+                stream = handler.get_stream()
+            except exc.NotFound as err:
+                raise exc.UnrecoverableContent(
+                    "Cannot download position %d: %s" %
+                    (pos, err))
+            except Exception as err:
+                raise exc.ServiceUnavailable(
+                    "Error while downloading position %d: %s" %
+                    (pos, err))
             try:
                 for part_info in stream:
                     for dat in part_info['iter']:

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2016-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,6 +14,7 @@
 # License along with this library.
 
 
+import copy
 import logging
 import time
 from mock import MagicMock as Mock
@@ -1371,13 +1372,15 @@ class TestObjectStorageApi(ObjectStorageApiTestBase):
             _, chunks_copies = self.api.object_locate(self.account, snapshot,
                                                       test_object % i)
 
-            for chunk, copy in zip(sorted(chunks), sorted(chunks_copies)):
+            for chunk, chunk_copy in zip(sorted(chunks),
+                                         sorted(chunks_copies)):
                 # check that every chunk is different from the target
-                self.assertNotEqual(chunk['url'], copy['url'])
+                self.assertNotEqual(chunk['url'], chunk_copy['url'])
 
                 # check the metadata
                 meta = self.api._blob_client.chunk_head(chunk['url'])
-                meta_copies = self.api._blob_client.chunk_head(copy['url'])
+                meta_copies = self.api._blob_client.chunk_head(
+                    chunk_copy['url'])
 
                 fullpath = encode_fullpath(
                     self.account, snapshot, test_object % i,
@@ -1821,3 +1824,178 @@ class TestObjectList(ObjectStorageApiTestBase):
         props = self.api.object_get_properties(self.account, name, name)
         self.assertEqual(metadata['version'], props['version'])
         self.assertEqual(int(props['length']), size)
+
+
+class TestObjectStorageApiUsingCache(ObjectStorageApiTestBase):
+
+    def setUp(self):
+        super(TestObjectStorageApiUsingCache, self).setUp()
+        self.cache = dict()
+        self.api = ObjectStorageApi(self.ns, endpoint=self.uri,
+                                    cache=self.cache)
+
+        self.container = random_str(8)
+        self.path = random_str(8)
+        self.api.object_create(self.account, self.container,
+                               obj_name=self.path, data='cache')
+        self.created.append((self.container, self.path))
+        self.assertEqual(0, len(self.cache))
+
+        self.api.container._direct_request = Mock(
+            side_effect=self.api.container._direct_request)
+
+    def tearDown(self):
+        super(TestObjectStorageApiUsingCache, self).tearDown()
+        self.assertEqual(0, len(self.cache))
+
+    def test_object_properties(self):
+        expected_obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertIsNotNone(expected_obj_meta)
+        expected_obj_meta = expected_obj_meta.copy()
+        self.assertEqual(1, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(1, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        properties = {'test1': '1', 'test2': '2'}
+        self.api.object_set_properties(
+            self.account, self.container, self.path, properties)
+        self.assertEqual(2, self.api.container._direct_request.call_count)
+        self.assertEqual(0, len(self.cache))
+
+        expected_obj_meta['properties'] = properties
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        self.api.object_del_properties(
+            self.account, self.container, self.path, properties.keys())
+        self.assertEqual(4, self.api.container._direct_request.call_count)
+        self.assertEqual(0, len(self.cache))
+
+        expected_obj_meta['properties'] = dict()
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(5, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(5, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+    def test_object_locate(self):
+        properties = {'test1': '1', 'test2': '2'}
+        self.api.object_set_properties(
+            self.account, self.container, self.path, properties)
+        self.assertEqual(1, self.api.container._direct_request.call_count)
+        self.assertEqual(0, len(self.cache))
+
+        expected_obj_meta, expected_chunks = self.api.object_locate(
+            self.account, self.container, self.path, properties=False)
+        self.assertIsNotNone(expected_obj_meta)
+        self.assertIsNotNone(expected_chunks)
+        expected_obj_meta = expected_obj_meta.copy()
+        expected_chunks = copy.deepcopy(expected_chunks)
+        self.assertEqual(2, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta, chunks = self.api.object_locate(
+            self.account, self.container, self.path, properties=False)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertListEqual(expected_chunks, chunks)
+        self.assertEqual(2, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        expected_obj_meta['properties'] = properties
+        obj_meta, chunks = self.api.object_locate(
+            self.account, self.container, self.path, properties=True)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertListEqual(expected_chunks, chunks)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta, chunks = self.api.object_locate(
+            self.account, self.container, self.path, properties=True)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertListEqual(expected_chunks, chunks)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        expected_obj_meta['properties'] = dict()
+        obj_meta, chunks = self.api.object_locate(
+            self.account, self.container, self.path, properties=False)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertListEqual(expected_chunks, chunks)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        expected_obj_meta['properties'] = properties
+        obj_meta = self.api.object_get_properties(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+    def test_object_fetch(self):
+        expected_obj_meta, stream = self.api.object_fetch(
+            self.account, self.container, self.path)
+        self.assertIsNotNone(expected_obj_meta)
+        data = b''
+        for chunk in stream:
+            data += chunk
+        self.assertEqual('cache', data)
+        self.assertEqual(1, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        obj_meta, stream = self.api.object_fetch(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        data = b''
+        for chunk in stream:
+            data += chunk
+        self.assertEqual('cache', data)
+        self.assertEqual(1, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+
+        # Make the cache invalid
+        self.api.object_delete(
+            self.account, self.container, self.path, cache=None)
+        self.assertEqual(2, self.api.container._direct_request.call_count)
+        self.assertEqual(1, len(self.cache))
+        self.wait_for_event(
+            'oio-preserved', types=[EventTypes.CONTENT_DELETED])
+
+        obj_meta, stream = self.api.object_fetch(
+            self.account, self.container, self.path)
+        self.assertDictEqual(expected_obj_meta, obj_meta)
+        try:
+            data = b''
+            for chunk in stream:
+                data += chunk
+            self.fail('This should not happen with the deleted chunks')
+        except exc.UnrecoverableContent:
+            pass
+        self.assertEqual(2, self.api.container._direct_request.call_count)
+        self.assertEqual(0, len(self.cache))
+
+        self.assertRaises(
+            exc.NoSuchObject, self.api.object_fetch,
+            self.account, self.container, self.path)
+        self.assertEqual(3, self.api.container._direct_request.call_count)
+        self.assertEqual(0, len(self.cache))


### PR DESCRIPTION
##### SUMMARY

Allow to cache object metadata

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 4.8.3.dev5
```