### PR TITLE
xcute: fix job listing in python3

### DIFF
--- a/oio/xcute/common/backend.py
+++ b/oio/xcute/common/backend.py
@@ -537,7 +537,7 @@ class XcuteBackend(RedisConnection):
 
             pipeline = self.conn.pipeline()
             for job_id in job_ids:
-                self._get_job_info(job_id, client=pipeline)
+                self._get_job_info(job_id.decode('utf-8'), client=pipeline)
             job_infos = pipeline.execute()
 
             for job_info in job_infos:


### PR DESCRIPTION
##### SUMMARY
Fix xcute job listing not working in Python3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
xcute

##### ADDITIONAL INFORMATION
The problem came from stringifying bytes, which become `b'my_string'` when converting into a string, instead of the wanted `my_string`.