### PR TITLE
allow multiple glob patterns in conscienceagent's include_dir conf

### DIFF
--- a/oio/conscience/agent.py
+++ b/oio/conscience/agent.py
@@ -18,6 +18,7 @@ from oio.common.green import GreenPool, sleep
 
 import re
 import os
+import glob
 
 from six import iteritems
 import pkg_resources
@@ -265,8 +266,8 @@ class ConscienceAgent(Daemon):
         if include_dir:
             include_dir = os.path.expanduser(include_dir)
 
-            cfgfiles = [os.path.join(include_dir, f)
-                        for f in os.listdir(include_dir)
+            cfgfiles = [f for d in include_dir.split(':')
+                        for f in glob.glob(d + "/*")
                         if re.match(r'.+\.(json|yml|yaml)$', f)]
             for cfgfile in cfgfiles:
                 name = os.path.basename(cfgfile)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
For a customer, we need to be able to watch multiple directories. this allow to split `include_dir` in muiltiple directory using the `:` separator. Then each directory is extracting using `glob` for maximizing possibilities.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- conscience-agent

##### SDS VERSION
```
openio 7.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# grep include_dir /etc/oio/sds/OPENIO/conscienceagent-0/conscienceagent-0.yml 
include_dir: "/etc/oio/sds/OPENIO/watch:/data/*/*/etc/OPENIO/watch"
```
