### PR TITLE
rawx: Don't print error for missing compression attr

### DIFF
--- a/rawx/chunk_info.go
+++ b/rawx/chunk_info.go
@@ -220,6 +220,10 @@ func loadAttr(inChunk fileReader, chunkID string, reqid string) (chunkInfo, erro
 					(hs.key == AttrNameMetachunkChecksum || hs.key == AttrNameMetachunkSize) {
 					continue
 				}
+				/* Compression is not mandatory, don't print error for missing Compression attr */
+				if hs.key == AttrNameCompression {
+					continue
+				}
 				LogWarning(msgMissingXattr(chunkID, reqid, hs.key, err))
 			} else {
 				return chunk, err


### PR DESCRIPTION
##### SUMMARY

Don't print error for missing compression attr, because compression is not mandatory

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- rawx

##### SDS VERSION

```
openio 5.7.1.dev19
```