### PR TITLE
Count build warnings, fix some nested functions (trampolines)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,10 @@ if (STACK_PROTECTOR)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
 endif()
 
+if (EXTRA_WARNINGS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn-trampolines -Wno-error=trampolines")
+endif()
+
 if (SOCKET_OPTIMIZED)
 	add_definitions(-D_GNU_SOURCE)
 	add_definitions(-DHAVE_SOCKET3)

--- a/core/ext.c
+++ b/core/ext.c
@@ -503,10 +503,7 @@ void _constructor_idle_cache (void);
 void _destructor_idle_cache (void);
 
 static void _free_majmin_idle_list (GSList *l) {
-	void _clean_idle (struct maj_min_idle_s *p) {
-		g_free (p);
-	}
-	g_slist_free_full (l, (GDestroyNotify)_clean_idle);
+	g_slist_free_full (l, (GDestroyNotify)g_free);
 }
 
 void __attribute__ ((constructor)) _constructor_idle_cache (void) {

--- a/core/oiovar.h
+++ b/core/oiovar.h
@@ -111,6 +111,8 @@ gboolean oio_var_value_with_files(const char *ns, gboolean sys, GSList *files);
  * of them.
  */
 void oio_var_list_all(void (*hook) (const char *k, const char *v));
+void oio_var_list_all_ext(void (*hook) (const char *k, const char *v, void *u),
+		void *udata);
 
 /**
  * Wraps oio_var_list_all() to build a simple JSON object, where each key

--- a/tools/oio-build-with-warnings.sh
+++ b/tools/oio-build-with-warnings.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# oio-build-with-warnings.sh
+# Copyright (C) 2020 OpenIO SAS, as part of OpenIO SDS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+set -e
+set -x
+
+SRCDIR="$1" ; [ -n "$SRCDIR" ] ; [ -d "$SRCDIR" ]
+
+echo "Compiling with extra warnings enabled..."
+D=$(mktemp -d)
+cd $D
+cmake ${CMAKE_OPTS} -D CMAKE_BUILD_TYPE=Release -D EXTRA_WARNINGS=1 ${SRCDIR}
+make -j "" all 2>warnings.log
+echo
+echo "--- Summary of warnings ------------------------------------------------"
+sed -r -n -e 's,([^\[]+)\[-W([^\]+)\],\2,p' warnings.log | sort | uniq -c
+echo "------------------------------------------------------------------------"
+echo
+make clean
+cd
+rm -rf "$D"

--- a/tools/oio-build-with-warnings.sh
+++ b/tools/oio-build-with-warnings.sh
@@ -24,7 +24,7 @@ echo "Compiling with extra warnings enabled..."
 D=$(mktemp -d)
 cd $D
 cmake ${CMAKE_OPTS} -D CMAKE_BUILD_TYPE=Release -D EXTRA_WARNINGS=1 ${SRCDIR}
-make -j "" all 2>warnings.log
+make -j  all 2>warnings.log
 echo
 echo "--- Summary of warnings ------------------------------------------------"
 sed -r -n -e 's,([^\[]+)\[-W([^\]+)\],\2,p' warnings.log | sort | uniq -c

--- a/tools/oio-travis-failfast.sh
+++ b/tools/oio-travis-failfast.sh
@@ -30,6 +30,7 @@ fold() {
 
 fold SDK ./tools/oio-build-sdk.sh ${PWD}
 fold Release ./tools/oio-build-release.sh ${PWD}
+fold Warnings ./tools/oio-build-with-warnings.sh ${PWD}
 fold Copyright ./tools/oio-check-copyright.sh ${PWD}
 fold Virtualenv python ./setup.py develop
 fold Variables tox -e variables


### PR DESCRIPTION
##### SUMMARY
Nested functions require compiler "trampolines", which require the stack to be executable. This is a security issue, and recent compilers advise not to use trampolines.

This pull request adds a test script to count compilation warnings, and fixes some of them.

See #2087.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- core
- CI

##### SDS VERSION
```
master
```