### PR TITLE
rawx: add more logs when replying error

### DIFF
--- a/rawx/handler_info.go
+++ b/rawx/handler_info.go
@@ -46,7 +46,7 @@ func doGetInfo(rr *rawxRequest) {
 
 func (rr *rawxRequest) serveInfo() {
 	if err := rr.drain(); err != nil {
-		rr.replyError(err)
+		rr.replyError("", err)
 		return
 	}
 

--- a/rawx/handler_stat.go
+++ b/rawx/handler_stat.go
@@ -177,7 +177,7 @@ func doGetStats(rr *rawxRequest) {
 
 func (rr *rawxRequest) serveStat() {
 	if err := rr.drain(); err != nil {
-		rr.replyError(err)
+		rr.replyError("", err)
 		return
 	}
 

--- a/rawx/rawx.go
+++ b/rawx/rawx.go
@@ -69,7 +69,7 @@ func (rr *rawxRequest) replyCode(code int) {
 	rr.rep.WriteHeader(rr.status)
 }
 
-func (rr *rawxRequest) replyError(err error) {
+func (rr *rawxRequest) replyError(action string, err error) {
 	if os.IsExist(err) {
 		rr.replyCode(http.StatusConflict)
 	} else if os.IsPermission(err) {
@@ -81,6 +81,10 @@ func (rr *rawxRequest) replyError(err error) {
 		// whatever the client has sent in the request, in terms of
 		// connection management.
 		rr.req.Close = true
+
+		if len(action) != 0 {
+			LogError(msgErrorAction(action, rr.reqid, err))
+		}
 
 		// Also, we debug what happened in the reply headers
 		// TODO(jfs): This is a job for a distributed tracing framework


### PR DESCRIPTION
##### SUMMARY

When rawx returns an error, there is only few codepath where more info is
logged as error.

I've chosen to always log error when we force connection to be closed instead of
adding LogError before each rr.replyWithError. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rawx

##### SDS VERSION
```
7.0.0.0b2-dev1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
