### PR TITLE
rawx: add tag http or https

### DIFF
--- a/rawx/handler_chunk.go
+++ b/rawx/handler_chunk.go
@@ -548,6 +548,7 @@ func (rr *rawxRequest) serveChunk() {
 			peer:      rr.req.RemoteAddr,
 			path:      rr.req.URL.Path,
 			reqId:     rr.reqid,
+			tls:       rr.req.TLS != nil,
 		})
 	}
 }

--- a/rawx/handler_info.go
+++ b/rawx/handler_info.go
@@ -70,6 +70,7 @@ func (rr *rawxRequest) serveInfo() {
 			peer:      rr.req.RemoteAddr,
 			path:      rr.req.URL.Path,
 			reqId:     rr.reqid,
+			tls:       rr.req.TLS != nil,
 		})
 	}
 }

--- a/rawx/handler_stat.go
+++ b/rawx/handler_stat.go
@@ -202,6 +202,7 @@ func (rr *rawxRequest) serveStat() {
 			peer:      rr.req.RemoteAddr,
 			path:      rr.req.URL.Path,
 			reqId:     rr.reqid,
+			tls:       rr.req.TLS != nil,
 		})
 	}
 }

--- a/rawx/logger.go
+++ b/rawx/logger.go
@@ -65,6 +65,7 @@ type AccessLogEvent struct {
 	peer      string
 	path      string
 	reqId     string
+	tls       bool
 }
 
 type NoopLogger struct{}
@@ -179,6 +180,12 @@ func (evt AccessLogEvent) String() string {
 	sb.WriteString(evt.reqId)
 	sb.WriteRune(' ')
 	sb.WriteString(evt.path)
+	sb.WriteRune(' ')
+	if evt.tls {
+		sb.WriteString("https")
+	} else {
+		sb.WriteString("http")
+	}
 	return sb.String()
 }
 


### PR DESCRIPTION
##### SUMMARY

With new feature to serve plain or TLS requests,
we should be able to distinguish traffic on monitoring.

This PR add field http or https on access logs:
```
juin 04 03:57:24 E480 OIO,OPENIO,rawx,1[15159]: 15159 access INF - 127.0.0.1:6009 127.0.0.1:36648 DELETE 204 2531 0 0 - create-3CE15D35F4DE0A077FCA1577A /B96C425504555470FAC63DFCA363DFD509DE150A3A982164D09E977FD7703602 http
juin 04 03:57:29 E480 OIO,OPENIO,rawx,1[15159]: 15159 access INF - 127.0.0.1:6010 127.0.0.1:56174 PUT 201 557 0 111 - create-3CF802CBDBE80BBF8F2CB1423 /ACFDCE4232A653A4C1162301F8A2DC4571EE998D7CBE802AB0548D46C0E95223 https
```

Fixes CUS-119


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rawx

##### SDS VERSION
```
7.0.0.0a3
```