### PR TITLE
rawx: Implement a buffer cache to avoid GC complications

### DIFF
--- a/rawx/buffer_pool.go
+++ b/rawx/buffer_pool.go
@@ -1,0 +1,51 @@
+// OpenIO SDS Go rawx
+// Copyright (C) 2015-2019 OpenIO SAS
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+type bufferPool interface {
+	Acquire() []byte
+	Release(buf []byte)
+}
+
+type unisizeBufferPool struct {
+	pool chan []byte
+	size int
+}
+
+func newBufferPool(max, size int) bufferPool {
+	nb := max / size
+	if nb < 1 {
+		nb = 1
+	}
+	return &unisizeBufferPool{pool: make(chan []byte, nb), size: size}
+}
+
+func (p *unisizeBufferPool) Acquire() []byte {
+	select {
+	case buf := <-p.pool:
+		return buf[:cap(buf)]
+	default:
+		return make([]byte, p.size, p.size)
+	}
+}
+
+func (p *unisizeBufferPool) Release(buf []byte) {
+	select {
+	case p.pool <- buf: // reused
+	default: // freed
+	}
+}

--- a/rawx/chunk_info.go
+++ b/rawx/chunk_info.go
@@ -147,7 +147,9 @@ func (chunk *chunkInfo) loadFullPath(getter func(string, string) (string, error)
 }
 
 func (chunk *chunkInfo) loadAttr(inChunk fileReader, chunkID string) error {
-	buf := make([]byte, 2048, 2048)
+	buf := xattrBufferPool.Acquire()
+	defer xattrBufferPool.Release(buf)
+
 	getAttr := func(k string) (string, error) {
 		l, err := inChunk.getAttr(k, buf)
 		if l <= 0 || err != nil {

--- a/rawx/const.go
+++ b/rawx/const.go
@@ -97,7 +97,11 @@ const (
 
 const (
 	// Default size (in KiB) of the buffer allocated for the upload
+	// This value is in kiB becase it has the same precision the configuration.
 	uploadBufferDefault int = 2 * 1024
+
+	// Total amount (in bytes) of upload buffers kept in cache
+	uploadBufferTotalDefault = 128 * 1024 * 1024
 
 	// Size (in bytes) used as a threshold to allow read().
 	// In other words: we do not read() if the available space in the buffer is less than this value

--- a/rawx/const.go
+++ b/rawx/const.go
@@ -96,12 +96,17 @@ const (
 )
 
 const (
-	// Default size (in KiB) of the buffer allocated for the upload
-	// This value is in kiB becase it has the same precision the configuration.
-	uploadBufferDefault int = 2 * 1024
+	// Default size (in bytes) of each buffer allocated for xattr operations
+	xattrBufferSizeDefault = 2 * 1024
 
-	// Total amount (in bytes) of upload buffers kept in cache
-	uploadBufferTotalDefault = 128 * 1024 * 1024
+	// Total amount (in bytes) of buffers allocated for xattr operations
+	xattrBufferTotalSizeDefault = 256 * 1024
+
+	// Default size (in bytes) of each buffer allocated for the upload
+	uploadBufferSizeDefault = 2 * 1024 * 1024
+
+	// Total amount (in bytes) of buffers allocated for uploads
+	uploadBufferTotalSizeDefault = 128 * 1024 * 1024
 
 	// Size (in bytes) used as a threshold to allow read().
 	// In other words: we do not read() if the available space in the buffer is less than this value

--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -100,7 +100,6 @@ func copyReadWriteBuffer(dst io.Writer, src io.Reader, pool bufferPool) (written
 
 	for {
 		// Fill the buffer
-		buf = buf[:cap(buf)]
 		totalr, er := fillBuffer(src, buf)
 
 		// Dump the buffer

--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -94,9 +94,13 @@ func dumpBuffer(dst io.Writer, buf []byte) (written int, err error) {
 	return written, err
 }
 
-func copyReadWriteBuffer(dst io.Writer, src io.Reader, buf []byte) (written int64, err error) {
+func copyReadWriteBuffer(dst io.Writer, src io.Reader, pool bufferPool) (written int64, err error) {
+	buf := pool.Acquire()
+	defer pool.Release(buf)
+
 	for {
 		// Fill the buffer
+		buf = buf[:cap(buf)]
 		totalr, er := fillBuffer(src, buf)
 
 		// Dump the buffer
@@ -141,15 +145,13 @@ func (rr *rawxRequest) putData(out io.Writer) (uploadInfo, error) {
 	}
 
 	ul := uploadInfo{}
-	buffer := make([]byte, rr.rawx.bufferSize, rr.rawx.bufferSize)
-	chunkLength, err := copyReadWriteBuffer(out, in, buffer)
+	chunkLength, err := copyReadWriteBuffer(out, in, rr.rawx.uploadBufferPool)
 	if err != nil {
 		return ul, err
 	}
 
 	if h != nil {
-		bin := make([]byte, 0, 32)
-		ul.hash = strings.ToUpper(hex.EncodeToString(h.Sum(bin)))
+		ul.hash = strings.ToUpper(hex.EncodeToString(h.Sum(nil)))
 	}
 	ul.length = chunkLength
 	rr.bytesIn = uint64(chunkLength)
@@ -352,7 +354,9 @@ func (rr *rawxRequest) downloadChunk() {
 	// Check if there is some compression
 	in := io.LimitedReader{R: inChunk.File(), N: chunkSize}
 
-	buf := make([]byte, 32, 32)
+	buf := xattrBufferPool.Acquire()
+	defer xattrBufferPool.Release(buf)
+
 	if sz, err := inChunk.getAttr(AttrNameCompression, buf); err != nil {
 		// The range is easy to manage with non-compressed chunks
 		if !rangeInf.isVoid() {
@@ -394,7 +398,9 @@ func (rr *rawxRequest) downloadChunk() {
 }
 
 func (rr *rawxRequest) removeChunk() {
-	tmp := make([]byte, 2048, 2048)
+	tmp := xattrBufferPool.Acquire()
+	defer xattrBufferPool.Release(tmp)
+
 	getter := func(name, key string) (string, error) {
 		nb, err := rr.rawx.repo.getAttr(name, key, tmp)
 		if nb <= 0 || err != nil {

--- a/rawx/logger.go
+++ b/rawx/logger.go
@@ -112,10 +112,6 @@ func LogWarning(format string, v ...interface{}) {
 	writeLogFmt(syslog.LOG_WARNING, format, v...)
 }
 
-func LogNotice(format string, v ...interface{}) {
-	writeLogFmt(syslog.LOG_NOTICE, format, v...)
-}
-
 func LogInfo(format string, v ...interface{}) {
 	writeLogFmt(syslog.LOG_INFO, format, v...)
 }

--- a/rawx/main.go
+++ b/rawx/main.go
@@ -37,6 +37,8 @@ import (
 	"time"
 )
 
+var xattrBufferPool = newBufferPool(128*1024, 2048)
+
 func checkURL(url string) {
 	addr, err := net.ResolveTCPAddr("tcp", url)
 	if err != nil || addr.Port <= 0 {
@@ -166,6 +168,8 @@ func main() {
 	if rawx.bufferSize < uploadBatchSize {
 		rawx.bufferSize = uploadBatchSize
 	}
+
+	rawx.uploadBufferPool = newBufferPool(uploadBufferTotalDefault, rawx.bufferSize)
 
 	// Patch the checksum mode
 	if v, ok := opts["checksum"]; ok {

--- a/rawx/main.go
+++ b/rawx/main.go
@@ -37,7 +37,7 @@ import (
 	"time"
 )
 
-var xattrBufferPool = newBufferPool(128*1024, 2048)
+var xattrBufferPool = newBufferPool(xattrBufferTotalSizeDefault, xattrBufferSizeDefault)
 
 func checkURL(url string) {
 	addr, err := net.ResolveTCPAddr("tcp", url)
@@ -152,7 +152,7 @@ func main() {
 		path:         chunkrepo.sub.root,
 		id:           rawxID,
 		repo:         &chunkrepo,
-		bufferSize:   1024 * opts.getInt("buffer_size", uploadBufferDefault),
+		bufferSize:   1024 * opts.getInt("buffer_size", uploadBufferSizeDefault/1024),
 		checksumMode: checksumAlways,
 		compress:     opts.getBool("compress", false),
 	}
@@ -169,7 +169,7 @@ func main() {
 		rawx.bufferSize = uploadBatchSize
 	}
 
-	rawx.uploadBufferPool = newBufferPool(uploadBufferTotalDefault, rawx.bufferSize)
+	rawx.uploadBufferPool = newBufferPool(uploadBufferTotalSizeDefault, rawx.bufferSize)
 
 	// Patch the checksum mode
 	if v, ok := opts["checksum"]; ok {

--- a/rawx/notifier.go
+++ b/rawx/notifier.go
@@ -39,7 +39,7 @@ const (
 
 const (
 	beanstalkNotifierDefaultTube = "oio"
-	beanstalkNotifierPipeSize    = 4096
+	beanstalkNotifierPipeSize    = 8192
 )
 
 // Tells if the current RAWX service may emit notifications

--- a/rawx/notifier.go
+++ b/rawx/notifier.go
@@ -91,7 +91,6 @@ func (notifier *beanstalkNotifier) connectBeanstalkd() error {
 	if notifier.beanstalkd != nil {
 		return nil
 	}
-	LogDebug("Connecting to %s using tube %s", notifier.endpoint, notifier.tube)
 	beanstalkd, err := DialBeanstalkd(notifier.endpoint)
 	if err != nil {
 		return err
@@ -100,6 +99,7 @@ func (notifier *beanstalkNotifier) connectBeanstalkd() error {
 	if err != nil {
 		return err
 	}
+	LogDebug("Connected to %s using tube %s", notifier.endpoint, notifier.tube)
 	notifier.beanstalkd = beanstalkd
 	return nil
 }

--- a/rawx/rawx.go
+++ b/rawx/rawx.go
@@ -42,6 +42,8 @@ type rawxService struct {
 	bufferSize   int
 	checksumMode int
 	compress     bool
+
+	uploadBufferPool bufferPool
 }
 
 type rawxRequest struct {


### PR DESCRIPTION
##### SUMMARY
A shared cache for large buffers is used for stream operations (upon uploads)
Another shared cache for small buffers is used for xattr operations.

##### ISSUE TYPE
enhancement

##### COMPONENT NAME
rawx

##### SDS VERSION
something like 5.3