### PR TITLE
Fix the compilation in Release mode

### DIFF
--- a/meta2v2/meta2_utils_lb.c
+++ b/meta2v2/meta2_utils_lb.c
@@ -255,7 +255,7 @@ _m2_generate_alias_header(struct gen_ctx_s *ctx)
 
 struct bean_CHUNKS_s *
 generate_chunk_bean(struct oio_lb_selected_item_s *sel,
-		const struct storage_policy_s *policy)
+		const struct storage_policy_s *policy UNUSED)
 {
 	guint8 binid[32];
 	gchar *chunkid = NULL, strid[65];

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -375,10 +375,6 @@ void oio_parse_chunk_url(const gchar *url,
 			if (id)
 				*id = g_strdup(first_slash + 1);
 		}
-	} else if (g_str_has_prefix(url, "b2/") || g_str_has_prefix(url, "b2:")) {
-		_type = "b2";
-		if (id)
-			*id = g_strdup(url + 3);
 	} else if (g_str_has_prefix(url, "k/")) {
 		_type = "k";
 		if (netloc)

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -375,10 +375,6 @@ void oio_parse_chunk_url(const gchar *url,
 			if (id)
 				*id = g_strdup(first_slash + 1);
 		}
-	} else if (g_str_has_prefix(url, "k/")) {
-		_type = "k";
-		if (netloc)
-			*netloc = g_strdup(url + 2);
 	}
 
 	if (type)

--- a/proxy/m2_actions.c
+++ b/proxy/m2_actions.c
@@ -191,7 +191,6 @@ _score_from_chunk_id (const char *id)
 	gchar *key = NULL, *type = NULL, *netloc = NULL;
 	struct location_and_score_s res = {};
 
-	// FIXME: probably broken with B2 URLs
 	oio_parse_chunk_url(id, &type, &netloc, NULL);
 	key = oio_make_service_key(ns_name, type, netloc);
 


### PR DESCRIPTION
##### SUMMARY
Remove few strains of the now-unsupported integration of B2.
With the previous cleanup, a warning was raised that made the compilation fail under specific conditions.

##### ISSUE TYPE
`fix`, `cleanup`

##### COMPONENT NAME
meta2, proxy

##### SDS VERSION
`openio 5.5.6.dev26`
