### PR TITLE
Python API: Return actual rebuilt size when rebuilding chunk

### DIFF
--- a/oio/blob/operator.py
+++ b/oio/blob/operator.py
@@ -43,13 +43,10 @@ class ChunkOperator(object):
         except ContentNotFound:
             raise OrphanChunk('Content not found: possible orphan chunk')
 
-        chunk_size = 0
         chunk_pos = None
         if len(chunk_id_or_pos) < 32:
             chunk_pos = chunk_id_or_pos
             chunk_id = None
-            metapos = int(chunk_pos.split('.', 1)[0])
-            chunk_size = content.chunks.filter(metapos=metapos).all()[0].size
         else:
             if '/' in chunk_id_or_pos:
                 chunk_id = chunk_id_or_pos.rsplit('/', 1)[-1]
@@ -62,9 +59,8 @@ class ChunkOperator(object):
                     'Chunk not found in content: possible orphan chunk')
             elif rawx_id and chunk.host != rawx_id:
                 raise ValueError('Chunk does not belong to this rawx')
-            chunk_size = chunk.size
 
-        content.rebuild_chunk(
+        rebuilt_bytes = content.rebuild_chunk(
             chunk_id, allow_frozen_container=allow_frozen_container,
             allow_same_rawx=allow_same_rawx,
             chunk_pos=chunk_pos)
@@ -87,4 +83,4 @@ class ChunkOperator(object):
                     'Failed to delete chunk entry (%s) from the rdir (%s): %s',
                     chunk_id, chunk.host, exc)
 
-        return chunk_size
+        return rebuilt_bytes

--- a/oio/content/ec.py
+++ b/oio/content/ec.py
@@ -93,7 +93,8 @@ class ECContent(Content):
         meta['metachunk_size'] = current_chunk.size
         meta['full_path'] = self.full_path
         meta['oio_version'] = OIO_VERSION
-        self.blob_client.chunk_put(spare_url[0], meta, GeneratorIO(stream))
+        bytes_transferred, _ = self.blob_client.chunk_put(
+            spare_url[0], meta, GeneratorIO(stream))
 
         # Register the spare chunk in object's metadata
         if chunk_id is None:
@@ -104,6 +105,8 @@ class ECContent(Content):
                                      frozen=allow_frozen_container)
         self.logger.debug('Chunk %s repaired in %s',
                           chunk_id or chunk_pos, spare_url[0])
+
+        return bytes_transferred
 
     def fetch(self):
         chunks = _sort_chunks(self.chunks.raw(), self.storage_method.ec,

--- a/oio/content/plain.py
+++ b/oio/content/plain.py
@@ -113,3 +113,5 @@ class PlainContent(Content):
                                      frozen=allow_frozen_container)
         self.logger.debug('Chunk %s repaired in %s',
                           chunk_id or chunk_pos, spare_url)
+
+        return current_chunk.size


### PR DESCRIPTION
##### SUMMARY

Return actual rebuilt size when rebuilding chunk

The rebuilt size was good for the duplicated chunk.
But the rebuilt size was wrong for chunk in EC.
The rebuilt size was the metachunk size, but it must be the chunk size.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- Python API
- Admin CLI
- oio-blob-rebuilder

##### SDS VERSION

```
openio 5.8.1.dev1
```