### PR TITLE
Python API: fix oioproxy URL parsing

### DIFF
--- a/oio/common/client.py
+++ b/oio/common/client.py
@@ -60,12 +60,15 @@ class ProxyClient(HttpApi):
             endpoint = self.conf.get('proxyd_url', None)
 
         ep_parts = list()
+        self.proxy_scheme = 'http'
         if endpoint:
-            self.proxy_netloc = endpoint.lstrip("http://")
+            if endpoint.startswith('https://'):
+                self.proxy_scheme = 'https'
+            self.proxy_netloc = endpoint.lstrip('%s://' % self.proxy_scheme)
         else:
             ns_conf = load_namespace_conf(self.ns)
             self.proxy_netloc = ns_conf.get('proxy')
-        ep_parts.append("http:/")
+        ep_parts.append('%s:/' % self.proxy_scheme)
         ep_parts.append(self.proxy_netloc)
 
         ep_parts.append("v3.0")

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -115,7 +115,8 @@ class ContainerClient(ProxyClient):
         Build URIs for request that don't use the same prefix as the one
         set in this class' constructor.
         """
-        uri = 'http://%s/v3.0/%s/%s' % (self.proxy_netloc, self.ns, target)
+        uri = '%s://%s/v3.0/%s/%s' % (self.proxy_scheme, self.proxy_netloc,
+                                      self.ns, target)
         return uri
 
     def _make_params(self, account=None, reference=None, path=None, cid=None,


### PR DESCRIPTION
##### SUMMARY
Refactor the code so we handle oioproxy's URL the same way, whether it comes from the application's configuration object, a keyword parameter, or the namespace configuration file.

If there is no scheme in the URL, consider it is HTTP. If there is a scheme, use it (but only HTTP will work at the moment).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 5.4.0.dev7
```
