### PR TITLE
Various fixes and enhancements

### DIFF
--- a/oio/cli/election/election.py
+++ b/oio/cli/election/election.py
@@ -171,7 +171,7 @@ class ElectionSync(ElectionCmd):
 
         data = self.app.client_manager.admin.election_sync(
             service_type, account=account, reference=reference, cid=cid,
-            timeout=parsed_args.timeout)
+            timeout=parsed_args.timeout, service_id=parsed_args.service_id)
 
         columns = ('Id', 'Status', 'Message', 'Body')
         data = sorted(data.iteritems())

--- a/oio/cli/election/election.py
+++ b/oio/cli/election/election.py
@@ -141,7 +141,7 @@ class ElectionDebug(ElectionCmd):
         import time
 
         def format_item(x, v):
-            if v is None:
+            if not v:
                 return format_json(x, v)
             patched_times = list()
             for entry in v.get("log", []):

--- a/sqliterepo/replication_dispatcher.c
+++ b/sqliterepo/replication_dispatcher.c
@@ -619,9 +619,18 @@ _pipe_from(const gchar *source, struct sqlx_repository_s *repo,
 {
 	GError *err;
 	struct restore_ctx_s *ctx = NULL;
+	gint64 now = oio_ext_monotonic_time();
 	err = _pipe_base_from(source, repo, name, &ctx);
-	if (!err)
+	gint64 elapsed = oio_ext_monotonic_time();
+	GRID_INFO("pipe_base_from took %"G_GINT64_FORMAT" ms",
+		(elapsed - now) / G_TIME_SPAN_MILLISECOND);
+
+	if (!err) {
+		now = elapsed;
 		err = _restore2(repo, name, ctx->path);
+		GRID_INFO("PIPEFROM restore db %s took %"G_GINT64_FORMAT" ms",
+			name->base, (oio_ext_monotonic_time() - now) / G_TIME_SPAN_MILLISECOND);
+	}
 
 	restore_ctx_clear(&ctx);
 	return err;
@@ -2144,7 +2153,18 @@ _handler_PROPGET(struct gridd_reply_ctx_s *reply,
 			}
 		}
 		g_free (keys); /*< pointers reused! */
-		g_ptr_array_add (tmp, NULL);
+
+		if (oio_ext_is_admin()) {
+			GPtrArray *stats = sqlx_admin_get_usage(sq3);
+			if (stats) {
+				for(guint i=0; i < stats->len; i++) {
+					g_ptr_array_add(tmp, g_ptr_array_index(stats, i));
+				}
+				g_ptr_array_free(stats, FALSE); /*< pointers reused! */
+			}
+		}
+		g_ptr_array_add(tmp, NULL);
+
 		gchar **pairs = (gchar**) g_ptr_array_free(tmp, FALSE);
 		GByteArray *body = KV_encode_gba (pairs);
 		g_strfreev(pairs);

--- a/sqliterepo/repository.c
+++ b/sqliterepo/repository.c
@@ -1679,7 +1679,12 @@ sqlx_repository_dump_base_fd_no_copy(struct sqlx_sqlite3_s *sq3,
 	}
 
 	/* Detect a wrong/corrupted database file */
+	gint64 now = oio_ext_monotonic_time();
 	rc = sqlx_exec(sq3->db, "PRAGMA quick_check");
+	GRID_INFO("Pragma quick check took %"G_GINT64_FORMAT" ms [%s][%s]",
+		(oio_ext_monotonic_time () - now) / G_TIME_SPAN_MILLISECOND,
+		sq3->name.base, sq3->name.type);
+
 	if (rc != SQLITE_OK) {
 		if (rc == SQLITE_NOTADB || rc == SQLITE_CORRUPT) {
 			err = NEWERROR(CODE_CORRUPT_DATABASE,

--- a/sqliterepo/sqlite_utils.h
+++ b/sqliterepo/sqlite_utils.h
@@ -204,4 +204,8 @@ void db_properties_add(
 GString * db_properties_to_json(
 		struct db_properties_s *db_properties, GString *json);
 
+/* database stats */
+
+GPtrArray* sqlx_admin_get_usage(struct sqlx_sqlite3_s *sq3);
+
 #endif /*OIO_SDS__sqliterepo__sqlite_utils_h*/

--- a/tests/functional/cli/object/test_object.py
+++ b/tests/functional/cli/object/test_object.py
@@ -28,7 +28,9 @@ CONTAINER_LIST_HEADERS = ['Name', 'Bytes', 'Count']
 CONTAINER_FIELDS = ['account', 'base_name', 'bytes_usage', 'quota',
                     'container', 'ctime', 'storage_policy', 'objects',
                     'max_versions', 'status', 'damaged_objects',
-                    'missing_chunks']
+                    'missing_chunks', 'stats.freelist_count',
+                    'stats.page_count', 'stats.page_size',
+                    'stats.space_wasted']
 OBJ_FIELDS = ['account', 'container', 'ctime', 'hash', 'id', 'mime-type',
               'mtime', 'object', 'policy', 'size', 'version']
 


### PR DESCRIPTION
##### SUMMARY

This PR will bring:
- some few fixes for CLI
- stats when a sync occurs
- expose sqlite stats through an admin request on `container/get_properties`

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
sqliterepo, CLI

##### SDS VERSION
```
5.x
```

##### ADDITIONAL INFORMATION
```
$ openio container show big
+----------------------+-----------------------------------------------------------------------------+
| Field                | Value                                                                       |
+----------------------+-----------------------------------------------------------------------------+
| account              | AUTH_88fddfcf6d6c4a85baa1fc27c0ee24bf                                       |
| base_name            | 30AE0C4B4F4E75E44CBC92465BACCCD87A98CEB39F0C967230D20272019CCB4E.1          |
| bucket               | big                                                                         |
| bytes_usage          | 57.412GB                                                                    |
| container            | big+segments%2Fsubdir |
| ctime                | 1594304161                                                                  |
| damaged_objects      | 0                                                                           |
| max_versions         | Namespace default                                                           |
| missing_chunks       | 0                                                                           |
| objects              | 6.848K                                                                      |
| quota                | Namespace default                                                           |
| stats.freelist_count | 3196841                                                                     |
| stats.page_count     | 3206562                                                                     |
| stats.page_size      | 4096                                                                        |
| stats.space_wasted   | 99.70% (est. 13.094G)                                                       |
| status               | Enabled                                                                     |
| storage_policy       | Namespace default                                                           |
+----------------------+-----------------------------------------------------------------------------+
```