### PR TITLE
sqliterepo: Restore an option to prevent any lock operation.

### DIFF
--- a/sqlx/sqlx_service.c
+++ b/sqlx/sqlx_service.c
@@ -108,6 +108,9 @@ static struct grid_main_option_s common_options[] =
 	{"Replicate", OT_BOOL, {.b = &SRV.flag_replicable},
 		"DO NOT USE THIS. This might disable the replication"},
 
+	{"NoXattrLock", OT_BOOL, {.b = &SRV.flag_nolock},
+		"Set to TRUE to avoid any xattr operation on the repository root."},
+
 	{"CacheEnabled", OT_BOOL, {.b = &SRV.flag_cached_bases},
 		"If set, each base will be cached in a way it won't be accessed"
 			" by several requests in the same time."},


### PR DESCRIPTION
##### SUMMARY
Add an option to prevent any xattr check.

##### ISSUE TYPE
Welcome in the Danger Zone

##### COMPONENT NAME
sqliterepo

##### SDS VERSION
```openio 4.10.1.dev10```
