### PR TITLE
Python API: protect against read-after-close operations

### DIFF
--- a/oio/common/http_eventlet.py
+++ b/oio/common/http_eventlet.py
@@ -56,10 +56,11 @@ class CustomHTTPResponse(HTTPResponse):
     def read(self, amount=None):
         try:
             return HTTPResponse.read(self, amount)
-        except AttributeError as err:
+        except (ValueError, AttributeError) as err:
             # We have seen that in production but could not reproduce.
             # This message will help us track the error further.
-            if "no attribute 'recv'" in str(err):
+            if ("no attribute 'recv'" in str(err)
+                    or "Read on closed" in str(err)):
                 raise IOError('reading socket after close')
             else:
                 raise


### PR DESCRIPTION
##### SUMMARY

During test, errors previously catch by OS-361 are not more catch when TLS mode is enabled.

Jira: R2004-5

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio

##### SDS VERSION
```
7.0.0.0b2-dev4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
