### PR TITLE
Fix meta2 rebuilder

### DIFF
--- a/bin/oio-meta2-rebuilder
+++ b/bin/oio-meta2-rebuilder
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     conf['report_interval'] = args.report_interval
     # local
     conf['concurrency'] = args.concurrency
-    conf['items_per_second'] = args.references_per_second
+    conf['items_per_second'] = args.items_per_second
 
     logger = get_logger_from_args(args, default_conf=conf)
 


### PR DESCRIPTION
##### SUMMARY

A reference of old parameter `references-per-second` was left in `oio-meta2-rebuilder`
Thanks to @pybt for the report

Closes  #2019

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio-meta2-rebuilder

##### SDS VERSION
```
openio 5.3.0
```