### PR TITLE
account: clean after bucket deletion

### DIFF
--- a/oio/account/backend.py
+++ b/oio/account/backend.py
@@ -70,6 +70,8 @@ class AccountBackend(RedisConnection):
             if bucket_name == container_name then
               redis.call('ZREM', buckets_list_key, bucket_name);
               redis.call('ZREM', '%(bucket_list_prefix)s', bucket_name);
+              -- Also delete the bucket
+              redis.call('DEL', bucket_key);
             end;
             return;
           end;


### PR DESCRIPTION
##### SUMMARY
When deleting a bucket, some entries were left in the account service. They are now cleaned.

Jira: OBSTO-161

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- account service

##### SDS VERSION
```
openio 7.1.1.dev2
```