### PR TITLE
CLI: allow to set a bucket name on an already created container

### DIFF
--- a/oio/cli/container/container.py
+++ b/oio/cli/container/container.py
@@ -227,6 +227,11 @@ class SetContainer(SetPropertyCommandMixin,
         parser = super(SetContainer, self).get_parser(prog_name)
         self.patch_parser(parser)
         self.patch_parser_container(parser)
+        # Same as in CreateContainer class
+        parser.add_argument(
+            '--bucket-name',
+            help=('Declare the container belongs to the specified bucket')
+        )
         parser.add_argument(
             '--clear',
             dest='clear',
@@ -247,6 +252,8 @@ class SetContainer(SetPropertyCommandMixin,
         super(SetContainer, self).take_action_container(parsed_args)
         properties = parsed_args.property
         system = dict()
+        if parsed_args.bucket_name:
+            system[M2_PROP_BUCKET_NAME] = parsed_args.bucket_name
         if parsed_args.quota is not None:
             system[M2_PROP_QUOTA] = str(parsed_args.quota)
         if parsed_args.storage_policy is not None:
@@ -649,6 +656,11 @@ class UnsetContainer(ContainerCommandMixin, Command):
         parser = super(UnsetContainer, self).get_parser(prog_name)
         self.patch_parser_container(parser)
         parser.add_argument(
+            '--bucket-name',
+            action='store_true',
+            help=('Declare the container no more belongs to any bucket')
+        )
+        parser.add_argument(
             '--property',
             metavar='<key>',
             action='append',
@@ -687,6 +699,8 @@ class UnsetContainer(ContainerCommandMixin, Command):
         self.take_action_container(parsed_args)
         properties = parsed_args.property
         system = dict()
+        if parsed_args.bucket_name:
+            system[M2_PROP_BUCKET_NAME] = ''
         if parsed_args.storage_policy:
             system[M2_PROP_STORAGE_POLICY] = ''
         if parsed_args.max_versions:

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -277,6 +277,36 @@ class ContainerTest(CliTestCase):
     def test_container_flush_quickly_with_cid(self):
         self._test_container_flush_quickly(with_cid=True)
 
+    def _test_container_set_bucket_name(self, with_cid=False):
+        cid_opt = ' '
+        name = self.NAME
+        bname = 'mybucket'
+        if with_cid:
+            cid_opt = ' --cid '
+            name = self.CID
+        opts = ' -f json'
+        output = self.openio('container show ' + cid_opt + name + opts)
+        output = self.json_loads(output)
+        self.assertNotIn(output, "bucket")
+        output = self.openio('container set --bucket-name '
+                             + bname + cid_opt + name)
+        self.assertEqual('', output)
+        output = self.openio('container show ' + cid_opt + name + opts)
+        output = self.json_loads(output)
+        self.assertEqual(output['bucket'], bname)
+        output = self.openio('container unset --bucket-name ' +
+                             cid_opt + name)
+        self.assertEqual('', output)
+        output = self.openio('container show ' + cid_opt + name + opts)
+        output = self.json_loads(output)
+        self.assertNotIn(output, "bucket")
+
+    def test_container_set_bucket_name(self):
+        self._test_container_set_bucket_name()
+
+    def test_container_set_bucket_name_with_cid(self):
+        self._test_container_set_bucket_name(with_cid=True)
+
     def _test_container_set_status(self, with_cid=False):
         cid_opt = ''
         name = self.NAME


### PR DESCRIPTION
##### SUMMARY
Implement the `--bucket-name` parameter for `openio container set` and `openio container unset` commands.

Jira: OB-572

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- CLI

##### SDS VERSION
```
openio 5.5.5
```