### PR TITLE
Enrich info on meta2 with SQLITE version

### DIFF
--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -1724,9 +1724,13 @@ _info_sqlite(GString *gstr)
 	const char *s;
 
 	g_string_append_static(gstr, "\"sqlite\":[");
+	g_string_append_static(gstr, "\"VERSION_COMPILED=");
+	g_string_append_static(gstr, SQLITE_VERSION);
+	g_string_append_static(gstr, "\",\"VERSION_RUNTIME=");
+	oio_str_gstring_append_json_string(gstr, sqlite3_libversion());
+	g_string_append_c(gstr, '"');
 	for (int i=0; NULL != (s = sqlite3_compileoption_get(i)); ++i) {
-		if (i!=0)
-			g_string_append_c(gstr, ',');
+		g_string_append_c(gstr, ',');
 		oio_str_gstring_append_json_quote(gstr, s);
 	}
 	g_string_append_c(gstr, ']');


### PR DESCRIPTION
##### SUMMARY

Show sqlite version (with compiled version and runtime version)

```
$ openio-admin meta2 info 127.0.0.1:6016
| sqlite                     | VERSION_COMPILED=3.31.1    |
|                            | VERSION_RUNTIME=3.31.1     |
|                            | COMPILER=gcc-9.3.0         |
|                            | ENABLE_COLUMN_METADATA     |
```


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
sqliterepo

##### SDS VERSION
```
7.0.2dev1
```
