### PR TITLE
Meta0: compare the requested namespace to the locally configured one

### DIFF
--- a/meta0v2/meta0_remote.c
+++ b/meta0v2/meta0_remote.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta0v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -54,18 +54,23 @@ _m0_remote_m0info (const char *m0, GByteArray *req, GSList **out, gint64 deadlin
 /* ------------------------------------------------------------------------- */
 
 GError *
-meta0_remote_get_meta1_all(const char *m0, GSList **out, gint64 deadline)
+meta0_remote_get_meta1_all(const char *m0, GSList **out, gint64 deadline,
+		const gchar *ns_name)
 {
 	MESSAGE request = metautils_message_create_named (NAME_MSGNAME_M0_GETALL, deadline);
+	if (oio_str_is_set(ns_name))
+		metautils_message_add_field_str(request, NAME_MSGKEY_NAMESPACE, ns_name);
 	return _m0_remote_m0info (m0, message_marshall_gba_and_clean (request), out, deadline);
 }
 
 GError*
 meta0_remote_get_meta1_one(const char *m0, const guint8 *prefix,
-		GSList **out, gint64 deadline)
+		GSList **out, gint64 deadline, const gchar *ns_name)
 {
 	MESSAGE request = metautils_message_create_named (NAME_MSGNAME_M0_GETONE, deadline);
 	metautils_message_add_field (request, NAME_MSGKEY_PREFIX, prefix, 2);
+	if (oio_str_is_set(ns_name))
+		metautils_message_add_field_str(request, NAME_MSGKEY_NAMESPACE, ns_name);
 	return _m0_remote_m0info (m0, message_marshall_gba_and_clean (request), out, deadline);
 }
 
@@ -86,12 +91,15 @@ meta0_remote_cache_reset (const char *m0, gboolean local, gint64 deadline)
 }
 
 GError*
-meta0_remote_force(const char *m0, const guint8 *mapping, gsize mapping_len, gint64 deadline)
+meta0_remote_force(const char *m0, const guint8 *mapping, gsize mapping_len,
+		gint64 deadline, const gchar *ns_name)
 {
 	if (!mapping || !mapping_len || !*mapping)
 		return NEWERROR(CODE_BAD_REQUEST, "Empty JSON mapping");
 
 	MESSAGE request = metautils_message_create_named(NAME_MSGNAME_M0_FORCE, deadline);
+	if (oio_str_is_set(ns_name))
+		metautils_message_add_field_str(request, NAME_MSGKEY_NAMESPACE, ns_name);
 	metautils_message_set_BODY(request, mapping, mapping_len);
 	return _m0_remote_no_return(m0, message_marshall_gba_and_clean(request), deadline);
 }

--- a/meta0v2/meta0_remote.h
+++ b/meta0v2/meta0_remote.h
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta0v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -22,10 +22,13 @@ License along with this library.
 
 #include <glib.h>
 
-GError * meta0_remote_get_meta1_all(const char *m0, GSList **out, gint64 deadline);
-GError * meta0_remote_get_meta1_one(const char *m0, const guint8 *prefix, GSList **out, gint64 deadline);
+GError * meta0_remote_get_meta1_all(const char *m0, GSList **out, gint64 deadline,
+		const gchar *ns_name);
+GError * meta0_remote_get_meta1_one(const char *m0, const guint8 *prefix, GSList **out,
+		gint64 deadline, const gchar *ns_name);
 GError * meta0_remote_cache_refresh(const char *m0, gint64 deadline);
 GError * meta0_remote_cache_reset(const char *m0, gboolean local, gint64 deadline);
-GError * meta0_remote_force(const char *m0, const guint8 *mapping, gsize mapping_len, gint64 deadline);
+GError * meta0_remote_force(const char *m0, const guint8 *mapping, gsize mapping_len,
+		gint64 deadline, const gchar *ns_name);
 
 #endif /*OIO_SDS__meta0v2__meta0_remote_h*/

