### PR TITLE
cli: expose perfdata as dedicated entry

### DIFF
--- a/oio/cli/common/shell.py
+++ b/oio/cli/common/shell.py
@@ -143,7 +143,7 @@ class OpenIOShell(CommonShell):
             res = super(OpenIOShell, self).run(argv)
             perfdata = self.client_manager.cli_conf().get('perfdata')
             if perfdata:
-                LOG.warn("Performance data: %s",
+                LOG.debug("Performance data: x %s",
                          json.dumps(perfdata, sort_keys=True, indent=4))
             return res
         except Exception as e:

--- a/oio/cli/object/object.py
+++ b/oio/cli/object/object.py
@@ -169,6 +169,7 @@ class CreateObject(ContainerCommandMixin, Lister):
         any_error = False
         properties = parsed_args.property
         results = []
+        perfdata = self.app.client_manager.storage.perfdata
         for obj in objs:
             name = obj
             try:
@@ -187,7 +188,11 @@ class CreateObject(ContainerCommandMixin, Lister):
                         mime_type=parsed_args.mime_type,
                         autocreate=autocreate)
 
-                    results.append((name, data[1], data[2].upper(), 'Ok'))
+                    res = (name, data[1], data[2].upper(), 'Ok')
+                    if perfdata:
+                        res += (perfdata,)
+
+                    results.append(res)
             except KeyboardInterrupt:
                 results.append((name, 0, None, 'Interrupted'))
                 any_error = True
@@ -200,6 +205,8 @@ class CreateObject(ContainerCommandMixin, Lister):
 
         listing = (obj for obj in results)
         columns = ('Name', 'Size', 'Hash', 'Status')
+        if perfdata:
+            columns += ('Perfdata',)
         if any_error:
             self.produce_output(parsed_args, columns, listing)
             raise Exception("Too many errors occured")


### PR DESCRIPTION
##### SUMMARY

To allow use of `--dump-perfdata` from other tools,
the perdata will be exposed as dedicated columns in output.
The previous output is still available through the `--debug` flag.
You should use format yaml or json for best output


Fixes #OS-520

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cli

##### SDS VERSION
```
5.x
```


##### ADDITIONAL INFORMATION

Best display with yaml formatter
```
openio --dump-perfdata object create a /etc/magic -f yaml
- Hash: 272913026300E7AE9B5E2D51F138E674
  Name: magic
  Perfdata:
    data_size: 111
    proxy:
      meta2: 0.002684
      overall: 0.0062420000322163105
      resolve: 0.001771
    rawx:
      http://127.0.0.1:6010/92C08C2F08D20542F462965E0600154179761EA4B2F83B763F9345A4FAC68B14: 0.0006470000371336937
      overall: 0.0011420000810176134
  Size: 111
  Status: Ok
```