### PR TITLE
Python API: Refresh the cached rawx scores

### DIFF
--- a/oio/common/cache.py
+++ b/oio/common/cache.py
@@ -126,7 +126,14 @@ def set_cached_object_metadata(content_meta, content_chunks,
     content_meta['properties'] = dict()
     cache_value['meta'] = content_meta
     if content_chunks is not None:
-        cache_value['chunks'] = content_chunks
+        downsized_chunks = list()
+        # The scores will be refreshed on reading
+        # There is therefore no reason to lose space for this information
+        for chunk in content_chunks:
+            downsized_chunk = chunk.copy()
+            downsized_chunk.pop('score', None)
+            downsized_chunks.append(downsized_chunk)
+        cache_value['chunks'] = downsized_chunks
 
     cache_key = _get_object_metadata_cache_key(
         account=account, reference=reference, path=path, cid=cid)

--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+import time
 import warnings
 from functools import wraps
 from urllib import unquote
@@ -25,6 +26,9 @@ from oio.common.cache import get_cached_container_metadata, \
     get_cached_object_metadata, set_cached_object_metadata, \
     del_cached_object_metadata
 from oio.common.easy_value import boolean_value
+from oio.common.exceptions import OioNetworkException
+from oio.common.green import eventlet
+from oio.conscience.client import ConscienceClient
 
 
 CONTENT_HEADER_PREFIX = 'x-oio-content-meta-'
@@ -105,10 +109,18 @@ class ContainerClient(ProxyClient):
     Intermediate level class to manage containers.
     """
 
-    def __init__(self, conf, **kwargs):
+    def __init__(self, conf, refresh_rawx_scores_delay=30.0, **kwargs):
         super(ContainerClient, self).__init__(conf,
                                               request_prefix="/container",
                                               **kwargs)
+
+        # to refresh the rawx scores from cache
+        kwargs.pop('pool_manager', None)
+        self.conscience_client = ConscienceClient(
+            self.conf, pool_manager=self.pool_manager, **kwargs)
+        self.rawx_scores = dict()
+        self._refresh_rawx_scores_delay = refresh_rawx_scores_delay
+        self._last_refresh_rawx_scores = 0.0
 
     def _make_uri(self, target):
         """
@@ -132,6 +144,36 @@ class ContainerClient(ProxyClient):
         if version:
             params.update({'version': version})
         return params
+
+    def _get_rawx_scores(self):
+        rawx_services = self.conscience_client.all_services('rawx')
+        rawx_scores = dict()
+        for rawx_service in rawx_services:
+            rawx_scores[rawx_service['id']] = \
+                rawx_service['score']
+        return rawx_scores
+
+    def _refresh_rawx_scores(self, now=None, **kwargs):
+        """Refresh rawx service scores."""
+        self.rawx_scores = self._get_rawx_scores()
+        if not now:
+            now = time.time()
+        self._last_refresh_rawx_scores = now
+
+    def _maybe_refresh_rawx_scores(self, **kwargs):
+        """Refresh rawx service scores if delay has been reached."""
+        if self._refresh_rawx_scores_delay >= 0.0 or not self.rawx_scores:
+            now = time.time()
+            if now - self._last_refresh_rawx_scores \
+                    > self._refresh_rawx_scores_delay:
+                try:
+                    self._refresh_rawx_scores(now, **kwargs)
+                except OioNetworkException as exc:
+                    self.logger.warn(
+                            "Failed to refresh rawx service scores: %s", exc)
+                except Exception as exc:
+                    self.logger.exception(
+                        "Failed to refresh rawx service scores")
 
     def container_create(self, account, reference,
                          properties=None, system=None, **kwargs):
@@ -670,6 +712,11 @@ class ContainerClient(ProxyClient):
             account=account, reference=reference, path=path,
             cid=cid, version=version, properties=properties, **kwargs)
         if content_meta is not None and chunks is not None:
+            # Refresh asynchronously so as not to slow down the current request
+            eventlet.spawn_n(self._maybe_refresh_rawx_scores, **kwargs)
+            for chunk in chunks:
+                chunk['score'] = self.rawx_scores.get(
+                    chunk['url'].split('/')[2], 0)
             return content_meta, chunks
 
         uri = self._make_uri('content/locate')

--- a/tests/functional/api/test_objectstorage.py
+++ b/tests/functional/api/test_objectstorage.py
@@ -2015,11 +2015,15 @@ class TestObjectStorageApiUsingCache(ObjectStorageApiTestBase):
         self.assertIsNotNone(expected_chunks)
         expected_obj_meta = expected_obj_meta.copy()
         expected_chunks = copy.deepcopy(expected_chunks)
+        for expected_chunk in expected_chunks:
+            del expected_chunk['score']
         self.assertEqual(2, self.api.container._direct_request.call_count)
         self.assertEqual(1, len(self.cache))
 
         obj_meta, chunks = self.api.object_locate(
             self.account, self.container, self.path, properties=False)
+        for chunk in chunks:
+            del chunk['score']
         self.assertDictEqual(expected_obj_meta, obj_meta)
         self.assertListEqual(expected_chunks, chunks)
         self.assertEqual(2, self.api.container._direct_request.call_count)
@@ -2028,6 +2032,8 @@ class TestObjectStorageApiUsingCache(ObjectStorageApiTestBase):
         expected_obj_meta['properties'] = properties
         obj_meta, chunks = self.api.object_locate(
             self.account, self.container, self.path, properties=True)
+        for chunk in chunks:
+            del chunk['score']
         self.assertDictEqual(expected_obj_meta, obj_meta)
         self.assertListEqual(expected_chunks, chunks)
         self.assertEqual(3, self.api.container._direct_request.call_count)
@@ -2035,6 +2041,8 @@ class TestObjectStorageApiUsingCache(ObjectStorageApiTestBase):
 
         obj_meta, chunks = self.api.object_locate(
             self.account, self.container, self.path, properties=True)
+        for chunk in chunks:
+            del chunk['score']
         self.assertDictEqual(expected_obj_meta, obj_meta)
         self.assertListEqual(expected_chunks, chunks)
         self.assertEqual(3, self.api.container._direct_request.call_count)
@@ -2043,6 +2051,8 @@ class TestObjectStorageApiUsingCache(ObjectStorageApiTestBase):
         expected_obj_meta['properties'] = dict()
         obj_meta, chunks = self.api.object_locate(
             self.account, self.container, self.path, properties=False)
+        for chunk in chunks:
+            del chunk['score']
         self.assertDictEqual(expected_obj_meta, obj_meta)
         self.assertListEqual(expected_chunks, chunks)
         self.assertEqual(3, self.api.container._direct_request.call_count)


### PR DESCRIPTION
##### SUMMARY

Refresh the rawx scores from cache

Refresh every 30 seconds (default) so as not to request the proxy all the time.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API

##### SDS VERSION

```
openio 5.5.3.dev7
```