### PR TITLE
CI: convert remaining tests using python 2 to python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,15 @@ sudo: required
 dist: bionic
 language: python
 python:
-    - "2.7"
+    - "3.6"
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://mirror2.openio.io/pub/repo/openio/sds/19.10/ubuntu/ bionic/'
+    - sourceline: 'deb http://mirror2.openio.io/pub/repo/openio/sds/20.04/ubuntu/ bionic/'
       key_url: 'http://mirror2.openio.io/pub/repo/openio/APT-GPG-KEY-OPENIO-0'
 # Please keep the following list sorted!
     packages:
     - apache2
-    - apache2-dev
     - asn1c
     - attr
     - beanstalkd
@@ -20,6 +19,7 @@ addons:
     - flex
     - gdb
     - lcov
+    - libapache2-mod-wsgi-py3
     - libapreq2-dev
     - libattr1-dev
     - libcurl4-gnutls-dev
@@ -32,11 +32,6 @@ addons:
     - libzmq3-dev
     - libzookeeper-mt-dev
     - openio-gridinit
-    - python-all-dev
-    - python-dev
-    - python-pbr
-    - python-setuptools
-    - python-virtualenv
     - python3
     - python3-coverage
     - redis-server
@@ -47,8 +42,6 @@ addons:
     - zookeeperd
 services:
   - zookeeper
-before_install:
-  - sudo apt-get install $([ "$TRAVIS_PYTHON_VERSION" == "2.7" ] && echo 'libapache2-mod-wsgi' || echo 'libapache2-mod-wsgi-py3')
 install:
   - pip install --upgrade pip setuptools virtualenv tox -r all-requirements.txt -r test-requirements.txt
   - go get gopkg.in/ini.v1 golang.org/x/sys/unix
@@ -72,10 +65,7 @@ jobs:
       script: ./tools/oio-travis-failfast.sh
       name: Copyright, Release build, SDK build
     - script: ./tools/oio-travis-unit.sh
-      name: C unit/func, Python 2 unit/pep8
-    - script: ./tools/oio-travis-unit.sh
       name: C unit/func, Python 3 unit/pep8
-      python: 3.6
 
     - stage: Functional tests (fast)
       script: ./tools/oio-travis-suites.sh
@@ -85,33 +75,17 @@ jobs:
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=worm
 
-    - stage: Functional tests (Python 3)
+    - stage: Functional tests
       script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=cli
-      python: 3.6
-    - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=rebuilder,with-service-id,zlib
-      python: 3.6
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=repli,with_tls
-      python: 3.6
-    - script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=ec,with-service-id
-      python: 3.6
-    - script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=3copies,with-service-id
-      python: 3.6
-    - script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=mover,with-service-id
-      python: 3.6
-
-    - stage: Functional tests (Python 2)
-      script: ./tools/oio-travis-suites.sh
-      env: TEST_SUITE=repli
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=ec,with-service-id,with_tls
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=3copies,with-service-id
+    - script: ./tools/oio-travis-suites.sh
+      env: TEST_SUITE=mover,with-service-id
     - script: ./tools/oio-travis-suites.sh
       env: TEST_SUITE=single,small-cache,fsync,webhook,zlib
     - script: ./tools/oio-travis-suites.sh

--- a/etc/bootstrap-option-smallcache.yml
+++ b/etc/bootstrap-option-smallcache.yml
@@ -1,3 +1,2 @@
 config:
-  sqliterepo.repo.hard_max: 16
   sqliterepo.repo.soft_max: 4

--- a/tests/functional/blob/test_mover.py
+++ b/tests/functional/blob/test_mover.py
@@ -135,7 +135,7 @@ class TestBlobMover(BaseTestCase):
         mover = BlobMoverWorker(self.conf, None,
                                 self.rawx_volumes[chunk_volume])
         meta, stream = mover.blob_client.chunk_get(orig_chunk['url'])
