### PR TITLE
cli: cleanup make_client

### DIFF
--- a/oio/cli/account/client.py
+++ b/oio/cli/account/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,18 +13,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from logging import getLogger
-from oio.api.object_storage import ObjectStorageApi
-
-LOG = getLogger(__name__)
-
-API_NAME = 'storage'
-
-
-def make_client(instance):
-    client = ObjectStorageApi(
-        endpoint=instance.get_endpoint('storage'),
-        namespace=instance.namespace,
-        admin_mode=instance.admin_mode
-    )
-    return client
+API_NAME = 'FIXME'

--- a/oio/cli/container/client.py
+++ b/oio/cli/container/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2017-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,18 +13,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from logging import getLogger
-from oio.api.object_storage import ObjectStorageApi
-
-LOG = getLogger(__name__)
-
-API_NAME = 'storage'
-
-
-def make_client(instance):
-    client = ObjectStorageApi(
-        endpoint=instance.get_endpoint('storage'),
-        namespace=instance.namespace,
-        admin_mode=instance.admin_mode
-    )
-    return client
+API_NAME = 'FIXME'

--- a/oio/cli/lifecycle/client.py
+++ b/oio/cli/lifecycle/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 OpenIO SAS, as part of OpenIO SDS
+# Copyright (C) 2017-2020 OpenIO SAS, as part of OpenIO SDS
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,18 +13,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from logging import getLogger
-from oio.api.object_storage import ObjectStorageApi
-
-LOG = getLogger(__name__)
-
-API_NAME = 'storage'
-
-
-def make_client(instance):
-    client = ObjectStorageApi(
-        endpoint=instance.get_endpoint('storage'),
-        namespace=instance.namespace,
-        admin_mode=instance.admin_mode
-    )
-    return client
+API_NAME = 'FIXME'


### PR DESCRIPTION
##### SUMMARY

When using interactive CLI with 
```
$ openio --dump-perfdata
(openio) object create cnt /etc/magic
```
the `ObjectStorageAPI` is initialized though `lifeclycle/client.py` instead of `object/client.py`,
the perfdata attrbute is lost.

This PR replace duplicated API_NAME `storage` by `FIXME`

Note:
This PR requires https://github.com/open-io/oio-sds/pull/2033 to allow use of `--dump-perfdata`  in interactive mode.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cli

##### SDS VERSION
```
7.0.0.0a3
```
