### PR TITLE
account: Refresh account without impacting the bucket counters

### DIFF
--- a/oio/account/client.py
+++ b/oio/account/client.py
@@ -209,6 +209,13 @@ class AccountClient(HttpApi):
                                            data=data, **kwargs)
         return body
 
+    def bucket_refresh(self, bucket, **kwargs):
+        """
+        Refresh the counters of a bucket. Recompute them from the counters
+        of all shards (containers).
+        """
+        self.account_request(bucket, 'POST', 'refresh-bucket', **kwargs)
+
     def container_list(self, account, limit=None, marker=None,
                        end_marker=None, prefix=None, delimiter=None,
                        s3_buckets_only=False, **kwargs):

--- a/oio/account/server.py
+++ b/oio/account/server.py
@@ -80,6 +80,8 @@ class Account(WerkzeugApp):
                  methods=['GET']),
             Rule('/v1.0/account/containers', endpoint='account_containers',
                  methods=['GET']),
+            Rule('/v1.0/account/refresh-bucket', endpoint='bucket_refresh',
+                 methods=['POST']),
             Rule('/v1.0/account/refresh', endpoint='account_refresh',
                  methods=['POST']),
             Rule('/v1.0/account/flush', endpoint='account_flush',
@@ -97,6 +99,8 @@ class Account(WerkzeugApp):
                  methods=['GET']),
             Rule('/v1.0/bucket/update', endpoint='bucket_update',
                  methods=['PUT']),
+            Rule('/v1.0/bucket/refresh', endpoint='bucket_refresh',
+                 methods=['POST']),
         ])
         super(Account, self).__init__(self.url_map, self.logger)
 
@@ -707,7 +711,7 @@ class Account(WerkzeugApp):
         return NotFound('Bucket not found')
 
     # ACCT{{
-    # POST /v1.0/bucket/update?id=<bucket_name>
+    # PUT /v1.0/bucket/update?id=<bucket_name>
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #
     # Update metadata of the specified bucket.
@@ -766,6 +770,40 @@ class Account(WerkzeugApp):
         if info is not None:
             return Response(json.dumps(info), mimetype='text/json')
         return NotFound('Bucket not found')
+
+    # ACCT{{
+    # POST /v1.0/bucket/refresh?id=<bucket_name>
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #
+    # Refresh the counters of a bucket named bucket_name
+    #
+    # Sample request:
+    #
+    # .. code-block:: http
+    #
+    #    POST /v1.0/bucket/refresh?id=mybucket HTTP/1.1
+    #    Host: 127.0.0.1:6013
+    #    User-Agent: curl/7.47.0
+    #    Accept: */*
+    #
+    # Sample response:
+    #
+    # .. code-block:: http
+    #
+    #    HTTP/1.1 204 NO CONTENT
+    #    Server: gunicorn/19.9.0
+    #    Date: Wed, 01 Aug 2018 12:17:25 GMT
+    #    Connection: keep-alive
+    #    Content-Type: text/plain; charset=utf-8
+    #
+    # }}ACCT
+    def on_bucket_refresh(self, req):
+        """
+        Refresh bucket counters.
+        """
+        bucket_name = self._get_item_id(req, what='bucket')
+        self.backend.refresh_bucket(bucket_name)
+        return Response(status=204)
 
     # ACCT{{
     # GET /v1.0/account/container/show?id=<account_name>&container=<container>

--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -829,6 +829,32 @@ class PurgeContainer(ContainerCommandMixin, Command):
         )
 
 
