### PR TITLE
account: do not try to decode "None" as UTF-8

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -581,7 +581,8 @@ class AccountBackend(RedisConnection):
                 pass
         for what in (BUCKET_PROP_REPLI_ENABLED.encode('utf-8'), ):
             try:
-                decoded = info.get(what, b'').decode('utf-8')
+                val = info.get(what)
+                decoded = val.decode('utf-8') if val is not None else None
                 info[what] = boolean_value(decoded)
             except (TypeError, ValueError):
                 pass


### PR DESCRIPTION
##### SUMMARY
Do not try to decode "None" as UTF-8. This error was frequent but unfortunately it was ignored by our tests.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- account

##### SDS VERSION

```
openio 7.0.2.dev13
```