-        data = stream.read()
+        data = b''.join(stream)
         stream.close()
         data = data[:-1]
         del meta['chunk_hash']

--- a/tests/functional/cli/container/test_container.py
+++ b/tests/functional/cli/container/test_container.py
@@ -125,7 +125,7 @@ class ContainerTest(CliTestCase):
                             types=(EventTypes.CONTAINER_STATE, ))
 
         with tempfile.NamedTemporaryFile() as file_:
-            file_.write('test')
+            file_.write(b'test')
             file_.flush()
             output = self.openio(
                 '--oio-account %s object create %s %s --name test' %
@@ -157,7 +157,7 @@ class ContainerTest(CliTestCase):
                             types=(EventTypes.CONTAINER_STATE, ))
 
         with tempfile.NamedTemporaryFile() as file_:
-            file_.write('test')
+            file_.write(b'test')
             file_.flush()
             output = self.openio('object create %s %s --name test' %
                                  (cname, file_.name))

--- a/tests/functional/conscience/test_conscience.py
+++ b/tests/functional/conscience/test_conscience.py
@@ -349,7 +349,7 @@ class TestConscienceFunctional(BaseTestCase):
             else:
                 self.fail("At least one service unlocked")
             self.assertEqual(len(services), len(expeted_services))
-            expeted_services.sort()
+            expeted_services.sort(key=lambda x: x['addr'])
 
             self._service('%s-conscience-1' % self.ns, 'stop')
             self._service('%s-conscience-1' % self.ns, 'start')
@@ -358,8 +358,9 @@ class TestConscienceFunctional(BaseTestCase):
             for _ in range(8):
                 self._flush_proxy()
                 self._reload_proxy()
-                self.assertListEqual(expeted_services,
-                                     sorted(self._list_srvs('rawx')))
+                self.assertListEqual(
+                    expeted_services,
+                    sorted(self._list_srvs('rawx'), key=lambda x: x['addr']))
         finally:
             try:
                 for service in services:

--- a/tests/functional/m2_filters/test_filters.py
+++ b/tests/functional/m2_filters/test_filters.py
@@ -116,7 +116,7 @@ class TestFilters(BaseTestCase):
             self.assertIn('worm', str(exc))
         else:
             self.fail("Delete without admin mode: no exception")
-        downloaded_data = ''.join(content.fetch())
+        downloaded_data = b''.join(content.fetch())
         self.assertEqual(downloaded_data, data2)
 
         # Delete with admin mode

--- a/tools/benchmark/oio-bench-object-create.py
+++ b/tools/benchmark/oio-bench-object-create.py
@@ -99,7 +99,7 @@ def main(threads, delay=5.0, duration=60.0):
 
 def _object_upload(ul_handler, **kwargs):
     ul_chunks = ul_handler.chunk_prep()
