### PR TITLE
xcute: Allow to update job configuration

### DIFF
--- a/oio/cli/admin/xcute/job.py
+++ b/oio/cli/admin/xcute/job.py
@@ -15,6 +15,7 @@
 
 from oio.cli import Lister, ShowOne, flat_dict_from_dict
 from oio.cli.admin.xcute import XcuteCommand
+from oio.cli.common.utils import KeyValueAction
 
 
 class JobList(XcuteCommand, Lister):
@@ -48,7 +49,7 @@ class JobShow(XcuteCommand, ShowOne):
         parser.add_argument(
             'job_id',
             metavar='<job_id>',
-            help=("Job ID to show"))
+            help=('ID of the job to show'))
         parser.add_argument(
             '--raw',
             action='store_true',
@@ -106,7 +107,7 @@ class JobPause(XcuteCommand, Lister):
             'job_ids',
             nargs='+',
             metavar='<job_id>',
-            help=("Job IDs to pause"))
+            help=('IDs of the job to pause'))
         return parser
 
     def _take_action(self, parsed_args):
@@ -139,7 +140,7 @@ class JobResume(XcuteCommand, Lister):
             'job_ids',
             nargs='+',
             metavar='<job_id>',
-            help=("Job IDs to resume"))
+            help=('IDs of the job to to resume'))
         return parser
 
     def _take_action(self, parsed_args):
@@ -159,6 +160,48 @@ class JobResume(XcuteCommand, Lister):
         return self.columns, self._take_action(parsed_args)
 
 
