### PR TITLE
pass proc_name setting to guinicorn app

### DIFF
--- a/etc/account-server.conf-sample
+++ b/etc/account-server.conf-sample
@@ -7,6 +7,7 @@ log_level = INFO
 log_facility = LOG_LOCAL0
 log_address = /dev/log
 syslog_prefix = OIO,OPENIO,account,1
+proc_name = oio-account-server
 
 # Configure Redis backend
 #redis_host = 127.0.0.1:6379

--- a/etc/xcute.conf-sample
+++ b/etc/xcute.conf-sample
@@ -5,6 +5,7 @@ log_address = /dev/log
 syslog_prefix = OIO,OPENIO,xcute,1
 
 namespace = OPENIO
+proc_name = oio-xcute
 
 # Configure Redis backend
 redis_host = 127.0.0.1:6379

--- a/oio/common/wsgi.py
+++ b/oio/common/wsgi.py
@@ -51,10 +51,9 @@ class Application(BaseApplication):
         self.cfg.set('keepalive', 30)
         self.cfg.set('access_log_format', self.conf.get('access_log_format',
                                                         self.access_log_fmt))
-        if self.logger_class:
-            # reactivate after
-            # self.cfg.set('logger_class', self.logger_class)
-            pass
+        self.cfg.set('proc_name',
+                     self.conf.get('proc_name',
+                                   self.application.__class__.__name__))
 
     def load(self):
         return self.application


### PR DESCRIPTION
##### SUMMARY
when the setproctitle python package exist, gunicorn changes the process title which does not make sens (too generic). It is possible to use a custom title using the `proc_name` settings but it was not passed through (https://docs.gunicorn.org/en/19.3/configure.html#proc-name).

This changes pass through the parameter `proc_name`

- https://openio.atlassian.net/browse/OS-544

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
common/wsgi

##### SDS VERSION
```
openio-6.0.0
```


##### ADDITIONAL INFORMATION
```

```