-    return ul_chunks.next(), 0, 'd41d8cd98f00b204e9800998ecf8427e'
+    return next(ul_chunks), 0, 'd41d8cd98f00b204e9800998ecf8427e'
 
 
 USAGE = """Concurrently create many fake objects in the same container.

--- a/tools/oio-test-unit.sh
+++ b/tools/oio-test-unit.sh
@@ -28,11 +28,5 @@ cd $WRKDIR
 make -C tests/unit test
 
 cd $SRCDIR
-if [ "${TRAVIS_PYTHON_VERSION:-2.7}" \< "3.6" ]
-then
-  tox -e pep8
-  tox -e py27
-else
-  tox -e py3_pep8
-  tox -e py3
-fi
+tox -e pep8
+tox -e py3

--- a/tools/oio-travis-failfast.sh
+++ b/tools/oio-travis-failfast.sh
@@ -34,5 +34,3 @@ fold Warnings ./tools/oio-build-with-warnings.sh ${PWD}
 fold Copyright ./tools/oio-check-copyright.sh ${PWD}
 fold Virtualenv python ./setup.py develop
 fold Variables tox -e variables
-fold VariablesPy3 tox -e py3_variables
-

--- a/tools/oio-webhook-test.py
+++ b/tools/oio-webhook-test.py
@@ -40,9 +40,10 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if self.path == '/PURGE':
             DATA = {}
             self.send_response(200)
+            self.end_headers()
             return
 
-        content_len = int(self.headers.getheader('content-length', 0))
+        content_len = int(self.headers.get('content-length', 0))
         body = json.loads(self.rfile.read(content_len))
 
         name = '/'.join([body['data']['account'], body['data']['container'],
@@ -55,9 +56,11 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 del DATA[name]
         else:
             self.send_response(400)
+            self.end_headers()
             return
 
         self.send_response(200)
+        self.end_headers()
 
     def do_GET(self):
         path = self.path.strip('/')
@@ -68,13 +71,14 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             data = DATA.get(self.path.strip('/'), None)
 
         if data:
-            body = json.dumps(data)
+            body = json.dumps(data).encode('utf-8')
             self.send_response(200)
             self.send_header('Content-Length', len(body))
             self.end_headers()
             self.wfile.write(body)
         else:
             self.send_response(404)
+            self.end_headers()
 
 
 def options():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3,pep8,py3_pep8
+envlist = py3,pep8
 minversion = 1.6
 skipdist = True
 
@@ -19,56 +19,22 @@ passenv = TRAVIS CIRCLECI OIO_* NOSE_ARGS
 [flake8]
 show-source = True
 
-# Python 2
-
-[testenv:coverage]
-basepython = python2
-commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {env:NOSE_ARGS:} {posargs:tests/unit}
-
-[testenv:pep8]
-basepython = python2
-commands =
-    flake8 oio tests setup.py --exclude oio/container/md5py.py
-    flake8 bin/oio-check-master
-    flake8 tools/oio-rdir-harass.py tools/oio-test-config.py tools/oio-test-config.py tools/oio-gdb.py tools/benchmark/
-
-[testenv:func]
-basepython = python2
-commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional}
-
-[testenv:cli]
-basepython = python2
-commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional/cli}
-
-[testenv:variables]
-basepython = python2
-commands = coverage run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p tests/func/test_variables.py .
-
 # Python 3
 
-[testenv:py3_coverage]
-basepython = python3
-whitelist_externals = coverage3
-commands = coverage3 run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose {env:NOSE_ARGS:} {posargs:tests/unit}
+[testenv:coverage]
+commands = coverage run --omit={envdir}/* -p -m nose {env:NOSE_ARGS:} {posargs:tests/unit}
 
-[testenv:py3_pep8]
-basepython = python3
+[testenv:pep8]
 commands =
     flake8 oio tests setup.py
     flake8 bin/oio-check-master
     flake8 tools/oio-rdir-harass.py tools/oio-test-config.py tools/oio-test-config.py tools/oio-gdb.py tools/benchmark/
 
-[testenv:py3_func]
-basepython = python3
-whitelist_externals = coverage3
-commands = coverage3 run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional}
+[testenv:func]
+commands = coverage run --omit={envdir}/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional}
 
-[testenv:py3_cli]
-basepython = python3
-whitelist_externals = coverage3
-commands = coverage3 run --omit={envdir}/*,/home/travis/oio/lib/python2.7/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional/cli}
+[testenv:cli]
+commands = coverage run --omit={envdir}/* -p -m nose -v {env:NOSE_ARGS:} {posargs:tests/functional/cli}
 
-[testenv:py3_variables]
-basepython = python3
-whitelist_externals = coverage3
-commands = coverage3 run --omit={envdir}/*,/home/travis/oio/lib/python3/* -p tests/func/test_variables.py .
+[testenv:variables]
+commands = coverage run --omit={envdir}/* -p tests/func/test_variables.py .


### PR DESCRIPTION
##### SUMMARY

Drop Python 2
Since gateway will use Python 3.7, launch tests with Python 3.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
oio

##### SDS VERSION
```
master
```
