### PR TITLE
Reassign new rdir to a service

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -192,6 +192,7 @@ openio.admin =
     rawx_list_containers = oio.cli.admin.service_list:RawxListContainers
     rawx_rebuild = oio.cli.admin.service_rebuild:RawxRebuild
     rdir_check = oio.cli.admin.service_check:RdirCheck
+    rdir_reassign = oio.cli.rdir.rdir:RdirReassign
     sqlx_get-config = oio.cli.admin.service_config:ServiceGetConfig
     sqlx_info = oio.cli.admin.service_info:ServiceInfo
     sqlx_set-config = oio.cli.admin.service_config:ServiceSetConfig

--- a/tests/functional/api/test_directory.py
+++ b/tests/functional/api/test_directory.py
@@ -389,11 +389,12 @@ class TestDirectoryAPI(BaseTestCase):
 
         # But ensure all calls have been made
         link_calls = [call(rawx['addr'], ANY, max_per_rdir=ANY, max_attempts=1,
-                           min_dist=ANY, service_type='rawx')
+                           min_dist=ANY, service_type='rawx', reassign=False)
                       for rawx in all_srvs['rawx']]
         disp._smart_link_rdir.assert_has_calls(link_calls)
         force_calls = \
-            [call(RDIR_ACCT, rawx['addr'], 'rdir', ANY, autocreate=True)
+            [call(RDIR_ACCT, rawx['addr'], 'rdir', ANY, autocreate=True,
+                  replace=ANY)
              for rawx in all_srvs['rawx']]
         disp.directory.force.assert_has_calls(force_calls)
 


### PR DESCRIPTION
##### SUMMARY

Reassign new rdir to a service

These new parameters to the 'openio rdir bootstrap' command are there to help decommission a rdir (see https://github.com/open-io/oio-product-docs/pull/64)

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- CLI

##### SDS VERSION

```
openio 5.6.2.dev1
```