### PR TITLE
meta2: Fix purge deleted aliases

### DIFF
--- a/meta2v2/meta2_utils.c
+++ b/meta2v2/meta2_utils.c
@@ -2838,21 +2838,22 @@ _purge_deleted_aliases(struct sqlx_sqlite3_s *sq3, gint64 delay,
 	GError *err = NULL;
 	gchar *sql;
 	GVariant *params[] = {NULL, NULL, NULL};
-	gint64 now = oio_ext_real_time () / G_TIME_SPAN_SECOND;
+	gint64 now = oio_ext_real_time();
 	gint64 time_limit = 0;
 
 	// All aliases which have one version deleted (the last) older than time_limit
 	if (alias) {
 		sql = (" alias IN "
 				"(SELECT alias FROM "
-				"  (SELECT alias,ctime,deleted FROM aliases WHERE alias = ? "
-				"   GROUP BY alias) "
-				" WHERE deleted AND ctime < ?) ");
+				"  (SELECT alias, MAX(version) as version, deleted "
+				"   FROM aliases WHERE alias = ? GROUP BY alias) "
+				" WHERE deleted AND version < ?) ");
 	} else {
 		sql = (" alias IN "
 				"(SELECT alias FROM "
-				"  (SELECT alias,ctime,deleted FROM aliases GROUP BY alias) "
-				" WHERE deleted AND ctime < ?) ");
+				"  (SELECT alias, MAX(version) as version, deleted "
+				"   FROM aliases GROUP BY alias) "
+				" WHERE deleted AND version < ?) ");
 	}
 
 	if (now < 0) {
@@ -2861,6 +2862,7 @@ _purge_deleted_aliases(struct sqlx_sqlite3_s *sq3, gint64 delay,
 		return err;
 	}
 
+	delay = delay * G_TIME_SPAN_SECOND;
 	if (delay >= 0 && delay < now) {
 		time_limit = now - delay;
 	}


### PR DESCRIPTION
##### SUMMARY

Fix purge deleted aliases
- Use version instead of creation time
- Select the current version to check if object is deleted

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `meta2`

##### SDS VERSION

```
openio 5.7.1.dev2
```

##### ADDITIONAL INFORMATION

This bug is visible with a recent version of sqlite3 (like version 3.31.1).