### PR TITLE
oio: fix flush with Python3

### DIFF
--- a/oio/container/client.py
+++ b/oio/container/client.py
@@ -239,7 +239,7 @@ class ContainerClient(ProxyClient):
             return results
         except exceptions.TooLarge:
             # Batch too large for the proxy
-            pivot = len(containers) / 2
+            pivot = len(containers) // 2
             head = containers[:pivot]
             tail = containers[pivot:]
             if head:
@@ -677,7 +677,7 @@ class ContainerClient(ProxyClient):
                 results.append((obj, rc))
             return results
         except exceptions.TooLarge:
-            pivot = len(paths) / 2
+            pivot = len(paths) // 2
             head = paths[:pivot]
             tail = paths[pivot:]
             if head:


### PR DESCRIPTION
##### SUMMARY

Python3 returns float when a division occurs between two integers 

$ python2
Python 2.7.17 (default, Sep 30 2020, 13:38:04)
>>> 3 / 2
1
$ python3
Python 3.6.9 (default, Oct  8 2020, 12:12:24)
>>> 3 / 2
1.5

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oio

##### SDS VERSION
```
openio 7.1.1.dev4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
