### PR TITLE
proxy: Limit size of object list when there is no max

### DIFF
--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -953,8 +953,10 @@ static GError *
 _max(struct req_args_s *args, gint64 *pmax)
 {
 	const char *s = OPT("max");
-	if (!s)
+	if (!s) {
+		*pmax = META2_LISTING_DEFAULT_LIMIT;
 		return NULL;
+	}
 
 	if (!oio_str_is_number(s, pmax))
 		return BADREQ("Invalid max number of items");


### PR DESCRIPTION
##### SUMMARY

Limit size of object list when there is no max

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- proxy

##### SDS VERSION

```
openio 5.5.3.dev1
```