### PR TITLE
rawx: Improve error message when the volume XATTRs are wrong

### DIFF
--- a/rawx/filerepo.go
+++ b/rawx/filerepo.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -459,7 +460,8 @@ func setOrHasXattr(path, key, value string) error {
 	if bytes.Equal([]byte(value), buf[:sz]) {
 		return nil
 	}
-	return errors.New("XATTR mismatch")
+	return fmt.Errorf("XATTR '%s' of '%s' mismatches with '%s'",
+		key, path, value)
 }
 
 func xattrKey(name string) string {


### PR DESCRIPTION
##### SUMMARY

Improve error message when the volume XATTRs are wrong

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- rawx (Go)

##### SDS VERSION

```
openio 5.6.2.dev2
```