### PR TITLE
Do not reiterate data generators when they already yield bytes

### DIFF
--- a/oio/api/io.py
+++ b/oio/api/io.py
@@ -416,7 +416,7 @@ class ChunkReader(object):
                     yield data
             raise StopIteration
 
-        return GeneratorIO(_iter())
+        return GeneratorIO(_iter(), False)
 
     def fill_ranges(self, start, end, length):
         """

--- a/oio/blob/client.py
+++ b/oio/blob/client.py
@@ -104,7 +104,7 @@ class BlobClient(object):
     @ensure_request_id
     def chunk_put(self, url, meta, data, **kwargs):
         if not hasattr(data, 'read'):
-            data = utils.GeneratorIO(data)
+            data = utils.GeneratorIO(data, False)
         chunk = {'url': self.resolve_url(url), 'pos': meta['chunk_pos']}
         # FIXME: ugly
         chunk_method = meta.get('chunk_method',

--- a/tests/functional/cli/__init__.py
+++ b/tests/functional/cli/__init__.py
@@ -71,7 +71,12 @@ class CliTestCase(BaseTestCase):
     @classmethod
     def openio_batch(cls, commands, **kwargs):
         """Execute several commands in the same openio CLI process."""
-        return execute('openio', stdin='\n'.join(commands), **kwargs)
+        script = '\n'.join(commands)
+        try:
+            return execute('openio', stdin=script, **kwargs)
+        except CommandFailed:
+            print("Stdin was:\n\n%s" % (script, ))
+            raise
 
     @classmethod
     def openio_admin(cls, cmd, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Do not reiterate data generators when they already yield bytes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Python API

##### SDS VERSION
```
openio 5.7.1.dev19
```