### PR TITLE
rawx: ignore errors for few xattr

### DIFF
--- a/rawx/const.go
+++ b/rawx/const.go
@@ -156,3 +156,7 @@ const (
 	// How long (in seconds) might a connection stay idle (between two requests)
 	timeoutIdle = 3600
 )
+
+const (
+	ECMethodPrefix = "ec/"
+)


### PR DESCRIPTION
##### SUMMARY

When a chunk is uploaded in other storage_policy than EC,
the metachunk-size and metachunk-hash is no sent by client.

When rawx read this chunk, it complains about missing xattr.

This PR will ignore only these xattr.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rawx

##### SDS VERSION
```
master
```