--- a/meta1v2/meta1_prefixes.c
+++ b/meta1v2/meta1_prefixes.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS meta1v2
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -142,7 +142,8 @@ _cache_load_from_m0(struct meta1_prefixes_set_s *m1ps,
 		GArray **updated_prefixes,
 		gboolean *meta0_ok,
 		guint digits,
-		gint64 deadline)
+		gint64 deadline,
+		const gchar *ns_name)
 {
 	EXTRA_ASSERT(m1ps != NULL);
 	GRID_TRACE2("%s(%p,%p,%p)", __FUNCTION__, m1ps, local_addr, m0_addr);
@@ -155,7 +156,7 @@ _cache_load_from_m0(struct meta1_prefixes_set_s *m1ps,
 
 	grid_addrinfo_to_string (m0_addr, m0, sizeof(m0));
 
-	err = meta0_remote_get_meta1_all(m0, &m0info_list, deadline);
+	err = meta0_remote_get_meta1_all(m0, &m0info_list, deadline, ns_name);
 	if (err) {
 		g_prefix_error(&err, "Remote error: ");
 		goto label_exit;
@@ -256,7 +257,7 @@ _cache_load_from_ns(struct meta1_prefixes_set_s *m1ps, const char *ns_name,
 	for (GSList *m0 = m0_list ; m0 && !err && !done ; m0 = m0->next) {
 		const struct service_info_s *si = m0->data;
 		err = _cache_load_from_m0(m1ps, &local_ai, &(si->addr),
-				updated_prefixes, meta0_ok, digits, deadline);
+				updated_prefixes, meta0_ok, digits, deadline, ns_name);
 		if (!err) {
 			done = TRUE;
 		} else {

--- a/proxy/admin_actions.c
+++ b/proxy/admin_actions.c
@@ -1,6 +1,6 @@
 /*
 OpenIO SDS proxy
-Copyright (C) 2016-2019 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2016-2020 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -91,7 +91,7 @@ static GError*
 _wrap_meta0_remote_get_meta1_all(const char *m0_url, GSList **out)
 {
 	const gint64 deadline = oio_ext_get_deadline();
-	return meta0_remote_get_meta1_all(m0_url, out, deadline);
+	return meta0_remote_get_meta1_all(m0_url, out, deadline, ns_name);
 }
 
 enum http_rc_e
@@ -113,7 +113,8 @@ static GError*
 _wrap_meta0_remote_force(const char *m0_url, GByteArray *udata)
 {
 	const gint64 deadline = oio_ext_get_deadline();
-	GError *err = meta0_remote_force(m0_url, udata->data, udata->len, deadline);
+	GError *err = meta0_remote_force(m0_url, udata->data, udata->len,
+			deadline, ns_name);
 	if (!err)
 		err = meta0_remote_cache_refresh(m0_url, deadline);
 	return err;

--- a/resolver/hc_resolver.c
+++ b/resolver/hc_resolver.c
@@ -1,7 +1,7 @@
 /*
 OpenIO SDS resolver
 Copyright (C) 2014 Worldline, as part of Redcurrant
-Copyright (C) 2015-2017 OpenIO SAS, as part of OpenIO SDS
+Copyright (C) 2015-2020 OpenIO SAS, as part of OpenIO SDS
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as
@@ -272,7 +272,7 @@ _m0list_to_urlv(GSList *l)
 
 static GError *
 _resolve_m1_through_one_m0(const char *m0, const guint8 *prefix,
-		gchar ***result, gint64 deadline)
+		gchar ***result, gint64 deadline, const gchar *ns_name)
 {
 	GRID_TRACE2("%s(%s,%02X%02X)", __FUNCTION__, m0, prefix[0], prefix[1]);
 	GError *err = NULL;
@@ -281,7 +281,7 @@ _resolve_m1_through_one_m0(const char *m0, const guint8 *prefix,
 
 	do {
 		GSList *lmap = NULL;
-		err = meta0_remote_get_meta1_one(url, prefix, &lmap, deadline);
+		err = meta0_remote_get_meta1_one(url, prefix, &lmap, deadline, ns_name);
 		if (err)
 			return err;
 		*result = _m0list_to_urlv(lmap);
@@ -294,7 +294,8 @@ _resolve_m1_through_one_m0(const char *m0, const guint8 *prefix,
 
 static GError *
 _resolve_m1_through_many_m0(struct hc_resolver_s *r, const char * const *urlv,
-		const guint8 *prefix, gchar ***result, gint64 deadline)
+		const guint8 *prefix, gchar ***result, gint64 deadline,
+		const gchar *ns_name)
 {
 	GRID_TRACE2("%s(%02X%02X)", __FUNCTION__, prefix[0], prefix[1]);
 
@@ -312,7 +313,8 @@ _resolve_m1_through_many_m0(struct hc_resolver_s *r, const char * const *urlv,
 	}
 
 	for (const char * const *purl=urlv; *purl ;++purl) {
-		GError *err = _resolve_m1_through_one_m0(*purl, prefix, result, deadline);
+		GError *err = _resolve_m1_through_one_m0(*purl, prefix, result,
+				deadline, ns_name);
 		EXTRA_ASSERT((err!=NULL) ^ (*result!=NULL));
 		if (!err)
 			return NULL;
@@ -343,7 +345,8 @@ _resolve_meta1(struct hc_resolver_s *r, struct oio_url_s *u, gchar ***result, gi
 			g_prefix_error(&err, "M0 resolution error: ");
 		else {
 			err = _resolve_m1_through_many_m0(r, (const char * const *)m0urlv,
-					oio_url_get_id(u), result, deadline);
+					oio_url_get_id(u), result, deadline,
+					oio_url_get(u, OIOURL_NS));
 			if (!err)
 				hc_resolver_store(r, r->csm0, hk,
 						(const char * const *) *result);


### PR DESCRIPTION
##### SUMMARY
We have seen services registered in the wrong namespace. But nothing prevented these services to be used. Now some request handlers will compare the input namespace against the configured one, and deny the request is they do not match.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- meta0

##### SDS VERSION
```
openio 5.5.5
```


##### ADDITIONAL INFORMATION
To test the new feature, run this command:
```
OIO_NS="CRAP" oio-meta0-client "$(openio --ns OPENIO cluster list meta0 -c Addr -f value | head -n 1)" list
```
And you should see something like:
```
40113854942 58943 0053 log INF oio.m0v2 Dumping the whole META0
40113855362 58943 0053 log WRN oio.m0v2 META0 request error (418) : Requested CRAP on service running OPENIO namespace
```
