### PR TITLE
proxy: set service type when extracting from cached JSON

### DIFF
--- a/proxy/cs_actions.c
+++ b/proxy/cs_actions.c
@@ -185,6 +185,8 @@ _cached_json_to_urlv(const char * srvtype, GBytes *json, gchar ***result)
 			err = service_info_load_json_object(obj, &si, TRUE);
 			if (err != NULL)
 				goto label_error;
+			if (!oio_str_is_set(si->type))
+				g_strlcpy(si->type, srvtype, sizeof(si->type));
 			g_ptr_array_add(tmp, metautils_service_to_m1url(si, 1));
 			service_info_clean(si);
 		}


### PR DESCRIPTION
##### SUMMARY
When the application requests service lists, and these services are in oioproxy's cache, don't forget to set the type in the resulting structures.

The bug has been detected by running `openio container locate`: the "meta0" field remained empty.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- oioproxy

##### SDS VERSION
```
openio 5.6.1.dev2
```