+class RefreshBucket(Command):
+    """
+    Refresh the counters of a bucket.
+
+    Reset all statistics counters and recompute them by summing
+    the counters of all shards (containers).
+    """
+
+    log = getLogger(__name__ + '.RefreshBucket')
+
+    def get_parser(self, prog_name):
+        parser = super(RefreshBucket, self).get_parser(prog_name)
+        parser.add_argument(
+            'bucket',
+            help='Name of the bucket to refresh.'
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug('take_action(%s)', parsed_args)
+
+        reqid = request_id(prefix='CLI-BUCKET-')
+        acct_client = self.app.client_manager.storage.account
+        acct_client.bucket_refresh(parsed_args.bucket, reqid=reqid)
+
+
 class RefreshContainer(ContainerCommandMixin, Command):
     """ Refresh counters of an account (triggers asynchronous treatments) """
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ openio.container =
     bucket_list = oio.cli.container.container:ListBuckets
     bucket_set = oio.cli.container.container:SetBucket
     bucket_show = oio.cli.container.container:ShowBucket
+    bucket_refresh = oio.cli.container.container:RefreshBucket
     container_create = oio.cli.container.container:CreateContainer
     container_delete = oio.cli.container.container:DeleteContainer
     container_flush = oio.cli.container.container:FlushContainer

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -112,6 +112,68 @@ class ContainerTest(CliTestCase):
         output = self.openio('bucket show ' + cname + opts)
         self.assertEqual(self.account_from_env() + '\n0\n0\n', output)
 
+    def test_bucket_show_with_account_refresh(self):
+        account = 'myaccount-' + random_str(4).lower()
+        opts = self.get_format_opts(fields=('Name', ))
+        cname = 'mybucket-' + random_str(4).lower()
+        output = self.openio(
+            '--oio-account %s container create --bucket-name %s %s %s' %
+            (account, cname, cname, opts))
+        self.assertOutput(cname + '\n', output)
+        self.wait_for_event('oio-preserved',
+                            fields={'user': cname},
+                            types=(EventTypes.CONTAINER_STATE, ))
+
+        with tempfile.NamedTemporaryFile() as file_:
+            file_.write('test')
+            file_.flush()
+            output = self.openio(
+                '--oio-account %s object create %s %s --name test' %
+                (account, cname, file_.name))
+        self.wait_for_event('oio-preserved',
+                            fields={'user': cname},
+                            types=(EventTypes.CONTAINER_STATE, ))
+
+        opts = self.get_format_opts(fields=('account', 'bytes', 'objects'))
+        output = self.openio('bucket show ' + cname + opts)
+        self.assertEqual(account + '\n4\n1\n', output)
+
+        output = self.openio('account refresh ' + account)
+        self.wait_for_event('oio-preserved',
+                            fields={'user': cname},
+                            types=(EventTypes.CONTAINER_STATE, ))
+
+        output = self.openio('bucket show ' + cname + opts)
+        self.assertEqual(account + '\n4\n1\n', output)
+
+    def test_bucket_refresh(self):
+        opts = self.get_format_opts(fields=('Name', ))
+        cname = 'mybucket-' + random_str(4).lower()
+        output = self.openio('container create --bucket-name %s %s %s' %
+                             (cname, cname, opts))
+        self.assertOutput(cname + '\n', output)
+        self.wait_for_event('oio-preserved',
+                            fields={'user': cname},
+                            types=(EventTypes.CONTAINER_STATE, ))
+
+        with tempfile.NamedTemporaryFile() as file_:
+            file_.write('test')
+            file_.flush()
+            output = self.openio('object create %s %s --name test' %
+                                 (cname, file_.name))
+        self.wait_for_event('oio-preserved',
+                            fields={'user': cname},
+                            types=(EventTypes.CONTAINER_STATE, ))
+
+        opts = self.get_format_opts(fields=('account', 'bytes', 'objects'))
+        output = self.openio('bucket show ' + cname + opts)
+        self.assertEqual(self.account_from_env() + '\n4\n1\n', output)
+
+        output = self.openio('bucket refresh ' + cname)
+
+        output = self.openio('bucket show ' + cname + opts)
+        self.assertEqual(self.account_from_env() + '\n4\n1\n', output)
+
     def test_container_show(self):
         self._test_container_show()
 


### PR DESCRIPTION
##### SUMMARY

Refresh account without impacting the bucket counters
- Use the bucket name already registered when it is not given
- Add all totals when a container is not yet associated with its bucket
- Refresh bucket counters

Jira: OS-562

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- account

##### SDS VERSION

```
openio 5.5.5.dev7
```