### PR TITLE
conscience-agent: add timeout for http stats

### DIFF
--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -123,12 +123,15 @@ class ServiceWatcher(object):
         """Update service definition with all configured stats"""
         if not self.status:
             return
+        collectors = (x for x in self.service_stats if self.running)
         try:
-            for stat in (x for x in self.service_stats if self.running):
+            for stat in collectors:
                 stats = stat.get_stats()
                 self.service_definition['tags'].update(stats)
         except Exception as ex:
-            self.logger.debug("get_stats error: %s", ex)
+            self.logger.debug("get_stats error: %s, skipping %s", ex,
+                              [type(col).__name__ for col in collectors]
+                              or "<nothing>")
             self.status = False
 
     def register(self):

--- a/oio/conscience/stats/http.py
+++ b/oio/conscience/stats/http.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,9 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from oio.common.json import json
 from oio.common.constants import REQID_HEADER
+from oio.common.easy_value import float_value
+from oio.common.green import OioTimeout, Timeout
 from oio.common.http_urllib3 import urllibexc
+from oio.common.json import json
 from oio.common.utils import request_id
 from oio.conscience.stats.base import BaseStat
 
@@ -35,6 +37,7 @@ class HttpStat(BaseStat):
         else:
             # default to lines parser (rawx style)
             self._parse_func = self._parse_stats_lines
+        self.timeout = float_value(self.stat_conf.get('timeout'), 10.0)
 
     @staticmethod
     def _parse_stats_lines(body):
@@ -75,9 +78,13 @@ class HttpStat(BaseStat):
             # on the remote side but not on the local side, thus we
             # explicitely require the connection to be closed.
             reqid = request_id('stat-')
-            resp = self.agent.pool_manager.request(
-                'GET', self.url, headers={'Connection': 'close',
-                                          REQID_HEADER: reqid})
+            try:
+                with OioTimeout(self.timeout):
+                    resp = self.agent.pool_manager.request(
+                        'GET', self.url, headers={'Connection': 'close',
+                                                  REQID_HEADER: reqid})
+            except Timeout as toe:
+                raise Exception(str(toe))
             if resp.status == 200:
                 result = self._parse_func(resp.data)
             else:


### PR DESCRIPTION
##### SUMMARY

It appears that some services may be seen as down by the conscience but
still running: the http stats plugin did not implement timeout on requests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
conscience-agent

##### SDS VERSION
```
5.x
```