### PR TITLE
Disable (as a default) the MD5 checksums on chunks

### DIFF
--- a/oio/api/ec.py
+++ b/oio/api/ec.py
@@ -555,7 +555,7 @@ class EcChunkWriter(object):
     Writes an EC chunk
     """
     def __init__(self, chunk, conn, write_timeout=None,
-                 chunk_checksum_algo='md5', perfdata=None, **kwargs):
+                 chunk_checksum_algo=None, perfdata=None, **kwargs):
         self._chunk = chunk
         self._conn = conn
         self.failed = False

--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -729,7 +729,7 @@ class MetachunkWriter(_MetachunkWriter):
     Base class for metachunk writers
     """
     def __init__(self, storage_method=None, quorum=None,
-                 chunk_checksum_algo='md5', reqid=None,
+                 chunk_checksum_algo=None, reqid=None,
                  chunk_buffer_min=32768, chunk_buffer_max=262144,
                  perfdata=None, **_kwargs):
         super(MetachunkWriter, self).__init__(

--- a/rawx/const.go
+++ b/rawx/const.go
@@ -177,6 +177,7 @@ const (
 	checksumAlways = iota
 	checksumNever  = iota
 	checksumSmart  = iota
+	checksumDefault = checksumNever
 )
 
 const (

--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -103,7 +103,7 @@ func copyReadWriteBuffer(dst io.Writer, src io.Reader, h hash.Hash, pool bufferP
 		// Fill the buffer
 		totalr, er := fillBuffer(src, buf)
 
-		if totalr > 0 {
+		if h != nil && totalr > 0 {
 			h.Write(buf[:totalr])
 		}
 

--- a/rawx/main.go
+++ b/rawx/main.go
@@ -157,7 +157,7 @@ func main() {
 		id:           rawxID,
 		repo:         chunkrepo,
 		bufferSize:   1024 * opts.getInt("buffer_size", uploadBufferSizeDefault/1024),
-		checksumMode: checksumAlways,
+		checksumMode: checksumDefault,
 		compression:  opts["compression"],
 	}
 

--- a/tests/unit/api/test_ec.py
+++ b/tests/unit/api/test_ec.py
@@ -319,13 +319,10 @@ class TestEC(unittest.TestCase):
         with patch('hashlib.new', wraps=hashlib.new) as algo_new:
             self._test_write_checksum_algo(EMPTY_MD5)
             algo_new.assert_called_with('md5')
-            # Should be called once for the metachunk
-            # and once for each chunk.
-            self.assertEqual(
-                (self.storage_method.ec_nb_data +
-                 self.storage_method.ec_nb_parity +
-                 1),
-                len(algo_new.call_args_list))
+            # Starting from oio-sds 7.0.0, chunk checksums are no more
+            # computed by default. Only the object md5 checksum will
+            # be computed.
+            self.assertEqual(1, len(algo_new.call_args_list))
 
     def test_write_custom_checksum_algo(self):
         with patch('hashlib.new', wraps=hashlib.new) as algo_new:

--- a/tools/oio-bootstrap.py
+++ b/tools/oio-bootstrap.py
@@ -200,6 +200,8 @@ grid_fsync_dir         ${FSYNC}
 # Enable compression ('zlib' or 'lzo' or 'off')
 grid_compression ${COMPRESSION}
 
+#grid_checksum disabled
+
 #tcp_keepalive disabled
 #timeout_read_header 10
 #timeout_read_request 10


### PR DESCRIPTION
##### SUMMARY
The logic is still in place, it is possible to restore the checksums with an explicit configuration.

##### ISSUE TYPE
standardization

##### COMPONENT NAME
oio, rawx

##### SDS VERSION
```
openio 7.0.0.0a3.dev4
```