+class JobUpdate(XcuteCommand, ShowOne):
+    """
+    Update job configuration.
+    """
+
+    def get_parser(self, prog_name):
+        parser = super(JobUpdate, self).get_parser(prog_name)
+        parser.add_argument(
+            'job_id',
+            metavar='<job_id>',
+            help=('ID of the job to update.'))
+        parser.add_argument(
+            '--tasks-per-second', type=int,
+            help='Max tasks per second.')
+        parser.add_argument(
+            '--tasks-batch-size', type=int,
+            help='Max tasks batch size.')
+        parser.add_argument(
+            '-p', '--param',
+            dest='params',
+            metavar='<key=value>',
+            action=KeyValueAction,
+            help='Configuration parameter to update'
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        self.logger.debug('take_action(%s)', parsed_args)
+
+        job_config = dict()
+        if parsed_args.tasks_per_second is not None:
+            job_config['tasks_per_second'] = parsed_args.tasks_per_second
+        if parsed_args.tasks_batch_size is not None:
+            job_config['tasks_batch_size'] = parsed_args.tasks_batch_size
+        if parsed_args.params is not None:
+            job_config['params'] = parsed_args.params
+        new_job_config = self.xcute.job_update(parsed_args.job_id, job_config)
+
+        return zip(*sorted(
+            flat_dict_from_dict(parsed_args, new_job_config).items()))
+
+
 class JobDelete(XcuteCommand, Lister):
     """
     Delete all information about the jobs.
@@ -172,7 +215,7 @@ class JobDelete(XcuteCommand, Lister):
             'job_ids',
             nargs='+',
             metavar='<job_id>',
-            help=("Job IDs to delete"))
+            help=('IDs of the job to delete'))
         return parser
 
     def _take_action(self, parsed_args):

--- a/oio/common/easy_value.py
+++ b/oio/common/easy_value.py
@@ -17,7 +17,7 @@ import string
 
 
 def int_value(value, default):
-    if value in (None, 'None'):
+    if value in (None, 'None', ''):
         return default
     try:
         value = int(value)
@@ -27,7 +27,7 @@ def int_value(value, default):
 
 
 def float_value(value, default):
-    if value in (None, 'None'):
+    if value in (None, 'None', ''):
         return default
     try:
         value = float(value)
@@ -46,7 +46,7 @@ def true_value(value):
 
 
 def boolean_value(value, default=False):
-    if value in (None, 'None'):
+    if value in (None, 'None', ''):
         return default
     try:
         value = str(value).lower()

--- a/oio/xcute/client.py
+++ b/oio/xcute/client.py
@@ -126,6 +126,11 @@ class XcuteClient(HttpApi):
             'POST', '/job/resume', params={'id': job_id})
         return data
 
+    def job_update(self, job_id, job_config=None):
+        _, data = self.xcute_request(
+            'POST', '/job/update', params={'id': job_id}, json=job_config)
+        return data
+
     def job_delete(self, job_id):
         self.xcute_request(
             'DELETE', '/job/delete', params={'id': job_id})

--- a/oio/xcute/common/job.py
+++ b/oio/xcute/common/job.py
@@ -21,7 +21,11 @@ class XcuteTask(object):
 
     def __init__(self, conf, job_params, logger=None):
         self.conf = conf
+        self.job_params = job_params
         self.logger = logger or get_logger(self.conf)
+
+    def params_have_changed(self, job_params):
+        return job_params != self.job_params
 
     def process(self, task_id, task_payload):
         raise NotImplementedError()
@@ -84,6 +88,23 @@ class XcuteJob(object):
         sanitized_job_params = dict()
 
         return sanitized_job_params, None
+
+    @staticmethod
+    def merge_config(current_config, new_config):
+        try:
+            merged_config = current_config.copy()
+            # If it is not set in the new configuration,
+            # recompute the new value
+            merged_config.pop('tasks_batch_size', None)
+            # Udpate configuration
+            merged_config.update(new_config)
+            # Update parameters
+            merged_params = (current_config.get('params') or dict()).copy()
+            merged_params.update(new_config.get('params') or dict())
+            merged_config['params'] = merged_params
+            return merged_config
+        except (TypeError, KeyError):
+            raise ValueError('Wrong config format')
 
     def prepare(self, job_params):
         """

--- a/oio/xcute/common/worker.py
+++ b/oio/xcute/common/worker.py
@@ -35,12 +35,14 @@ class XcuteWorker(object):
     def process(self, beanstalkd_job):
         job_id = beanstalkd_job['job_id']
         job_config = beanstalkd_job['job_config']
+        job_params = job_config['params']
 
         task = self.tasks.get(job_id)
+        if task is not None and task.params_have_changed(job_params):
+            task = None
         if task is None:
             job_type = beanstalkd_job['job_type']
             task_class = JOB_TYPES[job_type].TASK_CLASS
-            job_params = job_config['params']
             task = task_class(self.conf, job_params, logger=self.logger)
             self.tasks[job_id] = task
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -201,6 +201,7 @@ openio.admin =
     xcute_job_pause = oio.cli.admin.xcute.job:JobPause
     xcute_job_resume = oio.cli.admin.xcute.job:JobResume
     xcute_job_show = oio.cli.admin.xcute.job:JobShow
+    xcute_job_update = oio.cli.admin.xcute.job:JobUpdate
     xcute_lock_list = oio.cli.admin.xcute.lock:LockList
     xcute_lock_show = oio.cli.admin.xcute.lock:LockShow
     xcute_meta2_decommission = oio.cli.admin.xcute.meta2:Meta2Decommission


### PR DESCRIPTION
##### SUMMARY

Allow to update job configuration (only when the job is paused).

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- xcute

##### SDS VERSION

```
openio 5.7.1.dev8
```

##### ADDITIONAL INFORMATION

```
$ openio-admin xcute rawx decommission 127.0.0.1:6012 --chunks-per-second 2 --min-chunk-size 112
+------------------------------------+----------------------------------+
| Field                              | Value                            |
+------------------------------------+----------------------------------+
| config.params.excluded_rawx        |                                  |
| config.params.max_chunk_size       | 0                                |
| config.params.min_chunk_size       | 112                              |
| config.params.rawx_timeout         | 60.0                             |
| config.params.rdir_fetch_limit     | 1000                             |
| config.params.rdir_timeout         | 60.0                             |
| config.params.service_id           | 127.0.0.1:6012                   |
| config.params.usage_check_interval | 60.0                             |
| config.params.usage_target         | 0                                |
| config.tasks_batch_size            | 2                                |
| config.tasks_per_second            | 2                                |
| errors.total                       | 0                                |
| job.ctime                          | 1608131547.98                    |
| job.id                             | 20201216151227980437-6674b7fcd23 |
| job.lock                           | rawx/127.0.0.1:6012              |
| job.mtime                          | 1608131547.98                    |
| job.request_pause                  | False                            |
| job.status                         | WAITING                          |
| job.type                           | rawx-decommission                |
| tasks.all_sent                     | False                            |
| tasks.is_total_temp                | True                             |
| tasks.last_sent                    | None                             |
| tasks.processed                    | 0                                |
| tasks.sent                         | 0                                |
| tasks.total                        | 0                                |
| tasks.total_marker                 | None                             |
+------------------------------------+----------------------------------+
$ openio-admin xcute job pause 20201216151227980437-6674b7fcd23
+----------------------------------+--------+
| ID                               | Paused |
+----------------------------------+--------+
| 20201216151227980437-6674b7fcd23 | True   |
+----------------------------------+--------+
$ openio-admin xcute job show 20201216151227980437-6674b7fcd23
+------------------------------------+----------------------------------+
| Field                              | Value                            |
+------------------------------------+----------------------------------+
| config.params.excluded_rawx        |                                  |
| config.params.max_chunk_size       | 0                                |
| config.params.min_chunk_size       | 112                              |
| config.params.rawx_timeout         | 60.0                             |
| config.params.rdir_fetch_limit     | 1000                             |
| config.params.rdir_timeout         | 60.0                             |
| config.params.service_id           | 127.0.0.1:6012                   |
| config.params.usage_check_interval | 60.0                             |
| config.params.usage_target         | 0                                |
| config.tasks_batch_size            | 2                                |
| config.tasks_per_second            | 2                                |
| errors.total                       | 0                                |
| job.ctime                          | 1608131547.98                    |
| job.duration                       | 373.796740055                    |
| job.id                             | 20201216151227980437-6674b7fcd23 |
| job.lock                           | rawx/127.0.0.1:6012              |
| job.mtime                          | 1608131921.78                    |
| job.status                         | PAUSED                           |
| job.type                           | rawx-decommission                |
| results.skipped_chunks_too_small   | 110                              |
| tasks.processed                    | 110                              |
| tasks.processed_per_second         | 0.294277579799                   |
| tasks.processed_percent            | 63.2183908046                    |
| tasks.sent                         | 110                              |
| tasks.sent_percent                 | 63.2183908046                    |
| tasks.total                        | 174 (estimated)                  |
+------------------------------------+----------------------------------+
$ openio-admin xcute job update 20201216151227980437-6674b7fcd23 --param min_chunk_size=
+-----------------------------+----------------+
| Field                       | Value          |
+-----------------------------+----------------+
| params.excluded_rawx        |                |
| params.max_chunk_size       | 0              |
| params.min_chunk_size       | 0              |
| params.rawx_timeout         | 60.0           |
| params.rdir_fetch_limit     | 1000           |
| params.rdir_timeout         | 60.0           |
| params.service_id           | 127.0.0.1:6012 |
| params.usage_check_interval | 60.0           |
| params.usage_target         | 0              |
| tasks_batch_size            | 2              |
| tasks_per_second            | 2              |
+-----------------------------+----------------+
$ openio-admin xcute job resume 20201216151227980437-6674b7fcd23
+----------------------------------+---------+
| ID                               | Resumed |
+----------------------------------+---------+
| 20201216151227980437-6674b7fcd23 | True    |
+----------------------------------+---------+
$ openio-admin xcute job show 20201216151227980437-6674b7fcd23
+------------------------------------+----------------------------------+
| Field                              | Value                            |
+------------------------------------+----------------------------------+
| config.params.excluded_rawx        |                                  |
| config.params.max_chunk_size       | 0                                |
| config.params.min_chunk_size       | 0                                |
| config.params.rawx_timeout         | 60.0                             |
| config.params.rdir_fetch_limit     | 1000                             |
| config.params.rdir_timeout         | 60.0                             |
| config.params.service_id           | 127.0.0.1:6012                   |
| config.params.usage_check_interval | 60.0                             |
| config.params.usage_target         | 0                                |
| config.tasks_batch_size            | 2                                |
| config.tasks_per_second            | 2                                |
| errors.total                       | 0                                |
| job.ctime                          | 1608131547.98                    |
| job.duration                       | 404.867830038                    |
| job.id                             | 20201216151227980437-6674b7fcd23 |
| job.lock                           | rawx/127.0.0.1:6012              |
| job.mtime                          | 1608131952.85                    |
| job.status                         | RUNNING                          |
| job.type                           | rawx-decommission                |
| results.moved_bytes                | 1776                             |
| results.moved_chunks               | 16                               |
| results.skipped_chunks_too_small   | 110                              |
| tasks.processed                    | 126                              |
| tasks.processed_per_second         | 0.311212673993                   |
| tasks.processed_percent            | 72.4137931034                    |
| tasks.sent                         | 126                              |
| tasks.sent_percent                 | 72.4137931034                    |
| tasks.total                        | 174 (estimated)                  |
+------------------------------------+----------------------------------+
```